### PR TITLE
Filter out companies from activity stream if date_published is null

### DIFF
--- a/activitystream/tests/test_views.py
+++ b/activitystream/tests/test_views.py
@@ -402,7 +402,7 @@ def test_company_viewset(api_client, companies_url):
     with freeze_time('2012-09-01 12:00:01'):
         company_2 = CompanyFactory(number='10000002', date_published=datetime.datetime(2020, 9, 2))
 
-    # Crate a company without a date_published date. This shouldn't be included in the response
+    # Create a company without a date_published date. This shouldn't be included in the response
     CompanyFactory(number='10000003')
 
     # Page 1

--- a/activitystream/tests/test_views.py
+++ b/activitystream/tests/test_views.py
@@ -402,6 +402,9 @@ def test_company_viewset(api_client, companies_url):
     with freeze_time('2012-09-01 12:00:01'):
         company_2 = CompanyFactory(number='10000002', date_published=datetime.datetime(2020, 9, 2))
 
+    # Crate a company without a date_published date. This shouldn't be included in the response
+    CompanyFactory(number='10000003')
+
     # Page 1
     auth = _auth_sender(companies_url).request_header
     response = api_client.get(

--- a/activitystream/views.py
+++ b/activitystream/views.py
@@ -256,9 +256,10 @@ class ActivityStreamCompanyViewSet(BaseActivityStreamViewSet):
     def list(self, request):
         """A single page of companies to be consumed by activity stream."""
         after_ts, after_id = self._parse_after(request)
-        companies = list(Company.objects.all().filter(
+        companies = list(Company.objects.filter(
             Q(modified=after_ts, id__gt=after_id) |
-            Q(modified__gt=after_ts)
+            Q(modified__gt=after_ts),
+            date_published__isnull=False
         ).order_by('modified', 'id')[:MAX_PER_PAGE])
         return self._generate_response(
             ActivityStreamCompanySerializer(companies, many=True).data,


### PR DESCRIPTION
The company object returned from the activity stream endpoint has a published key which is set to the company's date_published. As this field can be null, unpublished companies need to be filtered out