### PR TITLE
Split Enrolment creation into Enrolment, Company, and User

### DIFF
--- a/enrolment/queue.py
+++ b/enrolment/queue.py
@@ -2,14 +2,16 @@ import gc
 import json
 import logging
 
-from django.conf import settings
-from django.db import IntegrityError
-
 from psycopg2.errorcodes import UNIQUE_VIOLATION
+from rest_framework.serializers import ValidationError
+
+from django.conf import settings
+from django.db import IntegrityError, transaction
 
 from enrolment import serializers
 from enrolment.utils import ExitSignalReceiver, QueueService
-
+from user.serializers import UserSerializer
+from company.serializers import CompanySerializer
 
 logger = logging.getLogger(__name__)
 
@@ -104,9 +106,9 @@ class Worker:
             "Processing message '{}'".format(message.message_id)
         )
         if self.is_valid_enrolment(message.body):
-            self.save_enrolment(
-                sqs_message_id=message.message_id,
-                enrolment=json.loads(message.body)
+            self.create_objects(
+                json_payload=message.body,
+                message_id=message.message_id,
             )
         else:
             logger.error(
@@ -134,21 +136,55 @@ class Worker:
             exception.pgcode == UNIQUE_VIOLATION
         )
 
-    def save_enrolment(self, sqs_message_id, enrolment):
+    @transaction.atomic
+    def create_objects(self, json_payload, message_id):
+        # This function will create either all three objects (Enrolment, User,
+        # Company), or none of them. Using transactions.atomic rollsback our db
+        # changes on uncaught exception - so if `save_company` raises an
+        # exception, User and Enrolment objects will not be created too.
+        payload = json.loads(json_payload)
+        self.save_enrolment(
+            sqs_message_id=message_id,
+            aims=payload['aims'],
+            company_number=payload['company_number'],
+            email=payload['email'],
+            personal_name=payload['personal_name'],
+        )
+        self.save_user(
+            email=payload['email'],
+            name=payload['personal_name'],
+            referrer=payload['referrer'],
+            password=payload['password'],
+        )
+        # TODO: ED-228
+        # Link the company to the user.
+        self.save_company(
+            aims=payload['aims'],
+            number=payload['company_number'],
+        )
+
+    def save_enrolment(
+        self, sqs_message_id, aims, company_number, email, personal_name
+    ):
         """Creates new enrolment.models.Enrolment
 
         Args:
             sqs_message_id (str): SQS message ID
-            enrolment (str): Enrolment
+            aims (str[]): Goals of joining the scheme
+            company_number (str): Companies House number
+            email (str): User's email
+            personal_name (str): User's full name
         """
         logger.debug(
             "Saving new enrolment from message '{}'".format(sqs_message_id)
         )
-        # `copy` enrolment to avoid it being be mutated is other scopes.
-        data = enrolment.copy()
-        data['sqs_message_id'] = sqs_message_id
-
-        serializer = serializers.EnrolmentSerializer(data=data)
+        serializer = serializers.EnrolmentSerializer(data={
+            'aims': aims,
+            'company_number': company_number,
+            'email': email,
+            'personal_name': personal_name,
+            'sqs_message_id': sqs_message_id,
+        })
         assert serializer.is_valid()
 
         try:
@@ -162,3 +198,37 @@ class Worker:
                 )
             else:
                 raise
+
+    def save_user(self, email, name, referrer, password):
+        serializer = UserSerializer(data={
+            'email':email,
+            'name': name,
+            'referrer': referrer,
+            'password': password,
+        })
+        try:
+            serializer.is_valid(raise_exception=True)
+        except ValidationError:
+            logger.error(
+                'Cannot create user. Invalid details.',
+                extra={'erorrs': serializer.errors}
+            )
+            raise # trigger transaction rollback in parent function.
+        else:
+            serializer.save()
+
+    def save_company(self, aims, number, raise_on_invalid=False):
+        serializer = CompanySerializer(data={
+            'aims': aims,
+            'number': number,
+        })
+        try:
+            serializer.is_valid(raise_exception=True)
+        except ValidationError:
+            logger.error(
+                'Cannot create company. Invalid details.',
+                extra={'errors': serializer.errors}
+            )
+            raise # trigger transaction rollback in parent function.
+        else:
+            serializer.save()

--- a/enrolment/tests/__init__.py
+++ b/enrolment/tests/__init__.py
@@ -7,6 +7,8 @@ VALID_REQUEST_DATA = {
     "company_number": "01234567",
     "email": "test@example.com",
     "personal_name": "Test",
+    "referrer": "email",
+    "password": "hunter2"
 }
 VALID_REQUEST_DATA_JSON = json.dumps(VALID_REQUEST_DATA)
 

--- a/enrolment/tests/test_queue.py
+++ b/enrolment/tests/test_queue.py
@@ -1,12 +1,15 @@
 from unittest import mock
-
+from unittest.mock import patch, Mock
 import pytest
+from rest_framework.serializers import ValidationError
 
 import enrolment.queue
 import enrolment.models
 from enrolment.tests import (
     MockBoto, VALID_REQUEST_DATA, VALID_REQUEST_DATA_JSON
 )
+from user.models import User
+from company.models import Company
 
 
 class TestQueueWorker(MockBoto):
@@ -20,7 +23,7 @@ class TestQueueWorker(MockBoto):
         )
 
     @pytest.mark.django_db
-    def test_process_message(self):
+    def test_process_message_creates_enrolment(self):
         """ Test processing a message creates a new .models.Enrolment object
         """
         worker = enrolment.queue.Worker()
@@ -32,3 +35,99 @@ class TestQueueWorker(MockBoto):
         assert instance.company_number == VALID_REQUEST_DATA['company_number']
         assert instance.email == VALID_REQUEST_DATA['email']
         assert instance.personal_name == VALID_REQUEST_DATA['personal_name']
+
+    @pytest.mark.django_db
+    def test_process_message_creates_user(self):
+        worker = enrolment.queue.Worker()
+        worker.process_message(
+            mock.Mock(message_id='1', body=VALID_REQUEST_DATA_JSON)
+        )
+        instance = User.objects.last()
+        assert instance.name == VALID_REQUEST_DATA['personal_name']
+        assert instance.email == VALID_REQUEST_DATA['email']
+
+    @pytest.mark.django_db
+    def test_process_message_creates_company(self):
+        worker = enrolment.queue.Worker()
+        worker.process_message(
+            mock.Mock(message_id='1', body=VALID_REQUEST_DATA_JSON)
+        )
+        instance = Company.objects.last()
+        assert instance.aims == VALID_REQUEST_DATA['aims']
+        assert instance.number == VALID_REQUEST_DATA['company_number']
+
+    @pytest.mark.django_db
+    def test_process_message_company_exception_rollback(self):
+        for exception_class in [Exception, ValidationError]:
+            stub = Mock(side_effect=exception_class('!'))
+            with patch.object(enrolment.queue.Worker, 'save_company', stub):
+                worker = enrolment.queue.Worker()
+                with pytest.raises(exception_class):
+                    worker.process_message(
+                        mock.Mock(message_id='1', body=VALID_REQUEST_DATA_JSON)
+                    )
+                assert Company.objects.count() == 0
+                assert User.objects.count() == 0
+                assert enrolment.models.Enrolment.objects.count() == 0
+
+    @pytest.mark.django_db
+    def test_process_message_user_exception_rollback(self):
+        for exception_class in [Exception, ValidationError]:
+            stub = Mock(side_effect=exception_class('!'))
+            with patch.object(enrolment.queue.Worker, 'save_user', stub):
+                worker = enrolment.queue.Worker()
+                with pytest.raises(exception_class):
+                    worker.process_message(
+                        mock.Mock(message_id='1', body=VALID_REQUEST_DATA_JSON)
+                    )
+                assert Company.objects.count() == 0
+                assert User.objects.count() == 0
+                assert enrolment.models.Enrolment.objects.count() == 0
+
+    @pytest.mark.django_db
+    def test_process_message_enrolment_exception_rollback(self):
+        for exception_class in [Exception, ValidationError]:
+            stub = Mock(side_effect=exception_class('!'))
+            with patch.object(enrolment.queue.Worker, 'save_enrolment', stub):
+                worker = enrolment.queue.Worker()
+                with pytest.raises(exception_class):
+                    worker.process_message(
+                        mock.Mock(message_id='1', body=VALID_REQUEST_DATA_JSON)
+                    )
+                assert Company.objects.count() == 0
+                assert User.objects.count() == 0
+                assert enrolment.models.Enrolment.objects.count() == 0
+
+    @pytest.mark.django_db
+    def test_save_user_hashes_password(self):
+        worker = enrolment.queue.Worker()
+        worker.save_user(
+            email=VALID_REQUEST_DATA['email'],
+            name=VALID_REQUEST_DATA['personal_name'],
+            referrer=VALID_REQUEST_DATA['referrer'],
+            plaintext_password='password'
+        )
+        instance = User.objects.last()
+        assert instance.check_password('password')
+
+    @pytest.mark.django_db
+    def test_save_company_handles_exception(self):
+        user = User()
+        worker = enrolment.queue.Worker()
+        with pytest.raises(ValidationError):
+            worker.save_company(
+                number=None,  # cause ValidationError
+                aims=VALID_REQUEST_DATA['aims'],
+                user=user,
+            )
+
+    @pytest.mark.django_db
+    def test_save_user_handles_exception(self):
+        worker = enrolment.queue.Worker()
+        with pytest.raises(ValidationError):
+            worker.save_user(
+                email=None,  # cause ValidationError
+                name=VALID_REQUEST_DATA['personal_name'],
+                referrer=VALID_REQUEST_DATA['referrer'],
+                plaintext_password='password'
+            )

--- a/enrolment/tests/test_queue_worker_command.py
+++ b/enrolment/tests/test_queue_worker_command.py
@@ -14,10 +14,10 @@ import enrolment.queue
 from enrolment.tests import MockBoto, VALID_REQUEST_DATA
 
 
-def get_reqest_data_json(email_preix):
+def get_request_data_json(email_prefix):
     request_data = VALID_REQUEST_DATA.copy()
     # email muse be unique.
-    request_data['email'] = email_preix + request_data['email']
+    request_data['email'] = email_prefix + request_data['email']
     return json.dumps(request_data)
 
 
@@ -28,7 +28,7 @@ class TestQueueWorkerCommand(MockBoto):
         """ Test queue worker stops running on sigterm """
         worker = enrolment.queue.Worker()
         worker.enrolment_queue._queue.receive_messages.return_value = [
-            mock.Mock(message_id=x, body=get_reqest_data_json(str(x)))
+            mock.Mock(message_id=x, body=get_request_data_json(str(x)))
             for x in range(1000)
         ]
         worker_process = multiprocessing.Process(

--- a/enrolment/tests/test_queue_worker_command.py
+++ b/enrolment/tests/test_queue_worker_command.py
@@ -1,3 +1,4 @@
+import json
 import multiprocessing
 from unittest import mock
 import os
@@ -10,7 +11,14 @@ from django.core.management import call_command
 import pytest
 
 import enrolment.queue
-from enrolment.tests import MockBoto, VALID_REQUEST_DATA_JSON
+from enrolment.tests import MockBoto, VALID_REQUEST_DATA
+
+
+def get_reqest_data_json(email_preix):
+    request_data = VALID_REQUEST_DATA.copy()
+    # email muse be unique.
+    request_data['email'] = email_preix + request_data['email']
+    return json.dumps(request_data)
 
 
 class TestQueueWorkerCommand(MockBoto):
@@ -20,7 +28,7 @@ class TestQueueWorkerCommand(MockBoto):
         """ Test queue worker stops running on sigterm """
         worker = enrolment.queue.Worker()
         worker.enrolment_queue._queue.receive_messages.return_value = [
-            mock.Mock(message_id=x, body=VALID_REQUEST_DATA_JSON)
+            mock.Mock(message_id=x, body=get_reqest_data_json(str(x)))
             for x in range(1000)
         ]
         worker_process = multiprocessing.Process(

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -10,7 +10,8 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = models.User
         fields = ('id', 'name', 'email', 'terms_agreed', 'referrer',
-                  'date_joined')
+                  'date_joined', 'password',)
+        extra_kwargs = {'password': {'write_only': True, 'required': False}}
 
     def validate_name(self, value):
         return value or ''

--- a/user/tests/test_serializers.py
+++ b/user/tests/test_serializers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from user.serializers import UserSerializer
+from user.models import User
 from user.tests import VALID_REQUEST_DATA
 
 
@@ -48,3 +49,19 @@ def test_user_serializer_save():
     assert user.is_staff is False
     assert user.password == ''
     assert user.last_login is None
+
+
+@pytest.mark.django_db
+def test_user_serializer_readonly_password_serialize():
+    user = User(password=123)
+    serializer = UserSerializer(user)
+    assert 'password' not in serializer.data
+
+
+@pytest.mark.django_db
+def test_user_serializer_readonly_password_deserialize():
+    data = VALID_REQUEST_DATA.copy()
+    data['password'] = 'password'
+    serializer = UserSerializer(data=data)
+    assert serializer.is_valid()
+    assert serializer.validated_data['password'] == 'password'


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-173)

I have added placed the Enrolment, the User, and the Company creation within one transaction so either all three are created or none are created - to avoid orphaned objects.
