### PR TITLE
(feat) Include local company ID in activity stream

### DIFF
--- a/activitystream/views.py
+++ b/activitystream/views.py
@@ -225,6 +225,7 @@ class ActivityStreamViewSet(ViewSet):
                     'id': 'dit:directory:CompanyVerification:' + str(item.id),
                     'attributedTo': {
                         'type': ['Organization', 'dit:Company'],
+                        'id': 'dit:directory:Company:' + item.object_id,
                         'dit:companiesHouseNumber':
                             companies_by_id[int(item.object_id)]['number'],
                         'name': companies_by_id[int(item.object_id)]['name'],


### PR DESCRIPTION
When clients import from the activity stream, it is useful to be able to
uniquely identify each source to be able to deal with updates and avoid
duplication.

The specific use case in mind is Data Hub, which is to create companies
based on verified directory companies.