### PR TITLE
Allow viewing other people's case studies

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -51,12 +51,12 @@ urlpatterns = [
         name='company-verify'
     ),
     url(
-        r'^supplier/(?P<sso_id>[0-9]+)/company/case-study/$',
+        r'^company/case-study/$',
         CompanyCaseStudyViewSet.as_view({'post': 'create'}),
         name='company-case-study',
     ),
     url(
-        r'^supplier/(?P<sso_id>[0-9]+)/company/case-study/(?P<pk>[0-9]+)/$',
+        r'^company/case-study/(?P<pk>[0-9]+)/$',
         CompanyCaseStudyViewSet.as_view({
             'get': 'retrieve',
             'patch': 'partial_update',

--- a/company/permissions.py
+++ b/company/permissions.py
@@ -1,0 +1,10 @@
+from rest_framework import permissions
+
+
+class IsCaseStudyOwnerOrReadOnly(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        if not request.META.get('sso_id'):
+            return False
+        return obj.company.suppliers.filter(sso_id=request.META['sso_id'])

--- a/company/permissions.py
+++ b/company/permissions.py
@@ -5,6 +5,6 @@ class IsCaseStudyOwnerOrReadOnly(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS:
             return True
-        if not request.META.get('sso_id'):
+        if not request.META.get('sso-id'):
             return False
-        return obj.company.suppliers.filter(sso_id=request.META['sso_id'])
+        return obj.company.suppliers.filter(sso_id=request.META['sso-id'])

--- a/company/tests/test_views.py
+++ b/company/tests/test_views.py
@@ -409,7 +409,7 @@ def test_company_case_study_create(
     case_study_data, api_client, supplier, company
 ):
     # set headers to identify requester
-    api_client.defaults['sso_id'] = supplier.sso_id
+    api_client.defaults['sso-id'] = supplier.sso_id
 
     url = reverse('company-case-study')
     response = api_client.post(url, case_study_data, format='multipart')
@@ -437,7 +437,7 @@ def test_company_case_study_create(
 @patch('django.core.files.storage.Storage.save', mock_save)
 def test_company_case_study_update(supplier_case_study, supplier, api_client):
     # set headers to identify requester
-    api_client.defaults['sso_id'] = supplier.sso_id  # user is the owner
+    api_client.defaults['sso-id'] = supplier.sso_id  # user is the owner
 
     pk = supplier_case_study.pk
     url = reverse('company-case-study-detail', kwargs={'pk': pk})
@@ -457,7 +457,7 @@ def test_company_case_study_update(supplier_case_study, supplier, api_client):
 @patch('django.core.files.storage.Storage.save', mock_save)
 def test_company_case_study_delete(supplier_case_study, supplier, api_client):
     # set headers to identify requester
-    api_client.defaults['sso_id'] = supplier.sso_id  # user is the owner
+    api_client.defaults['sso-id'] = supplier.sso_id  # user is the owner
 
     pk = supplier_case_study.pk
     url = reverse('company-case-study-detail', kwargs={'pk': pk})
@@ -474,7 +474,7 @@ def test_company_case_study_get(
         supplier_case_study, supplier, api_client
 ):
     # set headers to identify requester
-    api_client.defaults['sso_id'] = supplier.sso_id  # user is the owner
+    api_client.defaults['sso-id'] = supplier.sso_id  # user is the owner
 
     pk = supplier_case_study.pk
     url = reverse('company-case-study-detail', kwargs={'pk': pk})
@@ -507,7 +507,7 @@ def test_company_case_study_prevent_non_owner_update(
     supplier_case_study, supplier, api_client
 ):
     # set headers to identify requester
-    api_client.defaults['sso_id'] = supplier.sso_id + 1 # user is not the owner
+    api_client.defaults['sso-id'] = supplier.sso_id + 1  # user not the owner
 
     pk = supplier_case_study.pk
     url = reverse('company-case-study-detail', kwargs={'pk': pk})
@@ -525,7 +525,7 @@ def test_company_case_study_prevent_non_owner_delete(
     supplier_case_study, supplier, api_client
 ):
     # set headers to identify requester
-    api_client.defaults['sso_id'] = supplier.sso_id + 1 # user is not the owner
+    api_client.defaults['sso-id'] = supplier.sso_id + 1  # user not the owner
 
     pk = supplier_case_study.pk
     url = reverse('company-case-study-detail', kwargs={'pk': pk})
@@ -535,7 +535,6 @@ def test_company_case_study_prevent_non_owner_delete(
     assert response.status_code == http.client.FORBIDDEN
 
 
-
 @pytest.mark.django_db
 @patch('signature.permissions.SignaturePermission.has_permission', Mock)
 @patch('django.core.files.storage.Storage.save', mock_save)
@@ -543,7 +542,7 @@ def test_company_case_study_handles_unidentified_user_update(
     supplier_case_study, supplier, api_client
 ):
     # set headers to non-logged in
-    api_client.defaults['sso_id'] = {}
+    api_client.defaults['sso-id'] = {}
 
     pk = supplier_case_study.pk
     url = reverse('company-case-study-detail', kwargs={'pk': pk})
@@ -561,7 +560,7 @@ def test_company_case_study_handles_unidentified_user_delete(
     supplier_case_study, supplier, api_client
 ):
     # set headers to non-logged in
-    api_client.defaults['sso_id'] = {}
+    api_client.defaults['sso-id'] = {}
 
     pk = supplier_case_study.pk
     url = reverse('company-case-study-detail', kwargs={'pk': pk})
@@ -578,7 +577,7 @@ def test_company_case_study_allow_non_owner_retrieve(
     supplier_case_study, supplier, api_client
 ):
     # set headers to identify requester
-    api_client.defaults['sso_id'] = supplier.sso_id + 1 # user is not the owner
+    api_client.defaults['sso-id'] = supplier.sso_id + 1  # user not the owner
 
     pk = supplier_case_study.pk
     url = reverse('company-case-study-detail', kwargs={'pk': pk})

--- a/company/views.py
+++ b/company/views.py
@@ -52,7 +52,7 @@ class CompanyCaseStudyViewSet(viewsets.ModelViewSet):
         if self.request.method == 'POST':
             # on case study create, get the company using the user's sso id.
             company = generics.get_object_or_404(
-                models.Company, suppliers__sso_id=self.request.META['sso_id']
+                models.Company, suppliers__sso_id=self.request.META['sso-id']
             )
             kwargs['data']['company'] = company.pk
         return super().get_serializer(*args, **kwargs)


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-630)

Instead of passing the sso user id in the url, we now provide it as a header. This counters the fact that now we want users to be able to see other people's case studies.

Added some permission handling to make sure that only the users attached to the case study's company can change the case study.