### PR TITLE
Performance improvement of "article read" endpoint

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -199,6 +199,11 @@ if DEBUG:
                 'level': 'WARNING',
                 'propagate': False,
             },
+            'elasticsearch': {
+                'handlers': ['console'],
+                'level': 'WARNING',
+                'propagate': False,
+            },
             '': {
                 'handlers': ['console'],
                 'level': 'DEBUG',

--- a/api/settings.py
+++ b/api/settings.py
@@ -189,6 +189,16 @@ if DEBUG:
                 'level': 'ERROR',
                 'propagate': True,
             },
+            'mohawk': {
+                'handlers': ['console'],
+                'level': 'WARNING',
+                'propagate': False,
+            },
+            'requests': {
+                'handlers': ['console'],
+                'level': 'WARNING',
+                'propagate': False,
+            },
             '': {
                 'handlers': ['console'],
                 'level': 'DEBUG',

--- a/exportreadiness/mixins.py
+++ b/exportreadiness/mixins.py
@@ -1,12 +1,17 @@
+from rest_framework.fields import empty
 from rest_framework.generics import get_object_or_404
 
+from django.http import QueryDict
 
-class InjectSSOIDCreateMixin:
 
-    def create(self, validated_data):
-        sso_id = self.context['request'].user.id
-        validated_data['sso_id'] = sso_id
-        return super().create(validated_data)
+class InjectSSOIDMixin:
+
+    def run_validation(self, data=empty):
+        if data:
+            if isinstance(data, QueryDict):
+                data = data.dict()
+            data['sso_id'] = self.context['request'].user.id
+        return super().run_validation(data)
 
 
 class GetObjectOr404FromSSOIdMixin:

--- a/exportreadiness/models.py
+++ b/exportreadiness/models.py
@@ -47,6 +47,9 @@ class ArticleRead(TimeStampedModel):
     article_uuid = models.UUIDField(choices=choices.EXREAD_ARTICLES_CHOICES)
     sso_id = models.PositiveIntegerField()
 
+    class Meta:
+        unique_together = ('article_uuid', 'sso_id')
+
 
 class TaskCompleted(TimeStampedModel):
     task_uuid = models.UUIDField()

--- a/exportreadiness/views.py
+++ b/exportreadiness/views.py
@@ -19,6 +19,17 @@ class ArticleReadCreateRetrieveView(mixins.FilterBySSOIdMixin,
                                     ListCreateAPIView):
     serializer_class = serializers.ArticleReadSerializer
 
+    def get_serializer(self, *args, **kwargs):
+        # allow bulk creating articles read for performance gains: ED-2822
+        if isinstance(kwargs.get('data'), list):
+            kwargs['many'] = True
+        return super().get_serializer(*args, **kwargs)
+
+    def create(self, *args, **kwargs):
+        super().create(*args, **kwargs)
+        # return all read articles on creation for performance gains: ED-2822
+        return self.list(*args, **kwargs)
+
 
 class TaskCompletedCreateRetrieveView(mixins.FilterBySSOIdMixin,
                                       ListCreateAPIView):


### PR DESCRIPTION
[part of this task](https://uktrade.atlassian.net/browse/ED-2822)

 😞 - not RESTful 
 😄 - allows bulk creation. Prevents ExRed needing to creating 40 "article read" in series during ExRed's request-response cycle.
 😄 - returns a list of read articles after bulk creating, so no need to POST then GET articles

I also calmed the logging of a few things to reduce noise.

do not merge

need to make single persist article work