### PR TITLE
Add fix for incorrect has_valid_address logic

### DIFF
--- a/company/models.py
+++ b/company/models.py
@@ -152,7 +152,7 @@ class Company(TimeStampedModel):
             'address_line_1',
             'postal_code',
         ]
-        return all(hasattr(self, field) for field in required_address_fields)
+        return all(getattr(self, field) for field in required_address_fields)
 
 
 class CompanyCaseStudy(TimeStampedModel):

--- a/company/tests/test_models.py
+++ b/company/tests/test_models.py
@@ -7,13 +7,40 @@ from django.db import IntegrityError
 from django_extensions.db.fields import (
     ModificationDateTimeField, CreationDateTimeField
 )
-
 from company import models, tests
+from company.tests.factories import CompanyFactory
 
 
 @pytest.fixture
 def company():
     return models.Company.objects.create(**tests.VALID_REQUEST_DATA)
+
+
+@pytest.fixture
+def company_some_address_missing():
+    return CompanyFactory(
+        postal_full_name='Mr Fakingham',
+        address_line_1='',
+        postal_code='',
+    )
+
+
+@pytest.fixture
+def company_all_address_missing():
+    return CompanyFactory(
+        postal_full_name='',
+        address_line_1='',
+        postal_code='',
+    )
+
+
+@pytest.fixture
+def company_address_set():
+    return CompanyFactory(
+        postal_full_name='Mr Fakingham',
+        address_line_1='123 fake street',
+        postal_code='EM6 6EM',
+    )
 
 
 @pytest.mark.django_db
@@ -89,3 +116,18 @@ def test_company_case_study_model_has_update_create_timestamps():
     modified_field = models.CompanyCaseStudy._meta.get_field_by_name(
         'modified')[0]
     assert modified_field.__class__ is ModificationDateTimeField
+
+
+@pytest.mark.django_db
+def test_has_valid_address_some_values_missing(company_some_address_missing):
+    assert company_some_address_missing.has_valid_address() is False
+
+
+@pytest.mark.django_db
+def test_has_valid_address_all_values_missing(company_all_address_missing):
+    assert company_all_address_missing.has_valid_address() is False
+
+
+@pytest.mark.django_db
+def test_has_valid_address_all_values_present(company_address_set):
+    assert company_address_set.has_valid_address() is True

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ psycopg2==2.6.1
 raven==5.19.0
 boto3==1.4.1
 git+https://git@github.com/alphagov/notifications-python-client.git@1.4.0#egg=notifications-python-client
-git+https://github.com/uktrade/directory-validators.git@1.2.0#egg=directory_validators
+git+https://github.com/uktrade/directory-validators.git@1.3.2#egg=directory_validators
 git+https://github.com/uktrade/directory-constants.git@2.0.0#egg=directory_constants


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-735)

API was reporting the company address as known, even though it was not known.

This is because we were checking if the company had the address fields, rather than checking if those fields were set.