### PR TITLE
Use different permission class for gecko endpoint

### DIFF
--- a/user/tests/test_views.py
+++ b/user/tests/test_views.py
@@ -1,6 +1,6 @@
 import json
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from django.core.urlresolvers import reverse
 
@@ -169,23 +169,26 @@ class UserViewsTests(TestCase):
         response = client.get(reverse('validate-phone-number'), {})
         assert response.status_code == status.HTTP_200_OK
 
-    @pytest.mark.django_db
-    def test_gecko_num_registered_user_view_returns_correct_json(self):
-        client = APIClient()
-        User.objects.create(**VALID_REQUEST_DATA)
 
-        response = client.get(reverse('gecko-total-registered-users'))
+@pytest.mark.django_db
+@patch('rest_framework.permissions.IsAuthenticated.has_permission',
+       Mock(return_value=True))
+def test_gecko_num_registered_user_view_returns_correct_json():
+    client = APIClient()
+    User.objects.create(**VALID_REQUEST_DATA)
 
-        expected = {
-            "item": [
-                {
-                  "value": 1,
-                  "text": "Total registered users"
-                }
-              ]
-        }
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == expected
+    response = client.get(reverse('gecko-total-registered-users'))
+
+    expected = {
+        "item": [
+            {
+              "value": 1,
+              "text": "Total registered users"
+            }
+          ]
+    }
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == expected
 
 
 @pytest.mark.django_db

--- a/user/views.py
+++ b/user/views.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.renderers import JSONRenderer
 from rest_framework.authentication import BasicAuthentication
+from rest_framework.permissions import IsAuthenticated
 
 from user import models, serializers, gecko
 
@@ -39,6 +40,7 @@ class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
 
 class GeckoTotalRegisteredUsersView(APIView):
 
+    permission_classes = (IsAuthenticated, )
     authentication_classes = (BasicAuthentication, )
     renderer_classes = (JSONRenderer, )
     http_method_names = ("get", )


### PR DESCRIPTION
The IsAuthenticated permission class needs to be used instead of signing for Basic Auth to work with geckoboard (hopefully).