### PR TITLE
X-Forwarded-For spoofing mitigation

### DIFF
--- a/activitystream/tests/test_views.py
+++ b/activitystream/tests/test_views.py
@@ -1,225 +1,307 @@
 import datetime
 
-from freezegun import freeze_time
 import mohawk
+import pytest
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
 
 
-def auth_header(key_id, secret_key, url, method, content, content_type):
-    return mohawk.Sender({
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+def _url():
+    return 'http://testserver' + reverse('activity-stream')
+
+
+def _url_incorrect_domain():
+    return 'http://incorrect' + reverse('activity-stream')
+
+
+def _url_incorrect_path():
+    return 'http://testserver' + reverse('activity-stream') + 'incorrect/'
+
+
+def _auth_sender(key_id='some-id', secret_key='some-secret', url=_url,
+                 method='GET', content='', content_type=''):
+    credentials = {
         'id': key_id,
         'key': secret_key,
         'algorithm': 'sha256',
-    },
-        url,
+    }
+    return mohawk.Sender(
+        credentials,
+        url(),
         method,
         content=content,
         content_type=content_type,
-    ).request_header
-
-
-def test_if_x_forwarded_for_not_passed_then_401_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret',
-        'http://testserver/activity-stream/', 'GET', '', ''
-    )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
     )
 
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
 
-
-def test_if_x_forwarded_for_not_in_whitelist_then_401_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret',
-        'http://testserver/activity-stream/', 'GET', '', ''
+@pytest.mark.parametrize(
+    'get_kwargs,expected_json',
+    (
+        (
+            # If no X-Forwarded-For header
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If second-to-last X-Forwarded-For header isn't whitelisted
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='9.9.9.9, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the only IP address in X-Forwarded-For is whitelisted
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the only IP address in X-Forwarded-For isn't whitelisted
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If third-to-last IP in X-Forwarded-For header is whitelisted
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 124.124.124, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If last of 3 IPs in X-Forwarded-For header is whitelisted
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='124.124.124, 123.123.123.123, 1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header isn't passed
+            dict(
+                content_type='',
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            ),
+            {'detail': 'Authentication credentials were not provided.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect ID
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    key_id='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect secret
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    secret_key='incorrect'
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect domain
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    url=_url_incorrect_domain,
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect path
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    url=_url_incorrect_path,
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect method
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    method='POST',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from an incorrect
+            # content-type
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    content_type='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the Authorization header generated from incorrect content
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    content='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+    ),
+)
+@pytest.mark.django_db
+def test_401_returned(api_client, get_kwargs, expected_json):
+    """If the request isn't properly Hawk-authenticated, then a 401 is
+    returned
+    """
+    response = api_client.get(
+        _url(),
+        **get_kwargs,
     )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='9.9.9.9',
-    )
 
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == expected_json
 
 
-def test_if_authentication_not_passed_then_401_returned(client):
-    response = client.get(
-        '/activity-stream/',
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-
-    assert response.status_code == 401
-    error = b'{"detail":"Authentication credentials were not provided."}'
-    assert response.content == error
-
-
-def test_if_authentication_passed_but_61_seconds_in_past_401_returned(client):
-    past = datetime.datetime.now() + datetime.timedelta(seconds=-61)
+@pytest.mark.django_db
+def test_if_61_seconds_in_past_401_returned(api_client):
+    """If the Authorization header is generated 61 seconds in the past, then a
+    401 is returned
+    """
+    past = datetime.datetime.now() - datetime.timedelta(seconds=61)
     with freeze_time(past):
-        auth = auth_header(
-            'some-id', 'some-secret',
-            'http://testserver/activity-stream/', 'GET', '', ''
+        auth = _auth_sender().request_header
+    response = api_client.get(
+        reverse('activity-stream'),
+        content_type='',
+        HTTP_AUTHORIZATION=auth,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    error = {'detail': 'Incorrect authentication credentials.'}
+    assert response.json() == error
+
+
+@pytest.mark.django_db
+def test_if_authentication_reused_401_returned(api_client):
+    """If the Authorization header is reused, then a 401 is returned"""
+    auth = _auth_sender().request_header
+
+    response_1 = api_client.get(
+        _url(),
+        content_type='',
+        HTTP_AUTHORIZATION=auth,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+    )
+    assert response_1.status_code == status.HTTP_200_OK
+
+    response_2 = api_client.get(
+        _url(),
+        content_type='',
+        HTTP_AUTHORIZATION=auth,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+    )
+    assert response_2.status_code == status.HTTP_401_UNAUTHORIZED
+    error = {'detail': 'Incorrect authentication credentials.'}
+    assert response_2.json() == error
+
+
+@pytest.mark.django_db
+def test_empty_object_returned_with_authentication_3_ips(api_client):
+    """If the Authorization and X-Forwarded-For headers are correct,
+    with an extra IP address prepended to the X-Forwarded-For then
+    the correct, and authentic, data is returned
+    """
+    sender = _auth_sender()
+    response = api_client.get(
+        _url(),
+        content_type='',
+        HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='3.3.3.3, 1.2.3.4, 123.123.123.123',
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    content = {'secret': 'content-for-pen-test'}
+    assert response.json() == content
+
+
+@pytest.mark.django_db
+def test_empty_object_returned_with_authentication(api_client):
+    """If the Authorization and X-Forwarded-For headers are correct, then
+    the correct, and authentic, data is returned
+    """
+    sender = _auth_sender()
+    response = api_client.get(
+        _url(),
+        content_type='',
+        HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    content = {'secret': 'content-for-pen-test'}
+    assert response.json() == content
+
+    # Just asserting that accept_response doesn't raise is a bit weak,
+    # so we also assert that it raises if the header, content, or
+    # content_type are incorrect
+    sender.accept_response(
+        response_header=response['Server-Authorization'],
+        content=response.content,
+        content_type=response['Content-Type'],
+    )
+    with pytest.raises(mohawk.exc.MacMismatch):
+        sender.accept_response(
+            response_header=response['Server-Authorization'] + 'incorrect',
+            content=response.content,
+            content_type=response['Content-Type'],
         )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-    )
-
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
-
-
-def test_if_authentication_reused_401_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret',
-        'http://testserver/activity-stream/', 'GET', '', ''
-    )
-    response_1 = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-    assert response_1.status_code == 200
-
-    response_2 = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-    assert response_2.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response_2.content == error
-
-
-def test_if_incorrect_id_then_401_returned(client):
-    auth = auth_header(
-        'some-id-incorrect', 'some-secret',
-        'http://testserver/activity-stream/', 'GET', '', ''
-    )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
-
-
-def test_if_incorrect_secret_then_401_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret-incorrect',
-        'http://testserver/activity-stream/', 'GET', '', ''
-    )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
-
-
-def test_if_incorrect_domain_then_401_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret',
-        'http://incorrect/activity-stream/', 'GET', '', ''
-    )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
-
-
-def test_if_incorrect_path_then_401_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret',
-        'http://testserver/incorrect/', 'GET', '', ''
-    )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
-
-
-def test_if_incorrect_method_then_401_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret',
-        'http://testserver/activity-stream/', 'POST', '', ''
-    )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
-
-
-def test_if_incorrect_content_type_then_401_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret',
-        'http://testserver/activity-stream/', 'GET', 'incorrect', ''
-    )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
-
-
-def test_if_incorrect_content_then_401_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret',
-        'http://testserver/activity-stream/', 'GET', '', 'incorrect'
-    )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-
-    assert response.status_code == 401
-    error = b'{"detail":"Incorrect authentication credentials."}'
-    assert response.content == error
-
-
-def test_empty_object_returned(client):
-    auth = auth_header(
-        'some-id', 'some-secret',
-        'http://testserver/activity-stream/', 'GET', '', ''
-    )
-    response = client.get(
-        '/activity-stream/',
-        HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
-    )
-
-    assert response.status_code == 200
-    assert response.content == b'{"secret":"content-for-pen-test"}'
+    with pytest.raises(mohawk.exc.MisComputedContentHash):
+        sender.accept_response(
+            response_header=response['Server-Authorization'],
+            content='incorrect',
+            content_type=response['Content-Type'],
+        )
+    with pytest.raises(mohawk.exc.MisComputedContentHash):
+        sender.accept_response(
+            response_header=response['Server-Authorization'],
+            content=response.content,
+            content_type='incorrect',
+        )

--- a/activitystream/views.py
+++ b/activitystream/views.py
@@ -106,9 +106,9 @@ class ActivityStreamAuthentication(BaseAuthentication):
             raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
 
         # PaaS appends 2 IPs, where the IP connected from is the first
-        remote_address = ip_addesses[-2].strip()
+        remote_ip = ip_addesses[-2].strip()
 
-        if remote_address not in settings.ACTIVITY_STREAM_IP_WHITELIST:
+        if remote_ip not in settings.ACTIVITY_STREAM_IP_WHITELIST:
             logger.warning(
                 'Failed authentication: the X-Forwarded-For header was not '
                 'produced by a whitelisted IP'

--- a/activitystream/views.py
+++ b/activitystream/views.py
@@ -2,6 +2,8 @@ import logging
 
 from django.conf import settings
 from django.core.cache import cache
+from django.utils.crypto import constant_time_compare
+from django.utils.decorators import decorator_from_middleware
 from mohawk import Receiver
 from mohawk.exc import HawkFail
 from rest_framework.authentication import BaseAuthentication
@@ -9,17 +11,22 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
-log = logging.getLogger(__name__)
 
-NOT_PROVIDED = 'Authentication credentials were not provided.'
-INCORRECT = 'Incorrect authentication credentials.'
+logger = logging.getLogger(__name__)
+
+NO_CREDENTIALS_MESSAGE = 'Authentication credentials were not provided.'
+INCORRECT_CREDENTIALS_MESSAGE = 'Incorrect authentication credentials.'
 
 
-def lookup_credentials(access_key_id):
-    if access_key_id != settings.ACTIVITY_STREAM_ACCESS_KEY_ID:
-        raise AuthenticationFailed(
-            'No Hawk ID of {access_key_id}'.format(id=access_key_id)
-        )
+def _lookup_credentials(access_key_id):
+    """Raises a HawkFail if the passed ID is not equal to
+    settings.ACTIVITY_STREAM_ACCESS_KEY_ID
+    """
+    if not constant_time_compare(access_key_id,
+                                 settings.ACTIVITY_STREAM_ACCESS_KEY_ID):
+        raise HawkFail('No Hawk ID of {access_key_id}'.format(
+            access_key_id=access_key_id,
+        ))
 
     return {
         'id': settings.ACTIVITY_STREAM_ACCESS_KEY_ID,
@@ -28,75 +35,124 @@ def lookup_credentials(access_key_id):
     }
 
 
-def seen_nonce(access_key_id, nonce, _):
-    # This is a reason to _not_ use HawkRest: its nonce cache key
-    # contains a timestamp but it shouldn't, since the same nonce
-    # on a different timestamp should be rejected.
+def _seen_nonce(access_key_id, nonce, _):
+    """Returns if the passed access_key_id/nonce combination has been
+    used within 60 seconds
+    """
     cache_key = 'activity_stream:{access_key_id}:{nonce}'.format(
-        access_key_id=access_key_id, nonce=nonce)
-    seen_cache_key = cache.get(cache_key, False)
+        access_key_id=access_key_id,
+        nonce=nonce,
+    )
 
     # cache.add only adds key if it isn't present
-    cache.add(cache_key, True, timeout=60)
+    seen_cache_key = not cache.add(
+        cache_key, True, timeout=60,
+    )
 
     if seen_cache_key:
-        log.warning('Already seen nonce {nonce}'.format(nonce=nonce))
+        logger.warning('Already seen nonce {nonce}'.format(nonce=nonce))
 
     return seen_cache_key
 
 
 def _authorise(request):
+    """Raises a HawkFail if the passed request cannot be authenticated"""
     return Receiver(
-        lookup_credentials,
+        _lookup_credentials,
         request.META['HTTP_AUTHORIZATION'],
         request.build_absolute_uri(),
         request.method,
         content=request.body,
         content_type=request.content_type,
-        seen_nonce=seen_nonce,
+        seen_nonce=_seen_nonce,
     )
 
 
-class ActivityStreamAuthentication(BaseAuthentication):
+class _ActivityStreamAuthentication(BaseAuthentication):
 
-    # This is returned as the WWW-Authenticate header when
-    # AuthenticationFailed is raised. DRF also requires this
-    # to send a 401 (as opposed to 403)
     def authenticate_header(self, request):
+        """This is returned as the WWW-Authenticate header when
+        AuthenticationFailed is raised. DRF also requires this
+        to send a 401 (as opposed to 403)
+        """
         return 'Hawk'
 
     def authenticate(self, request):
+        """Authenticates a request using two mechanisms:
+
+        1. The X-Forwarded-For-Header, compared against a whitelist
+        2. A Hawk signature in the Authorization header
+
+        If either of these suggest we cannot authenticate, AuthenticationFailed
+        is raised, as required in the DRF authentication flow
+        """
+        self._authenticate_by_ip(request)
+        return self._authenticate_by_hawk(request)
+
+    def _authenticate_by_ip(self, request):
         if 'HTTP_X_FORWARDED_FOR' not in request.META:
-            log.warning(
+            logger.warning(
                 'Failed authentication: no X-Forwarded-For header passed'
             )
-            raise AuthenticationFailed(INCORRECT)
+            raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
 
-        remote_address = \
-            request.META['HTTP_X_FORWARDED_FOR'].split(',')[0].strip()
+        x_forwarded_for = request.META['HTTP_X_FORWARDED_FOR']
+        ip_addesses = x_forwarded_for.split(',')
+        if len(ip_addesses) < 2:
+            logger.warning(
+                'Failed authentication: the X-Forwarded-For header does not '
+                'contain enough IP addresses'
+            )
+            raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
+
+        # PaaS appends 2 IPs, where the IP connected from is the first
+        remote_address = ip_addesses[-2].strip()
 
         if remote_address not in settings.ACTIVITY_STREAM_IP_WHITELIST:
-            log.warning(
-                'Failed authentication: the X-Forwarded-For header did not '
-                'start with an IP in the whitelist'
+            logger.warning(
+                'Failed authentication: the X-Forwarded-For header was not '
+                'produced by a whitelisted IP'
             )
-            raise AuthenticationFailed(INCORRECT)
+            raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
 
+    def _authenticate_by_hawk(self, request):
         if 'HTTP_AUTHORIZATION' not in request.META:
-            raise AuthenticationFailed(NOT_PROVIDED)
+            raise AuthenticationFailed(NO_CREDENTIALS_MESSAGE)
 
         try:
             hawk_receiver = _authorise(request)
         except HawkFail as e:
-            log.warning('Failed authentication {}'.format(e))
-            raise AuthenticationFailed(INCORRECT)
+            logger.warning('Failed authentication {e}'.format(
+                e=e,
+            ))
+            raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
 
         return (None, hawk_receiver)
 
 
+class _ActivityStreamHawkResponseMiddleware:
+    """Adds the Server-Authorization header to the response, so the originator
+    of the request can authenticate the response
+    """
+
+    def process_response(self, viewset, response):
+        """Adds the Server-Authorization header to the response, so the originator
+        of the request can authenticate the response
+        """
+        response['Server-Authorization'] = viewset.request.auth.respond(
+            content=response.content,
+            content_type=response['Content-Type'],
+        )
+        return response
+
+
 class ActivityStreamViewSet(ViewSet):
-    authentication_classes = (ActivityStreamAuthentication,)
+    """List-only view set for the activity stream"""
+
+    authentication_classes = (_ActivityStreamAuthentication,)
     permission_classes = ()
 
+    @decorator_from_middleware(_ActivityStreamHawkResponseMiddleware)
     def list(self, request):
-        return Response({"secret": "content-for-pen-test"})
+        """A single page of activities"""
+        return Response({'secret': 'content-for-pen-test'})

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -487,6 +487,10 @@ ELASTICSEARCH_CASE_STUDY_INDEX_ALIAS = env.str(
 )
 
 # Activity Stream
+REMOTE_IP_ADDRESS_RETRIEVER = (
+    'core.authentication.'
+    'GovukPaaSRemoteIPAddressRetriver'
+)
 ACTIVITY_STREAM_ACCESS_KEY_ID = env.str('ACTIVITY_STREAM_ACCESS_KEY_ID', '')
 ACTIVITY_STREAM_SECRET_ACCESS_KEY = env.str(
     'ACTIVITY_STREAM_SECRET_ACCESS_KEY', ''

--- a/core/authentication.py
+++ b/core/authentication.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.utils.translation import ugettext_lazy as _
 
+from core.helpers import GovukPaaSRemoteIPAddressRetriver  # noqa
 from supplier import helpers
 
 

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -1,0 +1,27 @@
+class GovukPaaSRemoteIPAddressRetriver:
+    def get_ip_address(self, request):
+        """
+        Returns the IP of the client making a HTTP request, using the
+        second-to-last IP address in the X-Forwarded-For header. This
+        should not be able to be spoofed in GovukPaaS, but it is not
+        safe to use in other environments.
+
+        Args:
+            request (HttpRequest): the incoming Django request object
+
+        Returns:
+            str: The IP address of the incoming request
+
+        Raises:
+            LookupError: The X-Forwarded-For header is not present, or
+            does not contain enough IPs
+        """
+        if 'HTTP_X_FORWARDED_FOR' not in request.META:
+            raise LookupError('X-Forwarded-For not in HTTP headers')
+
+        x_forwarded_for = request.META['HTTP_X_FORWARDED_FOR']
+        ip_addesses = x_forwarded_for.split(',')
+        if len(ip_addesses) < 2:
+            raise LookupError('Not enough IP addresses in X-Forwarded-For')
+
+        return ip_addesses[-2].strip()

--- a/requirements.in
+++ b/requirements.in
@@ -27,3 +27,4 @@ directory-sso-api-client==2.5.1
 sigauth==2.1.2
 directory-healthcheck==0.4.2
 django-admin-ip-restrictor==0.1.0
+import_string==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ elasticsearch-dsl==5.2.0
 elasticsearch==5.3.0
 gunicorn==19.5.0
 idna==2.6                 # via cryptography, requests
+import_string==0.1.0
 jmespath==0.9.3           # via boto3, botocore
 kombu==4.1.0
 mohawk==0.3.4             # via sigauth
@@ -56,7 +57,7 @@ requests-aws4auth==0.9
 requests[security]==2.18.4
 s3transfer==0.1.13        # via boto3
 sigauth==2.1.2
-six==1.11.0               # via cryptography, django-extensions, elasticsearch-dsl, mohawk, pyopenssl, python-dateutil
+six==1.11.0               # via cryptography, django-extensions, elasticsearch-dsl, import-string, mohawk, pyopenssl, python-dateutil
 urllib3==1.22             # via elasticsearch, requests
 vine==1.1.4               # via amqp
 waitress==1.1.0


### PR DESCRIPTION
We don't have network-level firewall capabilities, but in PaaS, the
second-to-last element in the X-Forwarded-For header cannot be spoofed.