### PR TITLE
Prevent new companies in industry spam

### DIFF
--- a/company/tests/test_signals.py
+++ b/company/tests/test_signals.py
@@ -82,7 +82,7 @@ def test_does_not_overwrite_verification_code_if_already_set(settings):
 
 
 @pytest.mark.django_db
-@mock.patch('company.stannp.stannp_client')
+@mock.patch('company.signals.stannp_client')
 def test_does_not_send_if_letter_already_sent(mock_stannp_client, settings):
     settings.FEATURE_VERIFICATION_LETTERS_ENABLED = True
     CompanyFactory(
@@ -95,7 +95,7 @@ def test_does_not_send_if_letter_already_sent(mock_stannp_client, settings):
 
 @pytest.mark.django_db
 @freeze_time()
-@mock.patch('company.stannp.stannp_client')
+@mock.patch('company.signals.stannp_client')
 def test_marks_letter_as_sent(mock_stannp_client, settings):
     settings.FEATURE_VERIFICATION_LETTERS_ENABLED = True
     company = CompanyFactory(verification_code='test')
@@ -106,7 +106,7 @@ def test_marks_letter_as_sent(mock_stannp_client, settings):
 
 
 @pytest.mark.django_db
-@mock.patch('company.stannp.stannp_client')
+@mock.patch('company.signals.stannp_client')
 @mock.patch(
     'company.models.Company.has_valid_address',
     mock.Mock(return_value=False)

--- a/notifications/helpers.py
+++ b/notifications/helpers.py
@@ -44,7 +44,8 @@ def get_new_companies_anonymous_subscribers():
     """
     An email can subscribe to multiple industries. This removes duplicate
     email addresses and groups industries. Excludes subscribers that have
-    already received "new companies in industry" email today.
+    already received "new companies in industry" email within configured
+    time period.
 
     :returns list:
         [
@@ -58,13 +59,14 @@ def get_new_companies_anonymous_subscribers():
     """
 
     unsubscribers = AnonymousUnsubscribe.objects.all()
-    notifications_sent_today = AnonymousEmailNotification.objects.filter(
+    delta = timedelta(days=settings.NEW_COMPANIES_IN_SECTOR_FREQUENCY_DAYS)
+    notifications_sent_recently = AnonymousEmailNotification.objects.filter(
         category=constants.NEW_COMPANIES_IN_SECTOR,
-        date_sent__date=datetime.today().date()
+        date_sent__date__gte=datetime.utcnow() - delta
     )
     exclude_emails = (
         list(unsubscribers.values_list('email', flat=True)) +
-        list(notifications_sent_today.values_list('email', flat=True))
+        list(notifications_sent_recently.values_list('email', flat=True))
     )
 
     subscribers = {}

--- a/notifications/tests/test_notifications.py
+++ b/notifications/tests/test_notifications.py
@@ -842,15 +842,17 @@ def test_new_companies_in_sector_exclude_unsbscribed(settings):
 
 @freeze_time()
 @pytest.mark.django_db
-def test_new_companies_in_sector_exclude_already_sent_today(settings):
+def test_new_companies_in_sector_exclude_already_sent_recently(settings):
     settings.NEW_COMPANIES_IN_SECTOR_FREQUENCY_DAYS = 3
     settings.NEW_COMPANIES_IN_SECTOR_SUBJECT = 'test subject'
 
     days_ago_three = datetime.utcnow() - timedelta(days=3)
     buyer_one = BuyerFactory.create(sector='AEROSPACE')
     buyer_two = BuyerFactory.create(sector='AEROSPACE')
-    # date implicitly set by the model on save
-    AnonymousEmailNotificationFactory(email=buyer_two.email)
+
+    notification = AnonymousEmailNotificationFactory(email=buyer_two.email)
+    notification.date_sent = days_ago_three
+    notification.save()
 
     CompanyFactory(sectors=['AEROSPACE'], date_published=days_ago_three)
 
@@ -864,14 +866,15 @@ def test_new_companies_in_sector_exclude_already_sent_today(settings):
 
 @freeze_time()
 @pytest.mark.django_db
-def test_new_companies_in_sector_include_already_sent_yesteryday(settings):
+def test_new_companies_in_sector_include_already_sent_long_time_ago(settings):
     settings.NEW_COMPANIES_IN_SECTOR_FREQUENCY_DAYS = 3
     settings.NEW_COMPANIES_IN_SECTOR_SUBJECT = 'test subject'
 
     days_ago_three = datetime.utcnow() - timedelta(days=3)
+    days_ago_four = datetime.utcnow() - timedelta(days=4)
     buyer_one = BuyerFactory.create(sector='AEROSPACE')
     notification = AnonymousEmailNotificationFactory(email=buyer_one.email)
-    notification.date_sent = datetime.today().date() - timedelta(days=1)
+    notification.date_sent = days_ago_four
     notification.save()
 
     CompanyFactory(sectors=['AEROSPACE'], date_published=days_ago_three)


### PR DESCRIPTION
This weekend I received 'new companies in indutry' email eveny day listing the exact same companies. Users would be unhappy with this occurring.

The problem happened because our definition of "new companies" is "companies published within the last week", and our anti-spam tactic was "do not send the email more than once a day".

The solution was to change the anti-spam tactic to "do not sent the email more than once a week".