### PR TITLE
Allow transferring ownership to collaborator

### DIFF
--- a/company/serializers.py
+++ b/company/serializers.py
@@ -243,7 +243,7 @@ class InviteSerializerMixin:
         if (
             user.supplier and
             user.supplier.company and
-            user.supplier.company is not self.instance.company
+            user.supplier.company != self.instance.company
         ):
             raise serializers.ValidationError({
                 self.email_field_name: self.MESSAGE_ALREADY_HAS_COMPANY


### PR DESCRIPTION
`user.supplier.company is not self.instance.company` does not fail during tests, but does fail during django running normally.

I cannot reproduce the error in tests.

I tried instantiating new instances of the Company in order to get a failing test, but still the test passed.