### PR TITLE
Allow updating of existing contact details

### DIFF
--- a/company/serializers.py
+++ b/company/serializers.py
@@ -75,6 +75,13 @@ class CompanySerializer(serializers.ModelSerializer):
     def validate_description(self, value):
         return value or ''
 
+    def validate_contact_details(self, value):
+        if self.partial:
+            contact_details = self.instance.contact_details or {}
+            contact_details.update(value)
+            return contact_details
+        return value
+
 
 class CompanyNumberValidatorSerializer(serializers.Serializer):
     number = serializers.CharField(validators=[

--- a/company/tests/test_serializers.py
+++ b/company/tests/test_serializers.py
@@ -259,3 +259,54 @@ def test_company_case_study_with_company(company_case_study_one):
         company_case_study_one
     )
     assert isinstance(serializer.data['company'], dict)
+
+
+@pytest.mark.django_db
+def test_company_serializer_updates_contact_details():
+    data = {
+        'number': "01234567",
+        'export_status': choices.EXPORT_STATUSES[1][0],
+        'name': 'Earnest Corp',
+        'date_of_creation': '2010-10-10',
+        'contact_details': {
+            'title': 'test_title',
+            'firstname': 'test_firstname',
+            'lastname': 'test_lastname',
+            'address_line_1': 'test_address_line_1',
+            'address_line_2': 'test_address_line_2',
+            'locality': 'test_locality',
+            'postal_code': 'test_postal_code',
+            'country': 'test_country',
+        }
+    }
+    create_serializer = serializers.CompanySerializer(data=data)
+
+    assert create_serializer.is_valid()
+    instance = create_serializer.save()
+
+    update_serializer = serializers.CompanySerializer(
+        instance,
+        data={
+            'contact_details': {
+                'postal_full_name': 'Jim'
+            }
+        },
+        partial=True
+    )
+
+    assert update_serializer.is_valid()
+    update_serializer.save()
+
+    instance.refresh_from_db()
+
+    assert instance.contact_details == {
+        'title': 'test_title',
+        'firstname': 'test_firstname',
+        'lastname': 'test_lastname',
+        'address_line_1': 'test_address_line_1',
+        'address_line_2': 'test_address_line_2',
+        'locality': 'test_locality',
+        'postal_code': 'test_postal_code',
+        'country': 'test_country',
+        'postal_full_name': 'Jim',
+    }


### PR DESCRIPTION
Now that we have standalone form edit pages, `contact_details` can be partially updated.