### PR TITLE
GP2-1068:  Apply Black and isort to the codebase + tooling to allow their ongoing use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,20 @@ jobs:
             . venv/bin/activate
             pip install flake8
             flake8
+  black:
+    docker:
+      - image: circleci/python:3.6.6
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Run Black in check mode
+          command: |
+            python3 -m venv .venv
+            . .venv/bin/activate
+            pip install black
+            black ./ --check
 
 workflows:
   version: 2
@@ -84,3 +98,4 @@ workflows:
     jobs:
       - test
       - flake8
+      - black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+repos:
+    - repo: https://github.com/psf/black
+      rev: 20.8b1
+      hooks:
+          - id: black
+          # Config for black lives in pyproject.toml
+    - repo: https://github.com/asottile/blacken-docs
+      rev: v1.6.0
+      hooks:
+          - id: blacken-docs
+            additional_dependencies: [black==20.8b1]
+    - repo: https://github.com/PyCQA/isort
+      rev: 5.6.4
+      hooks:
+          - id: isort
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.8.4
+      hooks:
+          - id: flake8
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.3.0
+      hooks:
+          - id: trailing-whitespace
+            args: ["--markdown-linebreak-ext=md,markdown"]
+          - id: end-of-file-fixer
+          - id: check-yaml
+          - id: check-added-large-files
+          # - id: fix-encoding-pragma
+          - id: check-ast
+          - id: check-byte-order-marker
+          - id: check-merge-conflict
+          - id: debug-statements
+          - id: detect-private-key
+# -   repo: https://github.com/pre-commit/pygrep-hooks
+#     rev: v1.7.0
+#     hooks:
+#     -   id: python-use-type-annotations
+#     -   id: python-no-eval
+#     -   id: python-no-log-warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre release
 
 ### Implemented enhancements
+- GP2-1068 - Apply black and isort autoformatting to codebase incl makefile additions
 - GP2-1063 - Moved SuggestedCountries under dataservices app
 
 ### Bugs fixed
@@ -42,8 +43,8 @@
 - GP2-245 - generic view for CIA factbook
 - GP2-188 - population data from UN
 - GP2-316 - rename json field from target markets to market approach
-- GP2-315 - route-to-market model/view new api 
-- GP2-393 - model changes adaption target markets fields 
+- GP2-315 - route-to-market model/view new api
+- GP2-393 - model changes adaption target markets fields
 - GP2-395 - add target market documents
 - GP2-545 - remove airtable dependency
 - GP2-543 - country name mapping to improve lookup
@@ -60,7 +61,7 @@
 - No ticket - Migration fix for new build
 - No ticket - Upgrade django and markdown to fix security vulnerability
 - No Ticket - Faker spamming log message - only passing error message
-- No Ticket - Migration leaf node 
+- No Ticket - Migration leaf node
 - GP2-360 - un-data match
 - No Ticket - fix route to markets choices make optional
 - no commodity code make optional

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Secrets such as API keys and environment specific configurations are placed in `
 | make init_secrets             | Create your secret env var file |
 | make worker                   | Run the celery worker |
 | make beat                     | Run the celery beat scheduler |
+| make checks                   | Run isort, black and flake8 in check-only mode |
+| make autoformat               | Run isort, black and flake8 in update-files mode |
 
 
 ## SSO
@@ -99,8 +101,3 @@ https://github.com/uktrade?q=great
 
 [calver-image]: https://img.shields.io/badge/Versioning%20strategy-CalVer-5FBB1C.svg
 [calver]: https://calver.org
-
-
-
-
-

--- a/activitystream/serializers.py
+++ b/activitystream/serializers.py
@@ -10,6 +10,7 @@ class ActivityStreamCompanySerializer(serializers.ModelSerializer):
     - Adds extra response fields required by activity stream.
     - Adds the required prefix to field names
     """
+
     class Meta:
         model = Company
         fields = (
@@ -81,6 +82,6 @@ class ActivityStreamCompanySerializer(serializers.ModelSerializer):
             'object': {
                 'id': f'{prefix}:{instance.id}',
                 'type': 'dit:directory:Company',
-                **{f'{prefix}:{k}': v for k, v in super().to_representation(instance).items()}
-            }
+                **{f'{prefix}:{k}': v for k, v in super().to_representation(instance).items()},
+            },
         }

--- a/activitystream/tests/test_views.py
+++ b/activitystream/tests/test_views.py
@@ -33,19 +33,16 @@ def _url_incorrect_domain():
 
 @pytest.fixture
 def _url_incorrect_path():
-    return (
-        'http://testserver' +
-        reverse('activity-stream:activity-stream') +
-        'incorrect/'
-    )
+    return 'http://testserver' + reverse('activity-stream:activity-stream') + 'incorrect/'
 
 
 def _empty_collection():
     return {
         '@context': [
-            'https://www.w3.org/ns/activitystreams', {
+            'https://www.w3.org/ns/activitystreams',
+            {
                 'dit': 'https://www.trade.gov.uk/ns/activitystreams/v1',
-            }
+            },
         ],
         'type': 'Collection',
         'orderedItems': [],
@@ -127,8 +124,7 @@ def test_empty_object_returned_with_authentication(api_client, activities_url):
 
 @pytest.mark.django_db
 def test_if_never_verified_not_in_stream(api_client, activities_url):
-    """If the company never verified, then it's not in the activity stream
-    """
+    """If the company never verified, then it's not in the activity stream"""
 
     with freeze_time('2012-01-14 12:00:02'):
         CompanyFactory()
@@ -143,9 +139,10 @@ def test_if_never_verified_not_in_stream(api_client, activities_url):
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': [
-            'https://www.w3.org/ns/activitystreams', {
+            'https://www.w3.org/ns/activitystreams',
+            {
                 'dit': 'https://www.trade.gov.uk/ns/activitystreams/v1',
-            }
+            },
         ],
         'type': 'Collection',
         'orderedItems': [],
@@ -155,22 +152,18 @@ def test_if_never_verified_not_in_stream(api_client, activities_url):
 
 @pytest.mark.django_db
 def test_if_verified_with_code_in_stream_in_date_then_seq_order(api_client, activities_url):
-    """If the company verified_with_code, then it's in the activity stream
-    """
+    """If the company verified_with_code, then it's in the activity stream"""
 
     CompanyFactory(number=10000000)
 
     with freeze_time('2012-01-14 12:00:02'):
-        company_a = CompanyFactory(
-            number=10000003, name='a', verified_with_code=True)
+        company_a = CompanyFactory(number=10000003, name='a', verified_with_code=True)
 
     with freeze_time('2012-01-14 12:00:02'):
-        company_b = CompanyFactory(
-            number=10000002, name='b', verified_with_code=True)
+        company_b = CompanyFactory(number=10000002, name='b', verified_with_code=True)
 
     with freeze_time('2012-01-14 12:00:01'):
-        company_c = CompanyFactory(
-            number=10000001, name='c', verified_with_code=True)
+        company_c = CompanyFactory(number=10000001, name='c', verified_with_code=True)
 
     sender = _auth_sender(activities_url)
     response = api_client.get(
@@ -268,18 +261,15 @@ def test_if_verified_with_preverified_enrolment_in_stream(api_client, activities
 
 @pytest.mark.django_db
 def test_pagination(api_client, django_assert_num_queries, activities_url):
-    """The requests are paginated, ending on a page without a next key
-    """
+    """The requests are paginated, ending on a page without a next key"""
 
     with freeze_time('2012-01-14 12:00:02'):
         for i in range(0, 250):
-            CompanyFactory(number=10000000 + i,
-                           verified_with_preverified_enrolment=True)
+            CompanyFactory(number=10000000 + i, verified_with_preverified_enrolment=True)
 
     with freeze_time('2012-01-14 12:00:01'):
         for i in range(250, 501):
-            CompanyFactory(number=10000000 + i,
-                           verified_with_preverified_enrolment=True)
+            CompanyFactory(number=10000000 + i, verified_with_preverified_enrolment=True)
 
     items = []
     next_url = activities_url
@@ -297,9 +287,7 @@ def test_pagination(api_client, django_assert_num_queries, activities_url):
             )
             response_json = response.json()
             items += response_json['orderedItems']
-            next_url = \
-                response_json['next'] if 'next' in response_json else \
-                None
+            next_url = response_json['next'] if 'next' in response_json else None
 
     assert num_pages == 5
     assert len(items) == 501
@@ -389,9 +377,9 @@ def _expected_company_response(company):
             'dit:directory:Company:expertise_languages': company.expertise_languages,
             'dit:directory:Company:expertise_products_services': {
                 'other': ['Regulatory', 'Finance', 'IT'],
-                'Finance': ['Insurance']
-            }
-        }
+                'Finance': ['Insurance'],
+            },
+        },
     }
 
 

--- a/activitystream/views.py
+++ b/activitystream/views.py
@@ -1,12 +1,11 @@
-from datetime import datetime
 import logging
+from datetime import datetime
 
-from django.db.models import Q
 from django.conf import settings
 from django.core.cache import cache
+from django.db.models import Q
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import decorator_from_middleware
-
 from field_history.models import FieldHistory
 from mohawk import Receiver
 from mohawk.exc import HawkFail
@@ -29,11 +28,12 @@ def lookup_credentials(access_key_id):
     """Raises a HawkFail if the passed ID is not equal to
     settings.ACTIVITY_STREAM_INCOMING_ACCESS_KEY
     """
-    if not constant_time_compare(access_key_id,
-                                 settings.ACTIVITY_STREAM_INCOMING_ACCESS_KEY):
-        raise HawkFail('No Hawk ID of {access_key_id}'.format(
-            access_key_id=access_key_id,
-        ))
+    if not constant_time_compare(access_key_id, settings.ACTIVITY_STREAM_INCOMING_ACCESS_KEY):
+        raise HawkFail(
+            'No Hawk ID of {access_key_id}'.format(
+                access_key_id=access_key_id,
+            )
+        )
 
     return {
         'id': settings.ACTIVITY_STREAM_INCOMING_ACCESS_KEY,
@@ -53,7 +53,9 @@ def seen_nonce(access_key_id, nonce, _):
 
     # cache.add only adds key if it isn't present
     seen_cache_key = not cache.add(
-        cache_key, True, timeout=60,
+        cache_key,
+        True,
+        timeout=60,
     )
 
     if seen_cache_key:
@@ -76,7 +78,6 @@ def authorise(request):
 
 
 class ActivityStreamAuthentication(BaseAuthentication):
-
     def authenticate_header(self, request):
         """This is returned as the WWW-Authenticate header when
         AuthenticationFailed is raised. DRF also requires this
@@ -100,9 +101,11 @@ class ActivityStreamAuthentication(BaseAuthentication):
         try:
             hawk_receiver = authorise(request)
         except HawkFail as e:
-            logger.warning('Failed authentication {e}'.format(
-                e=e,
-            ))
+            logger.warning(
+                'Failed authentication {e}'.format(
+                    e=e,
+                )
+            )
             raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
 
         return (None, hawk_receiver)
@@ -144,16 +147,19 @@ class BaseActivityStreamViewSet(ViewSet):
     def _generate_response(items, next_page_url):
         """Put together a response in the format required by activity stream"""
         next_page = {'next': next_page_url} if next_page_url else {}
-        return Response({
-            '@context': [
-                'https://www.w3.org/ns/activitystreams', {
-                    'dit': 'https://www.trade.gov.uk/ns/activitystreams/v1',
-                },
-            ],
-            'type': 'Collection',
-            'orderedItems': items,
-            **next_page,
-        })
+        return Response(
+            {
+                '@context': [
+                    'https://www.w3.org/ns/activitystreams',
+                    {
+                        'dit': 'https://www.trade.gov.uk/ns/activitystreams/v1',
+                    },
+                ],
+                'type': 'Collection',
+                'orderedItems': items,
+                **next_page,
+            }
+        )
 
 
 class ActivityStreamViewSet(BaseActivityStreamViewSet):
@@ -191,10 +197,11 @@ class ActivityStreamViewSet(BaseActivityStreamViewSet):
         that the db will use an index
         """
         after_ts, after_id = self._parse_after(request)
-        history_qs_all = FieldHistory.objects.all().filter(
-            Q(date_created=after_ts, id__gt=after_id) |
-            Q(date_created__gt=after_ts)
-        ).order_by('date_created', 'id')
+        history_qs_all = (
+            FieldHistory.objects.all()
+            .filter(Q(date_created=after_ts, id__gt=after_id) | Q(date_created__gt=after_ts))
+            .order_by('date_created', 'id')
+        )
         history_qs = history_qs_all[:MAX_PER_PAGE]
         history = list(history_qs)
 
@@ -205,47 +212,36 @@ class ActivityStreamViewSet(BaseActivityStreamViewSet):
         # so is likely not worse.
 
         company_ids = [item.object_id for item in history]
-        companies = Company.objects.all().filter(
-            id__in=company_ids).values('id', 'number', 'name')
-        companies_by_id = dict(
-            (company['id'], company) for company in companies
-        )
+        companies = Company.objects.all().filter(id__in=company_ids).values('id', 'number', 'name')
+        companies_by_id = dict((company['id'], company) for company in companies)
 
-        items = [{
-            'id': (
-                'dit:directory:CompanyVerification:' + str(item.id) +
-                ':Create'
-            ),
-            'type': 'Create',
-            'published': item.date_created.isoformat('T'),
-            'generator': {
-                'type': 'Application',
-                'name': 'dit:directory',
-            },
-            'object': {
-                'type': ['Document', 'dit:directory:CompanyVerification'],
-                'id': 'dit:directory:CompanyVerification:' + str(item.id),
-                'attributedTo': {
-                    'type': ['Organization', 'dit:Company'],
-                    'id': 'dit:directory:Company:' + item.object_id,
-                    'dit:companiesHouseNumber':
-                        companies_by_id[int(item.object_id)]['number'],
-                    'name': companies_by_id[int(item.object_id)]['name'],
+        items = [
+            {
+                'id': ('dit:directory:CompanyVerification:' + str(item.id) + ':Create'),
+                'type': 'Create',
+                'published': item.date_created.isoformat('T'),
+                'generator': {
+                    'type': 'Application',
+                    'name': 'dit:directory',
                 },
-            },
-        } for item in history
-            if (
-                self._company_in_db(companies_by_id, item) and
-                self._was_company_verified(item)
-            )
+                'object': {
+                    'type': ['Document', 'dit:directory:CompanyVerification'],
+                    'id': 'dit:directory:CompanyVerification:' + str(item.id),
+                    'attributedTo': {
+                        'type': ['Organization', 'dit:Company'],
+                        'id': 'dit:directory:Company:' + item.object_id,
+                        'dit:companiesHouseNumber': companies_by_id[int(item.object_id)]['number'],
+                        'name': companies_by_id[int(item.object_id)]['name'],
+                    },
+                },
+            }
+            for item in history
+            if (self._company_in_db(companies_by_id, item) and self._was_company_verified(item))
         ]
 
         return self._generate_response(
             items=items,
-            next_page_url=(
-                self._build_after(request, history[-1].date_created, history[-1].id)
-                if history else None
-            ),
+            next_page_url=(self._build_after(request, history[-1].date_created, history[-1].id) if history else None),
         )
 
 
@@ -256,12 +252,12 @@ class ActivityStreamCompanyViewSet(BaseActivityStreamViewSet):
     def list(self, request):
         """A single page of companies to be consumed by activity stream."""
         after_ts, after_id = self._parse_after(request)
-        companies = list(Company.objects.filter(
-            Q(modified=after_ts, id__gt=after_id) |
-            Q(modified__gt=after_ts),
-            date_published__isnull=False
-        ).order_by('modified', 'id')[:MAX_PER_PAGE])
+        companies = list(
+            Company.objects.filter(
+                Q(modified=after_ts, id__gt=after_id) | Q(modified__gt=after_ts), date_published__isnull=False
+            ).order_by('modified', 'id')[:MAX_PER_PAGE]
+        )
         return self._generate_response(
             ActivityStreamCompanySerializer(companies, many=True).data,
-            self._build_after(request, companies[-1].modified, companies[-1].id) if companies else None
+            self._build_after(request, companies[-1].modified, companies[-1].id) if companies else None,
         )

--- a/buyer/admin.py
+++ b/buyer/admin.py
@@ -2,8 +2,8 @@ import datetime
 
 from django.contrib import admin
 
-from core.helpers import generate_csv_response
 from buyer.models import Buyer
+from core.helpers import generate_csv_response
 
 
 @admin.register(Buyer)
@@ -11,20 +11,15 @@ class BuyerAdmin(admin.ModelAdmin):
     search_fields = ('email', 'name', 'country')
     readonly_fields = ('created', 'modified')
     list_display = ('name', 'email', 'sector', 'country', 'created')
-    list_filter = ('sector', )
+    list_filter = ('sector',)
     actions = ['download_csv']
 
-    csv_excluded_fields = ('buyeremailnotification', )
-    csv_filename = 'find-a-buyer_buyers_{}.csv'.format(
-                datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
+    csv_excluded_fields = ('buyeremailnotification',)
+    csv_filename = 'find-a-buyer_buyers_{}.csv'.format(datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
 
     def download_csv(self, request, queryset):
         return generate_csv_response(
-            queryset=queryset,
-            filename=self.csv_filename,
-            excluded_fields=self.csv_excluded_fields
+            queryset=queryset, filename=self.csv_filename, excluded_fields=self.csv_excluded_fields
         )
 
-    download_csv.short_description = (
-        "Download CSV report for selected buyers"
-    )
+    download_csv.short_description = "Download CSV report for selected buyers"

--- a/buyer/management/commands/generate_buyers_csv_dump.py
+++ b/buyer/management/commands/generate_buyers_csv_dump.py
@@ -3,10 +3,8 @@ import io
 from django.conf import settings
 from django.core.management import BaseCommand
 
-
-from core.helpers import generate_csv
 from buyer.models import Buyer
-from core.helpers import upload_file_object_to_s3
+from core.helpers import generate_csv, upload_file_object_to_s3
 
 
 class Command(BaseCommand):
@@ -20,19 +18,11 @@ class Command(BaseCommand):
             key=key,
             bucket=settings.AWS_STORAGE_BUCKET_NAME_DATA_SCIENCE,
         )
-        self.stdout.write(
-            self.style.SUCCESS(
-                'All done, bye!'
-            )
-        )
+        self.stdout.write(self.style.SUCCESS('All done, bye!'))
 
     @staticmethod
     def generate_csv_file():
         csv_excluded_fields = ('buyeremailnotification',)
         file_object = io.StringIO()
-        generate_csv(
-            file_object=file_object,
-            queryset=Buyer.objects.all(),
-            excluded_fields=csv_excluded_fields
-        )
+        generate_csv(file_object=file_object, queryset=Buyer.objects.all(), excluded_fields=csv_excluded_fields)
         return file_object

--- a/buyer/models.py
+++ b/buyer/models.py
@@ -1,5 +1,4 @@
 from directory_constants import choices
-
 from django.db import models
 
 from core.helpers import TimeStampedModel

--- a/buyer/serializers.py
+++ b/buyer/serializers.py
@@ -4,7 +4,6 @@ from buyer import models
 
 
 class BuyerSerializer(serializers.ModelSerializer):
-
     class Meta(object):
         model = models.Buyer
         fields = (

--- a/buyer/tests/factories.py
+++ b/buyer/tests/factories.py
@@ -1,10 +1,8 @@
 import factory
 import factory.fuzzy
-
 from directory_constants import choices
 
 from buyer.models import Buyer
-
 
 SECTORS = [i[0] for i in choices.INDUSTRIES]
 
@@ -12,12 +10,10 @@ SECTORS = [i[0] for i in choices.INDUSTRIES]
 class BuyerFactory(factory.django.DjangoModelFactory):
 
     name = factory.fuzzy.FuzzyText(length=12)
-    email = factory.LazyAttribute(
-        lambda buyer: '%s@example.com' % buyer.name)
+    email = factory.LazyAttribute(lambda buyer: '%s@example.com' % buyer.name)
     sector = factory.fuzzy.FuzzyChoice(SECTORS)
     company_name = factory.fuzzy.FuzzyText(length=12)
-    country = factory.fuzzy.FuzzyChoice(
-        ['Germany', 'China', 'Japan', 'Neverland', 'Roman Empire'])
+    country = factory.fuzzy.FuzzyChoice(['Germany', 'China', 'Japan', 'Neverland', 'Roman Empire'])
 
     class Meta:
         model = Buyer

--- a/buyer/tests/test_admin.py
+++ b/buyer/tests/test_admin.py
@@ -1,11 +1,10 @@
 from collections import OrderedDict
 from unittest import TestCase
 
+import pytest
+from django.contrib.auth.models import User
 from django.test import Client
 from django.urls import reverse
-from django.contrib.auth.models import User
-
-import pytest
 
 from buyer.models import Buyer
 from buyer.tests.factories import BuyerFactory
@@ -13,39 +12,29 @@ from buyer.tests.factories import BuyerFactory
 
 @pytest.mark.django_db
 class DownloadCSVTestCase(TestCase):
-
     def setUp(self):
-        superuser = User.objects.create_superuser(
-            username='admin', email='admin@example.com', password='test'
-        )
+        superuser = User.objects.create_superuser(username='admin', email='admin@example.com', password='test')
         self.client = Client()
         self.client.force_login(superuser)
 
     def test_download_csv(self):
         buyer = BuyerFactory()
 
-        data = {
-            'action': 'download_csv',
-            '_selected_action': Buyer.objects.all().values_list(
-                'pk', flat=True
-            )
-        }
-        response = self.client.post(
-            reverse('admin:buyer_buyer_changelist'),
-            data,
-            follow=True
-        )
+        data = {'action': 'download_csv', '_selected_action': Buyer.objects.all().values_list('pk', flat=True)}
+        response = self.client.post(reverse('admin:buyer_buyer_changelist'), data, follow=True)
 
-        expected_data = OrderedDict([
-            ('company_name', str(buyer.company_name)),
-            ('country', str(buyer.country)),
-            ('created', str(buyer.created)),
-            ('email', buyer.email),
-            ('id', str(buyer.id)),
-            ('modified', str(buyer.modified)),
-            ('name', buyer.name),
-            ('sector', buyer.sector),
-        ])
+        expected_data = OrderedDict(
+            [
+                ('company_name', str(buyer.company_name)),
+                ('country', str(buyer.country)),
+                ('created', str(buyer.created)),
+                ('email', buyer.email),
+                ('id', str(buyer.id)),
+                ('modified', str(buyer.modified)),
+                ('name', buyer.name),
+                ('sector', buyer.sector),
+            ]
+        )
         actual = str(response.content, 'utf-8').split('\r\n')
 
         assert actual[0] == ','.join(expected_data.keys())
@@ -53,48 +42,45 @@ class DownloadCSVTestCase(TestCase):
 
     def test_download_csv_multiple_buyers(self):
         buyers = BuyerFactory.create_batch(3)
-        buyer_one_expected_data = OrderedDict([
-            ('company_name', str(buyers[0].company_name)),
-            ('country', str(buyers[0].country)),
-            ('created', str(buyers[0].created)),
-            ('email', buyers[0].email),
-            ('id', str(buyers[0].id)),
-            ('modified', str(buyers[0].modified)),
-            ('name', buyers[0].name),
-            ('sector', buyers[0].sector),
-        ])
-        buyer_two_expected_data = OrderedDict([
-            ('company_name', str(buyers[1].company_name)),
-            ('country', str(buyers[1].country)),
-            ('created', str(buyers[1].created)),
-            ('email', buyers[1].email),
-            ('id', str(buyers[1].id)),
-            ('modified', str(buyers[1].modified)),
-            ('name', buyers[1].name),
-            ('sector', buyers[1].sector),
-        ])
-        buyer_three_expected_data = OrderedDict([
-            ('company_name', str(buyers[2].company_name)),
-            ('country', str(buyers[2].country)),
-            ('created', str(buyers[2].created)),
-            ('email', buyers[2].email),
-            ('id', str(buyers[2].id)),
-            ('modified', str(buyers[2].modified)),
-            ('name', buyers[2].name),
-            ('sector', buyers[2].sector),
-        ])
-
-        data = {
-            'action': 'download_csv',
-            '_selected_action': Buyer.objects.all().values_list(
-                'pk', flat=True
-            )
-        }
-        response = self.client.post(
-            reverse('admin:buyer_buyer_changelist'),
-            data,
-            follow=True
+        buyer_one_expected_data = OrderedDict(
+            [
+                ('company_name', str(buyers[0].company_name)),
+                ('country', str(buyers[0].country)),
+                ('created', str(buyers[0].created)),
+                ('email', buyers[0].email),
+                ('id', str(buyers[0].id)),
+                ('modified', str(buyers[0].modified)),
+                ('name', buyers[0].name),
+                ('sector', buyers[0].sector),
+            ]
         )
+        buyer_two_expected_data = OrderedDict(
+            [
+                ('company_name', str(buyers[1].company_name)),
+                ('country', str(buyers[1].country)),
+                ('created', str(buyers[1].created)),
+                ('email', buyers[1].email),
+                ('id', str(buyers[1].id)),
+                ('modified', str(buyers[1].modified)),
+                ('name', buyers[1].name),
+                ('sector', buyers[1].sector),
+            ]
+        )
+        buyer_three_expected_data = OrderedDict(
+            [
+                ('company_name', str(buyers[2].company_name)),
+                ('country', str(buyers[2].country)),
+                ('created', str(buyers[2].created)),
+                ('email', buyers[2].email),
+                ('id', str(buyers[2].id)),
+                ('modified', str(buyers[2].modified)),
+                ('name', buyers[2].name),
+                ('sector', buyers[2].sector),
+            ]
+        )
+
+        data = {'action': 'download_csv', '_selected_action': Buyer.objects.all().values_list('pk', flat=True)}
+        response = self.client.post(reverse('admin:buyer_buyer_changelist'), data, follow=True)
 
         actual = str(response.content, 'utf-8').split('\r\n')
         assert actual[0] == ','.join(buyer_one_expected_data.keys())

--- a/buyer/tests/test_management_commands.py
+++ b/buyer/tests/test_management_commands.py
@@ -8,9 +8,7 @@ from buyer.tests.factories import BuyerFactory
 
 
 @pytest.mark.django_db
-@mock.patch(
-    'buyer.management.commands.generate_buyers_csv_dump.upload_file_object_to_s3'  # NOQA
-)
+@mock.patch('buyer.management.commands.generate_buyers_csv_dump.upload_file_object_to_s3')
 def test_upload_buyers_csv_to_s3(mocked_upload_file_object_to_s3):
     BuyerFactory.create_batch(5)
     settings.AWS_STORAGE_BUCKET_NAME_DATA_SCIENCE = 'my_ds_bucket'

--- a/buyer/tests/test_models.py
+++ b/buyer/tests/test_models.py
@@ -1,8 +1,5 @@
 import pytest
-
-from django_extensions.db.fields import (
-    ModificationDateTimeField, CreationDateTimeField
-)
+from django_extensions.db.fields import CreationDateTimeField, ModificationDateTimeField
 
 from buyer import models
 from buyer.tests.factories import BuyerFactory

--- a/buyer/tests/test_tasks.py
+++ b/buyer/tests/test_tasks.py
@@ -7,6 +7,4 @@ from buyer.tasks import buyers_csv_upload
 @mock.patch('buyer.tasks.call_command')
 def test_buyers_csv_upload(mocked_call_command):
     buyers_csv_upload()
-    mocked_call_command.assert_called_once_with(
-        'generate_buyers_csv_dump'
-    )
+    mocked_call_command.assert_called_once_with('generate_buyers_csv_dump')

--- a/buyer/tests/test_views.py
+++ b/buyer/tests/test_views.py
@@ -1,19 +1,17 @@
 import http
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from django.conf import settings
-
 from django.urls import reverse
 from rest_framework import status
 
 from buyer import models
-from core.tests.test_views import reload_urlconf, reload_module
+from core.tests.test_views import reload_module, reload_urlconf
 
 
 @pytest.mark.django_db
-@patch('sigauth.helpers.RequestSignatureChecker.test_signature',
-       Mock(return_value=True))
+@patch('sigauth.helpers.RequestSignatureChecker.test_signature', Mock(return_value=True))
 def test_create_buyer_deserialization(client):
     data = {
         'email': 'jim@example.com',
@@ -33,8 +31,7 @@ def test_create_buyer_deserialization(client):
 
 
 @pytest.mark.django_db
-@patch('sigauth.helpers.RequestSignatureChecker.test_signature',
-       Mock(return_value=True))
+@patch('sigauth.helpers.RequestSignatureChecker.test_signature', Mock(return_value=True))
 @patch('core.views.get_file_from_s3')
 def test_buyer_csv_dump(mocked_get_file_from_s3, authed_client):
     settings.STORAGE_CLASS_NAME = 'default'
@@ -44,19 +41,12 @@ def test_buyer_csv_dump(mocked_get_file_from_s3, authed_client):
     reload_urlconf()
     mocked_body = Mock()
     mocked_body.read.return_value = b'company_name\r\nacme\r\n'
-    mocked_get_file_from_s3.return_value = {
-        'Body': mocked_body
-    }
-    response = authed_client.get(
-        reverse('buyer-csv-dump'),
-        {'token': settings.CSV_DUMP_AUTH_TOKEN}
-    )
+    mocked_get_file_from_s3.return_value = {'Body': mocked_body}
+    response = authed_client.get(reverse('buyer-csv-dump'), {'token': settings.CSV_DUMP_AUTH_TOKEN})
     assert response.status_code == status.HTTP_200_OK
     assert response.content == b'company_name\r\nacme\r\n'
     assert response._headers['content-type'] == ('Content-Type', 'text/csv')
     assert response._headers['content-disposition'] == (
         'Content-Disposition',
-        'attachment; filename="{filename}"'.format(
-            filename=settings.BUYERS_CSV_FILE_NAME
-        )
+        'attachment; filename="{filename}"'.format(filename=settings.BUYERS_CSV_FILE_NAME),
     )

--- a/company/admin.py
+++ b/company/admin.py
@@ -3,18 +3,18 @@ from datetime import timedelta
 from django import forms
 from django.conf.urls import url
 from django.contrib import admin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
 from django.urls import reverse_lazy
 from django.utils import timezone
-from django.contrib.messages.views import SuccessMessageMixin
 from django.views.generic import FormView, TemplateView
-from import_export.resources import ModelResource
 from import_export.fields import Field
+from import_export.resources import ModelResource
 
-from core.helpers import build_preverified_url, generate_csv_response
 from company import helpers, models
-from company.forms import EnrolCompanies, UploadExpertise, ConfirmVerificationLetterForm
+from company.forms import ConfirmVerificationLetterForm, EnrolCompanies, UploadExpertise
+from core.helpers import build_preverified_url, generate_csv_response
 
 
 class GDPRComplianceFilter(admin.SimpleListFilter):
@@ -22,9 +22,7 @@ class GDPRComplianceFilter(admin.SimpleListFilter):
     parameter_name = 'gdpr'
 
     def lookups(self, request, model_admin):
-        return (
-            (True, 'is not compliant'),
-        )
+        return ((True, 'is not compliant'),)
 
     def queryset(self, request, queryset):
         value = self.value()
@@ -100,7 +98,7 @@ class CompaniesCreateFormView(FormView):
             {
                 'created_companies': created_companies,
                 'skipped_companies': form.skipped_companies,
-            }
+            },
         )
 
 
@@ -108,17 +106,13 @@ class DuplicateCompaniesView(TemplateView):
     template_name = 'admin/company/duplicate_companies.html'
 
     def get_context_data(self, **kwargs):
-        return super().get_context_data(
-            groups=helpers.get_duplicate_companies()
-        )
+        return super().get_context_data(groups=helpers.get_duplicate_companies())
 
 
 class CompaniesUploadExpertiseFormView(FormView):
     form_class = UploadExpertise
     template_name = 'admin/company/company_expertise_csv_upload_form.html'
-    success_url = reverse_lazy(
-        'admin/company/company_expertise_csv_upload_success.html'
-    )
+    success_url = reverse_lazy('admin/company/company_expertise_csv_upload_success.html')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -138,19 +132,14 @@ class CompaniesUploadExpertiseFormView(FormView):
             {
                 'updated_companies': form.updated_companies,
                 'errors': form.update_errors,
-            }
+            },
         )
 
 
 class PublishByCompanyHouseNumberForm(forms.Form):
-    COMPANY_DOESNT_EXIST_MSG = (
-        'Some companies in this data set are not in the db: {numbers}'
-    )
+    COMPANY_DOESNT_EXIST_MSG = 'Some companies in this data set are not in the db: {numbers}'
 
-    company_numbers = forms.CharField(
-        widget=forms.Textarea,
-        help_text='Comma-separated company house numbers'
-    )
+    company_numbers = forms.CharField(widget=forms.Textarea, help_text='Comma-separated company house numbers')
 
     options = (
         ("investment_support_directory", "Investment Support Directory"),
@@ -216,10 +205,20 @@ class CompanyUserInline(admin.options.TabularInline):
 class CompanyAdmin(admin.ModelAdmin):
     inlines = (CompanyUserInline,)
     search_fields = (
-        'name', 'description', 'keywords',
-        'sectors', 'website', 'verification_code', 'number',
-        'postal_full_name', 'address_line_1', 'address_line_2',
-        'locality', 'country', 'postal_code', 'po_box',
+        'name',
+        'description',
+        'keywords',
+        'sectors',
+        'website',
+        'verification_code',
+        'number',
+        'postal_full_name',
+        'address_line_1',
+        'address_line_2',
+        'locality',
+        'country',
+        'postal_code',
+        'po_box',
     )
     list_display = (
         'name',
@@ -240,31 +239,23 @@ class CompanyAdmin(admin.ModelAdmin):
         additional_urls = [
             url(
                 r'^publish/$',
-                self.admin_site.admin_view(
-                    PublishByCompanyHouseNumberView.as_view()
-                ),
-                name="company_company_publish"
+                self.admin_site.admin_view(PublishByCompanyHouseNumberView.as_view()),
+                name="company_company_publish",
             ),
             url(
                 r'^create-many/$',
-                self.admin_site.admin_view(
-                    CompaniesCreateFormView.as_view()
-                ),
-                name="company_company_enrol"
+                self.admin_site.admin_view(CompaniesCreateFormView.as_view()),
+                name="company_company_enrol",
             ),
             url(
                 r'^expertise-upload/$',
-                self.admin_site.admin_view(
-                    CompaniesUploadExpertiseFormView.as_view()
-                ),
-                name="upload_company_expertise"
+                self.admin_site.admin_view(CompaniesUploadExpertiseFormView.as_view()),
+                name="upload_company_expertise",
             ),
             url(
                 r'^duplicates/$',
-                self.admin_site.admin_view(
-                    DuplicateCompaniesView.as_view()
-                ),
-                name="duplicate_companies"
+                self.admin_site.admin_view(DuplicateCompaniesView.as_view()),
+                name="duplicate_companies",
             ),
         ]
         return additional_urls + urls
@@ -274,9 +265,16 @@ class CompanyAdmin(admin.ModelAdmin):
 class CompanyCaseStudyAdmin(admin.ModelAdmin):
 
     search_fields = (
-        'company__name', 'company__number', 'description', 'short_summary',
-        'title', 'website', 'keywords', 'testimonial',
-        'testimonial_company', 'testimonial_name',
+        'company__name',
+        'company__number',
+        'description',
+        'short_summary',
+        'title',
+        'website',
+        'keywords',
+        'testimonial',
+        'testimonial_company',
+        'testimonial_name',
     )
     readonly_fields = ('created', 'modified')
     actions = ['download_csv']
@@ -290,14 +288,10 @@ class CompanyCaseStudyAdmin(admin.ModelAdmin):
         """
 
         return generate_csv_response(
-            queryset=queryset,
-            filename=self.csv_filename,
-            excluded_fields=self.csv_excluded_fields
+            queryset=queryset, filename=self.csv_filename, excluded_fields=self.csv_excluded_fields
         )
 
-    download_csv.short_description = (
-        "Download CSV report for selected case studies"
-    )
+    download_csv.short_description = "Download CSV report for selected case studies"
 
 
 @admin.register(models.CollaborationInvite)
@@ -309,9 +303,16 @@ class CollaborationInviteAdmin(admin.ModelAdmin):
 
 @admin.register(models.CollaborationRequest)
 class CollaborationRequestAdmin(admin.ModelAdmin):
-    search_fields = ('uuid', 'role', 'requestor', )
+    search_fields = (
+        'uuid',
+        'role',
+        'requestor',
+    )
 
-    readonly_fields = ('accepted', 'accepted_date',)
+    readonly_fields = (
+        'accepted',
+        'accepted_date',
+    )
     list_display = ('uuid', 'requestor', 'role')
     list_filter = ('accepted', 'role')
 
@@ -336,18 +337,39 @@ class ResendVerificationLetterFormView(SuccessMessageMixin, FormView):
 class CompanyUserAdmin(admin.ModelAdmin):
 
     search_fields = (
-        'sso_id', 'name', 'mobile_number', 'company_email', 'company__name',
-        'company__description', 'company__number', 'company__website',
+        'sso_id',
+        'name',
+        'mobile_number',
+        'company_email',
+        'company__name',
+        'company__description',
+        'company__number',
+        'company__website',
     )
-    list_display = ('name', 'company_email', 'company', 'company_type',)
-    readonly_fields = ('company_type', 'created', 'modified',)
-    actions = ['send_verification_letter', 'download_csv', ]
+    list_display = (
+        'name',
+        'company_email',
+        'company',
+        'company_type',
+    )
+    readonly_fields = (
+        'company_type',
+        'created',
+        'modified',
+    )
+    actions = [
+        'send_verification_letter',
+        'download_csv',
+    ]
 
     def send_verification_letter(self, request, queryset):
         response = TemplateResponse(
             request,
             'admin/company/confirm_send_verification_letter.html',
-            {'queryset': queryset, 'ids': [q.pk for q in queryset], }
+            {
+                'queryset': queryset,
+                'ids': [q.pk for q in queryset],
+            },
         )
         return response
 
@@ -360,23 +382,22 @@ class CompanyUserAdmin(admin.ModelAdmin):
         Generates CSV report of all suppliers, with company details included.
         """
         response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = (
-            'attachment; filename="find-a-buyer_suppliers_{}.csv"'.format(timezone.now().strftime("%Y%m%d%H%M%S"))
+        response['Content-Disposition'] = 'attachment; filename="find-a-buyer_suppliers_{}.csv"'.format(
+            timezone.now().strftime("%Y%m%d%H%M%S")
         )
         helpers.generate_company_users_csv(file_object=response, queryset=queryset)
         return response
 
-    download_csv.short_description = (
-        "Download CSV report for selected suppliers"
-    )
+    download_csv.short_description = "Download CSV report for selected suppliers"
 
     def get_urls(self):
         urls = super().get_urls()
         additional_urls = [
-            url(r'^admin/company/resend-verification-letter/$',
+            url(
+                r'^admin/company/resend-verification-letter/$',
                 self.admin_site.admin_view(ResendVerificationLetterFormView.as_view()),
                 name='resend_verification_letter',
-                ),
+            ),
         ]
         return additional_urls + urls
 

--- a/company/apps.py
+++ b/company/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.db.models.signals import post_save, pre_save, post_delete
+from django.db.models.signals import post_delete, post_save, pre_save
 
 
 class CompanyConfig(AppConfig):
@@ -7,22 +7,11 @@ class CompanyConfig(AppConfig):
 
     def ready(self):
         from company import signals
-        pre_save.connect(
-            receiver=signals.store_date_published,
-            sender='company.Company'
-        )
-        post_save.connect(
-            receiver=signals.send_first_verification_letter,
-            sender='company.Company'
-        )
-        post_save.connect(
-            receiver=signals.send_company_registration_letter,
-            sender='company.Company'
-        )
-        post_save.connect(
-            receiver=signals.update_company_elasticsearch_document,
-            sender='company.Company'
-        )
+
+        pre_save.connect(receiver=signals.store_date_published, sender='company.Company')
+        post_save.connect(receiver=signals.send_first_verification_letter, sender='company.Company')
+        post_save.connect(receiver=signals.send_company_registration_letter, sender='company.Company')
+        post_save.connect(receiver=signals.update_company_elasticsearch_document, sender='company.Company')
         post_save.connect(
             receiver=signals.save_case_study_change_to_elasticsearch,
             sender='company.CompanyCaseStudy',
@@ -31,27 +20,19 @@ class CompanyConfig(AppConfig):
             receiver=signals.delete_company_elasticsearch_document,
             sender='company.Company',
         )
-        pre_save.connect(
-            receiver=signals.set_non_companies_house_number,
-            sender='company.Company'
-        )
+        pre_save.connect(receiver=signals.set_non_companies_house_number, sender='company.Company')
         post_save.connect(
-            receiver=signals.send_new_invite_collaboration_notification,
-            sender='company.CollaborationInvite'
+            receiver=signals.send_new_invite_collaboration_notification, sender='company.CollaborationInvite'
         )
         pre_save.connect(
-            receiver=signals.send_acknowledgement_admin_email_on_invite_accept,
-            sender='company.CollaborationInvite'
+            receiver=signals.send_acknowledgement_admin_email_on_invite_accept, sender='company.CollaborationInvite'
         )
         pre_save.connect(
-            receiver=signals.send_admins_new_collaboration_request_notification,
-            sender='company.CollaborationRequest'
+            receiver=signals.send_admins_new_collaboration_request_notification, sender='company.CollaborationRequest'
         )
         pre_save.connect(
-            receiver=signals.send_user_collaboration_request_email_on_accept,
-            sender='company.CollaborationRequest'
+            receiver=signals.send_user_collaboration_request_email_on_accept, sender='company.CollaborationRequest'
         )
         post_delete.connect(
-            receiver=signals.send_user_collaboration_request_email_on_decline,
-            sender='company.CollaborationRequest'
+            receiver=signals.send_user_collaboration_request_email_on_decline, sender='company.CollaborationRequest'
         )

--- a/company/documents.py
+++ b/company/documents.py
@@ -1,11 +1,9 @@
 from urllib.parse import urljoin
 
-from elasticsearch_dsl import analysis, Document, field, InnerDoc, MetaField
-
 from django.conf import settings
+from elasticsearch_dsl import Document, InnerDoc, MetaField, analysis, field
 
 from company import helpers, search_filters, serializers
-
 
 american_english_analyzer = analysis.analyzer(
     'normalize_american_english',
@@ -19,7 +17,7 @@ american_english_analyzer = analysis.analyzer(
     ],
     char_filter=[
         search_filters.american_english_normalizer_filter,
-    ]
+    ],
 )
 
 
@@ -50,9 +48,7 @@ class CompanyDocument(Document):
     case_study_count = field.Integer()
     company_type = field.Keyword(index=False, store=True)
     date_of_creation = field.Date(index=False)
-    description = field.Text(
-        copy_to='wildcard', analyzer=american_english_analyzer
-    )
+    description = field.Text(copy_to='wildcard', analyzer=american_english_analyzer)
     has_description = field.Boolean()
     employees = field.Keyword(index=False, store=True)
     facebook_url = field.Keyword(index=False, store=True)
@@ -64,35 +60,21 @@ class CompanyDocument(Document):
     modified = field.Date(index=False)
     ordering_name = field.Keyword()
     name = field.Text(copy_to=['wildcard', 'ordering_name'])
-    number = field.Keyword(copy_to='keyword_wildcard',)
+    number = field.Keyword(
+        copy_to='keyword_wildcard',
+    )
     sectors = field.Keyword(multi=True, copy_to='keyword_wildcard', store=True)
-    sectors_label = field.Keyword(
-        multi=True, copy_to='keyword_wildcard', store=True
-    )
-    expertise_industries = field.Keyword(
-        multi=True, copy_to='keyword_wildcard', store=True
-    )
-    expertise_regions = field.Keyword(
-        multi=True, copy_to='keyword_wildcard', store=True
-    )
-    expertise_languages = field.Keyword(
-        multi=True, copy_to='keyword_wildcard', store=True
-    )
-    expertise_countries = field.Keyword(
-        multi=True, copy_to='keyword_wildcard', store=True
-    )
+    sectors_label = field.Keyword(multi=True, copy_to='keyword_wildcard', store=True)
+    expertise_industries = field.Keyword(multi=True, copy_to='keyword_wildcard', store=True)
+    expertise_regions = field.Keyword(multi=True, copy_to='keyword_wildcard', store=True)
+    expertise_languages = field.Keyword(multi=True, copy_to='keyword_wildcard', store=True)
+    expertise_countries = field.Keyword(multi=True, copy_to='keyword_wildcard', store=True)
     # Represents Dict as it's the primitive datatype for this field
     expertise_products_services = field.Object(dynamic=True)
-    expertise_products_services_labels = field.Keyword(
-        multi=True, copy_to='keyword_wildcard', store=True
-    )
-    expertise_labels = field.Keyword(
-        multi=True, copy_to='keyword_wildcard', store=True
-    )
+    expertise_products_services_labels = field.Keyword(multi=True, copy_to='keyword_wildcard', store=True)
+    expertise_labels = field.Keyword(multi=True, copy_to='keyword_wildcard', store=True)
     slug = field.Keyword(copy_to='keyword_wildcard', store=True)
-    summary = field.Text(
-        copy_to='wildcard', analyzer=american_english_analyzer
-    )
+    summary = field.Text(copy_to='wildcard', analyzer=american_english_analyzer)
     twitter_url = field.Keyword(index=False, store=True)
     website = field.Keyword(copy_to='keyword_wildcard', store=True)
     supplier_case_studies = field.Nested(
@@ -109,9 +91,7 @@ class CompanyDocument(Document):
             'testimonial': field.Text(copy_to='casestudy_wildcard'),
             'website': field.Keyword(copy_to='casestudy_wildcard', store=True),
             'slug': field.Keyword(copy_to='keyword_wildcard', store=True),
-            'testimonial_name': field.Keyword(
-                copy_to='casestudy_wildcard', store=True
-            ),
+            'testimonial_name': field.Keyword(copy_to='casestudy_wildcard', store=True),
             'testimonial_company': field.Text(copy_to='casestudy_wildcard'),
             'testimonial_job_title': field.Text(copy_to='casestudy_wildcard'),
         }
@@ -199,8 +179,6 @@ def company_model_to_document(company, index=settings.ELASTICSEARCH_COMPANY_INDE
     )
 
     for case_study in company.supplier_case_studies.all():
-        document.supplier_case_studies.append({
-            key: getattr(case_study, key, '') for key in case_study_fields
-        })
+        document.supplier_case_studies.append({key: getattr(case_study, key, '') for key in case_study_fields})
 
     return document

--- a/company/email.py
+++ b/company/email.py
@@ -17,11 +17,8 @@ class MultiUserOwnershipBaseNotification:
     def get_context_data(self, **kwargs):
         return {
             'invite_link': self.instance.invite_link,
-            'requestor': (
-                self.instance.requestor.name or
-                self.instance.requestor.company_email
-            ),
-            'company_name': self.instance.company.name
+            'requestor': (self.instance.requestor.name or self.instance.requestor.company_email),
+            'company_name': self.instance.company.name,
         }
 
     def get_bodies(self):

--- a/company/gecko.py
+++ b/company/gecko.py
@@ -4,11 +4,4 @@ from company.models import CompanyUser
 def total_registered_company_users():
     # We're using the Number & Secondary Stat widget (and json format)
     # https://developer-custom.geckoboard.com/#number-and-secondary-stat
-    return {
-        "item": [
-            {
-              "value": CompanyUser.objects.count(),
-              "text": "Total registered company users"
-            }
-          ]
-    }
+    return {"item": [{"value": CompanyUser.objects.count(), "text": "Total registered company users"}]}

--- a/company/management/commands/create_registered_company.py
+++ b/company/management/commands/create_registered_company.py
@@ -22,10 +22,7 @@ class Command(BaseCommand):
                 verification_code='000000000000',
                 verified_with_code=True,
                 is_verification_letter_sent=True,
-                number=company_number
+                number=company_number,
             )
 
-            self.stdout.write(
-                self.style.SUCCESS('Successfully created '
-                                   'company "%s"' % company.id)
-            )
+            self.stdout.write(self.style.SUCCESS('Successfully created company "%s"' % company.id))

--- a/company/management/commands/create_test_search_data.py
+++ b/company/management/commands/create_test_search_data.py
@@ -26,9 +26,7 @@ class Command(BaseCommand):
 
             for j in range(5):
                 factories.CompanyCaseStudyFactory(
-                    company=gold_company,
-                    title='Thick case study {}'.format(j),
-                    description='Gold is delicious.'
+                    company=gold_company, title='Thick case study {}'.format(j), description='Gold is delicious.'
                 )
 
             lead_company = factories.CompanyFactory(
@@ -43,5 +41,5 @@ class Command(BaseCommand):
                 factories.CompanyCaseStudyFactory(
                     company=lead_company,
                     title='Thick case study {}'.format(j),
-                    description='We determined lead sinks in water.'
+                    description='We determined lead sinks in water.',
                 )

--- a/company/management/commands/create_test_users.py
+++ b/company/management/commands/create_test_users.py
@@ -27,10 +27,5 @@ class Command(BaseCommand):
             )
             user = models.CompanyUser.objects.create(sso_id=sso_id, company=company)
 
-            self.stdout.write(
-                self.style.SUCCESS('Successfully created user "%s"' % user.id)
-            )
-            self.stdout.write(
-                self.style.SUCCESS('Successfully created '
-                                   'company "%s"' % company.id)
-            )
+            self.stdout.write(self.style.SUCCESS('Successfully created user "%s"' % user.id))
+            self.stdout.write(self.style.SUCCESS('Successfully created company "%s"' % company.id))

--- a/company/management/commands/elasticsearch_migrate.py
+++ b/company/management/commands/elasticsearch_migrate.py
@@ -1,14 +1,11 @@
+from django.conf import settings
+from django.core import management
+from django.db.models import Q
+from django.utils.crypto import get_random_string
 from elasticsearch.helpers import bulk
 from elasticsearch_dsl.connections import connections
 
-from django.utils.crypto import get_random_string
-from django.core import management
-from django.conf import settings
-from django.db.models import Q
-
-from company import documents
-from company import models
-
+from company import documents, models
 
 ALIAS = settings.ELASTICSEARCH_COMPANY_INDEX_ALIAS
 PREFIX = 'companies-'
@@ -48,13 +45,8 @@ class Command(management.BaseCommand):
         index_template.save()
 
     def populate_new_indices(self):
-        companies = (
-            models.Company.objects
-            .prefetch_related('supplier_case_studies')
-            .filter(
-                Q(is_published_find_a_supplier=True) |
-                Q(is_published_investment_support_directory=True)
-            )
+        companies = models.Company.objects.prefetch_related('supplier_case_studies').filter(
+            Q(is_published_find_a_supplier=True) | Q(is_published_investment_support_directory=True)
         )
         data = []
         for company in companies:

--- a/company/management/commands/generate_company_users_csv_dump.py
+++ b/company/management/commands/generate_company_users_csv_dump.py
@@ -3,8 +3,8 @@ import io
 from django.conf import settings
 from django.core.management import BaseCommand
 
-from core.helpers import upload_file_object_to_s3
 from company import helpers, models
+from core.helpers import upload_file_object_to_s3
 
 
 class Command(BaseCommand):
@@ -24,5 +24,8 @@ class Command(BaseCommand):
     def generate_csv_file():
         file_object = io.StringIO()
         queryset = models.CompanyUser.objects.exclude(company__isnull=True)
-        helpers.generate_company_users_csv(file_object=file_object, queryset=queryset,)
+        helpers.generate_company_users_csv(
+            file_object=file_object,
+            queryset=queryset,
+        )
         return file_object

--- a/company/management/commands/import_hscodes.py
+++ b/company/management/commands/import_hscodes.py
@@ -1,6 +1,6 @@
-import tablib
 import pathlib
 
+import tablib
 from django.core.management import BaseCommand
 
 from company.admin import HsCodeSectorResource

--- a/company/management/commands/retrieve_companies_house_company_status.py
+++ b/company/management/commands/retrieve_companies_house_company_status.py
@@ -1,7 +1,6 @@
 from collections import Counter
 
 from directory_constants import company_types
-
 from django.core.management.base import BaseCommand
 
 from company import models

--- a/company/management/commands/retrieve_missing_company_details.py
+++ b/company/management/commands/retrieve_missing_company_details.py
@@ -2,7 +2,6 @@ from collections import Counter
 from datetime import datetime
 
 from directory_constants import company_types
-
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 

--- a/company/management/commands/tests/test_create_search_data.py
+++ b/company/management/commands/tests/test_create_search_data.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.core import management
 
 from company.models import Company

--- a/company/management/commands/tests/test_elasticsearch_migrate.py
+++ b/company/management/commands/tests/test_elasticsearch_migrate.py
@@ -1,9 +1,8 @@
 import pytest
-
 from django.core import management
 
-from company.tests import factories
 from company.documents import CompanyDocument
+from company.tests import factories
 
 
 @pytest.mark.django_db

--- a/company/management/commands/tests/test_import_hscodes.py
+++ b/company/management/commands/tests/test_import_hscodes.py
@@ -1,8 +1,9 @@
-import pytest
 from unittest import mock
 
+import pytest
 from django.core import management
 from import_export import results
+
 from company.models import HsCodeSector
 
 

--- a/company/management/commands/tests/test_retrieve_companies_house_company_status.py
+++ b/company/management/commands/tests/test_retrieve_companies_house_company_status.py
@@ -1,8 +1,7 @@
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
-from directory_constants import company_types
 import pytest
-
+from directory_constants import company_types
 from django.core.management import call_command
 
 from company.tests.factories import CompanyFactory
@@ -11,7 +10,7 @@ from company.tests.factories import CompanyFactory
 @pytest.mark.django_db
 @patch(
     'company.management.commands.retrieve_companies_house_company_status.get_companies_house_profile',
-    Mock(return_value={'company_status': 'active'})
+    Mock(return_value={'company_status': 'active'}),
 )
 def test_companies_house_active_status():
     company = CompanyFactory(date_of_creation=None, number=123)
@@ -23,7 +22,7 @@ def test_companies_house_active_status():
 @pytest.mark.django_db
 @patch(
     'company.management.commands.retrieve_companies_house_company_status.get_companies_house_profile',
-    Mock(return_value={'company_status': 'dissolved'})
+    Mock(return_value={'company_status': 'dissolved'}),
 )
 def test_companies_house_non_active_status():
     company = CompanyFactory(date_of_creation=None, number=123)
@@ -35,7 +34,7 @@ def test_companies_house_non_active_status():
 @pytest.mark.django_db
 @patch(
     'company.management.commands.retrieve_companies_house_company_status.get_companies_house_profile',
-    Mock(return_value={})
+    Mock(return_value={}),
 )
 def test_companies_house_missing_status_on_update():
     company = CompanyFactory(date_of_creation=None, number=123, companies_house_company_status='active')
@@ -47,7 +46,7 @@ def test_companies_house_missing_status_on_update():
 @pytest.mark.django_db
 @patch(
     'company.management.commands.retrieve_companies_house_company_status.get_companies_house_profile',
-    Mock(return_value={})
+    Mock(return_value={}),
 )
 def test_companies_house_missing_company_status_new_company():
     company = CompanyFactory(date_of_creation=None, number=123)
@@ -58,7 +57,7 @@ def test_companies_house_missing_company_status_new_company():
 @pytest.mark.django_db
 @patch(
     'company.management.commands.retrieve_companies_house_company_status.get_companies_house_profile',
-    Mock(return_value={'company_status': 'active'})
+    Mock(return_value={'company_status': 'active'}),
 )
 def test_ignores_sole_traders():
     company_one = CompanyFactory(number=123)
@@ -76,7 +75,7 @@ def test_ignores_sole_traders():
 @pytest.mark.django_db
 @patch(
     'company.management.commands.retrieve_companies_house_company_status.get_companies_house_profile',
-    Mock(side_effect=Exception())
+    Mock(side_effect=Exception()),
 )
 def test_retrieve_company_status_handles_error():
     company = CompanyFactory(number=123)

--- a/company/management/commands/tests/test_retrieve_missing_company_details.py
+++ b/company/management/commands/tests/test_retrieve_missing_company_details.py
@@ -1,9 +1,8 @@
 import datetime
 from unittest.mock import patch
 
-from directory_constants import company_types
 import pytest
-
+from directory_constants import company_types
 from django.core.management import call_command
 
 from company.tests.factories import CompanyFactory
@@ -31,8 +30,8 @@ def test_retrieve_missing_company_address(mock_get_companies_house_profile):
             'address_line_2': 'Fake land',
             'locality': 'Fakeville',
             'postal_code': 'FAKELAND',
-            'po_box': 'PO BOX'
-        }
+            'po_box': 'PO BOX',
+        },
     }
     call_command('retrieve_missing_company_details')
     company.refresh_from_db()
@@ -46,9 +45,7 @@ def test_retrieve_missing_company_address(mock_get_companies_house_profile):
 
 @pytest.mark.django_db
 @patch('company.management.commands.retrieve_missing_company_details.get_companies_house_profile')
-def test_retrieve_missing_company_address_po_box(
-    mock_get_companies_house_profile
-):
+def test_retrieve_missing_company_address_po_box(mock_get_companies_house_profile):
     company = CompanyFactory(date_of_creation=None, number=123)
     mock_get_companies_house_profile.return_value = {
         'date_of_creation': '2016-12-16',
@@ -57,7 +54,7 @@ def test_retrieve_missing_company_address_po_box(
             'address_line_2': 'Fake land',
             'locality': 'Fakeville',
             'postal_code': 'FAKELAND',
-        }
+        },
     }
     call_command('retrieve_missing_company_details')
     company.refresh_from_db()

--- a/company/models.py
+++ b/company/models.py
@@ -2,23 +2,23 @@ import uuid
 
 from directory_constants import choices, company_types, user_roles
 from directory_validators.string import no_html
-
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.template.defaultfilters import slugify
 from django.utils import timezone
-
-from core.helpers import TimeStampedModel
 from field_history.tracker import FieldHistoryTracker
 
-from core.helpers import generate_verification_code, path_and_rename_logos, path_and_rename_supplier_case_study
+from core.helpers import (
+    TimeStampedModel,
+    generate_verification_code,
+    path_and_rename_logos,
+    path_and_rename_supplier_case_study,
+)
 
 
 class Company(TimeStampedModel):
-    company_type = models.CharField(
-        max_length=15, choices=choices.COMPANY_TYPES, default=company_types.COMPANIES_HOUSE
-    )
+    company_type = models.CharField(max_length=15, choices=choices.COMPANY_TYPES, default=company_types.COMPANIES_HOUSE)
     summary = models.CharField(max_length=250, blank=True, default='', validators=[no_html])
     description = models.TextField(blank=True, default='', validators=[no_html])
     employees = models.CharField(max_length=20, choices=choices.EMPLOYEES, blank=True, default='')
@@ -55,14 +55,14 @@ class Company(TimeStampedModel):
         help_text=(
             'Companies that have a published profile on investment support completeness - they must have description '
             'or summary, be verified, and have an email address.'
-        )
+        ),
     )
     is_published_find_a_supplier = models.BooleanField(
         default=False,
         help_text=(
             'Companies that have a published profile on FAS completeness - they must have description or summary, be '
             'verified, and have an email address.'
-        )
+        ),
     )
     date_published = models.DateField(null=True, blank=True)
     verification_code = models.CharField(max_length=255, blank=True, default=generate_verification_code)
@@ -95,11 +95,13 @@ class Company(TimeStampedModel):
     is_showcase_company = models.BooleanField(default=False)
     is_uk_isd_company = models.BooleanField(default=False)
 
-    field_history = FieldHistoryTracker([
-        'verified_with_preverified_enrolment',
-        'verified_with_code',
-        'verified_with_companies_house_oauth2',
-    ])
+    field_history = FieldHistoryTracker(
+        [
+            'verified_with_preverified_enrolment',
+            'verified_with_code',
+            'verified_with_companies_house_oauth2',
+        ]
+    )
     companies_house_company_status = models.CharField(max_length=255, blank=True, default='', validators=[no_html])
 
     class Meta:
@@ -125,12 +127,14 @@ class Company(TimeStampedModel):
 
     @property
     def is_verified(self):
-        return any([
-            self.verified_with_preverified_enrolment,
-            self.verified_with_code,
-            self.verified_with_identity_check,
-            self.verified_with_companies_house_oauth2,
-        ])
+        return any(
+            [
+                self.verified_with_preverified_enrolment,
+                self.verified_with_code,
+                self.verified_with_identity_check,
+                self.verified_with_companies_house_oauth2,
+            ]
+        )
 
     def has_valid_address(self):
         return all(getattr(self, field) for field in ['postal_full_name', 'address_line_1', 'postal_code'])
@@ -155,7 +159,12 @@ class CompanyCaseStudy(TimeStampedModel):
     image_three_caption = models.CharField(max_length=200, blank=True, default='', validators=[no_html])
     video_one = models.FileField(upload_to=path_and_rename_supplier_case_study, blank=True, default='')
     testimonial = models.CharField(max_length=1000, blank=True, default='', validators=[no_html])
-    testimonial_name = models.CharField(max_length=255, blank=True, default='', validators=[no_html],)
+    testimonial_name = models.CharField(
+        max_length=255,
+        blank=True,
+        default='',
+        validators=[no_html],
+    )
     testimonial_job_title = models.CharField(max_length=255, blank=True, default='', validators=[no_html])
     testimonial_company = models.CharField(max_length=255, blank=True, default='', validators=[no_html])
     company = models.ForeignKey(Company, related_name='supplier_case_studies', on_delete=models.CASCADE)
@@ -176,9 +185,7 @@ class CompanyUser(TimeStampedModel):
     sso_id = models.PositiveIntegerField(verbose_name='sso user.sso_id', unique=True)
     # Deprecated, Name field should be used from SSO.UserProfile.FirstName + LastName
     name = models.CharField(verbose_name='name', max_length=255, blank=True, null=True, default='')
-    company = models.ForeignKey(
-        Company, related_name='company_users', null=True, blank=True, on_delete=models.SET_NULL
-    )
+    company = models.ForeignKey(Company, related_name='company_users', null=True, blank=True, on_delete=models.SET_NULL)
     # Deprecated, Email field should be used from SSO.User.Email
     company_email = models.EmailField('company email', unique=True)
     is_active = models.BooleanField(
@@ -186,7 +193,10 @@ class CompanyUser(TimeStampedModel):
         default=True,
         help_text='Unselect this instead of deleting accounts.',
     )
-    date_joined = models.DateTimeField(verbose_name='date joined', default=timezone.now,)
+    date_joined = models.DateTimeField(
+        verbose_name='date joined',
+        default=timezone.now,
+    )
     # Deprecated in favour of company.models.Company.contact_details
     mobile_number = models.CharField(max_length=20, null=True, blank=True)
     unsubscribed = models.BooleanField(
@@ -232,7 +242,10 @@ class CollaborationRequest(TimeStampedModel):
     accepted = models.BooleanField(default=False)
     accepted_date = models.DateTimeField(null=True, blank=True)
     role = models.CharField(max_length=15, choices=choices.USER_ROLES)
-    name = models.CharField(max_length=100, blank=True,)
+    name = models.CharField(
+        max_length=100,
+        blank=True,
+    )
 
 
 class HsCodeSector(models.Model):

--- a/company/permissions.py
+++ b/company/permissions.py
@@ -1,11 +1,9 @@
 from directory_constants import user_roles
-from rest_framework import permissions
-
 from django.conf import settings
+from rest_framework import permissions
 
 
 class IsCompanyAdmin(permissions.BasePermission):
-
     def has_permission(self, request, view):
         return request.user.company_user.role == user_roles.ADMIN
 

--- a/company/search_filters.py
+++ b/company/search_filters.py
@@ -1,9 +1,7 @@
 from elasticsearch_dsl import analysis
 
 companies_stopwords_filter = analysis.token_filter(
-    'companies_stopwords',
-    type='stop',
-    stopwords=['limited', 'ltd', 'plc', 'llp', 'lp', 'rc', 'partnership', 'ngo']
+    'companies_stopwords', type='stop', stopwords=['limited', 'ltd', 'plc', 'llp', 'lp', 'rc', 'partnership', 'ngo']
 )
 
 american_english_normalizer_filter = analysis.char_filter(
@@ -50,8 +48,8 @@ american_english_normalizer_filter = analysis.char_filter(
         "og=>ogue",
         "zation=>sation",
         "yze=>yse",
-        "yzing=>ysing"
-    ]
+        "yzing=>ysing",
+    ],
 )
 
 american_english_synonyms_filter = analysis.token_filter(
@@ -98,10 +96,7 @@ american_english_synonyms_filter = analysis.token_filter(
         "calibre, caliber",
         "candour, candor",
         "candy floss, cotton candy, candyfloss",
-        (
-            "car park, parking area, parking ground, parking lot, "
-            "parking-lot, parking place, parking"
-        ),
+        "car park, parking area, parking ground, parking lot, parking-lot, parking place, parking",
         "carburettor, carburetor",
         "castor, caster",
         "cataloguing, cataloging",
@@ -112,10 +107,7 @@ american_english_synonyms_filter = analysis.token_filter(
         "chequer, checker",
         "chequerboard, checkerboard",
         "chequered, checkered",
-        (
-            "christmas tree ball, christmas tree ball ornament, "
-            "christmas ball ornament, christmas bauble"
-        ),
+        "christmas tree ball, christmas tree ball ornament, christmas ball ornament, christmas bauble",
         "christmas, x-mas, xmas",
         "cinema, movies",
         "clangour, clangor",
@@ -133,10 +125,7 @@ american_english_synonyms_filter = analysis.token_filter(
         "defence, defense",
         "defenceless, defenseless",
         "demeanour, demeanor",
-        (
-            "departure platform, station platform, train platform, "
-            "train station"
-        ),
+        "departure platform, station platform, train platform, train station",
         "dishrag, dish cloth",
         "dishtowel, dishcloth, dish towel",
         "doughnut, donut",
@@ -211,10 +200,7 @@ american_english_synonyms_filter = analysis.token_filter(
         "licence, licenced, licencing, license",
         "liquorice, licorice",
         "lorry, truck",
-        (
-            "loupe, magnifier, magnifying, magnifying glass, magnifying lens, "
-            "zoom"
-        ),
+        "loupe, magnifier, magnifying, magnifying glass, magnifying lens, zoom",
         "louvred, louvered",
         "louvres, louver",
         "lustre, luster",
@@ -254,10 +240,7 @@ american_english_synonyms_filter = analysis.token_filter(
         "railway, railroad",
         "rancour, rancor",
         "rappel, abseil",
-        (
-            "row house, serial house, terrace house, terraced house, "
-            "terraced housing, town house"
-        ),
+        "row house, serial house, terrace house, terraced house, terraced housing, town house",
         "rigour, rigor",
         "rumour, rumor",
         "sabre, saber",
@@ -319,8 +302,8 @@ american_english_synonyms_filter = analysis.token_filter(
         "worshipper, worshipping, worshiping",
         "yoghourt, yoghurt, yogurt",
         "zip, zip code, postal code, postcode",
-        "zucchini, courgette"
-    )
+        "zucchini, courgette",
+    ),
 )
 
 

--- a/company/serializers.py
+++ b/company/serializers.py
@@ -1,18 +1,15 @@
-from django.utils.timezone import now
-from rest_framework import serializers
-
 import directory_validators.string
 from directory_constants import choices, user_roles
-
 from django.conf import settings
 from django.http import QueryDict
+from django.utils.timezone import now
+from rest_framework import serializers
 
 from company import models, validators
 from core.helpers import CompaniesHouseClient
 
 
 class AllowedFormatImageField(serializers.ImageField):
-
     def to_internal_value(self, data):
         file = super().to_internal_value(data)
         if file.image.format.upper() not in settings.ALLOWED_IMAGE_FORMATS:
@@ -60,7 +57,6 @@ class CompanyCaseStudySerializer(serializers.ModelSerializer):
 
 
 class CompanyCaseStudyWithCompanySerializer(CompanyCaseStudySerializer):
-
     class Meta(CompanyCaseStudySerializer.Meta):
         depth = 2
 
@@ -75,7 +71,7 @@ class CompanySerializer(serializers.ModelSerializer):
     has_valid_address = serializers.SerializerMethodField()
     keywords = serializers.CharField(
         validators=[directory_validators.string.word_limit(10), directory_validators.string.no_special_characters],
-        required=False
+        required=False,
     )
 
     class Meta:
@@ -284,7 +280,7 @@ class CollaborationInviteSerializer(serializers.ModelSerializer):
             defaults={
                 'company': collaborator_invite.company,
                 'role': collaborator_invite.role,
-            }
+            },
         )
 
 
@@ -303,9 +299,7 @@ class AddCollaboratorSerializer(serializers.ModelSerializer):
             'role',
         )
 
-        extra_kwargs = {
-            'role': {'required': False}
-        }
+        extra_kwargs = {'role': {'required': False}}
 
     def create(self, validated_data):
         if 'role' not in validated_data:
@@ -353,7 +347,6 @@ class ExternalCompanyUserSerializer(serializers.ModelSerializer):
 
 
 class CompanyUserSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.CompanyUser
         fields = (

--- a/company/tasks.py
+++ b/company/tasks.py
@@ -1,7 +1,7 @@
 from django.core.management import call_command
 
-from conf.celery import app
 from company import helpers
+from conf.celery import app
 from notifications.tasks import lock_acquired
 
 

--- a/company/tests/__init__.py
+++ b/company/tests/__init__.py
@@ -2,7 +2,6 @@ import json
 
 from rest_framework import serializers
 
-
 VALID_REQUEST_DATA = {
     'number': '11234567',
     'name': 'Test Company',

--- a/company/tests/factories.py
+++ b/company/tests/factories.py
@@ -1,9 +1,8 @@
-from directory_constants import choices, user_roles
 import factory
 import factory.fuzzy
-from faker import Faker
-
+from directory_constants import choices, user_roles
 from django.utils.text import slugify
+from faker import Faker
 
 from company import models
 

--- a/company/tests/test_admin.py
+++ b/company/tests/test_admin.py
@@ -1,26 +1,24 @@
-from collections import OrderedDict
-from datetime import timedelta
 import http
 import os
+from collections import OrderedDict
+from datetime import timedelta
 from unittest import TestCase
 from unittest.mock import patch
 
-from directory_constants import company_types
-from freezegun import freeze_time
 import pytest
-
+from directory_constants import company_types
 from django.conf import settings
-from django.test import Client
-from django.contrib.auth.models import User
 from django.contrib.admin import site
+from django.contrib.auth.models import User
 from django.core.signing import Signer
+from django.test import Client
 from django.urls import reverse
 from django.utils import timezone
+from freezegun import freeze_time
 
 from company import admin, constants, models
-from company.tests import factories, VALID_REQUEST_DATA, VALID_SUPPLIER_REQUEST_DATA
+from company.tests import VALID_REQUEST_DATA, VALID_SUPPLIER_REQUEST_DATA, factories
 from enrolment.models import PreVerifiedEnrolment
-
 
 COMPANY_DATA = VALID_REQUEST_DATA.copy()
 SUPPLIER_DATA = VALID_SUPPLIER_REQUEST_DATA.copy()
@@ -29,11 +27,8 @@ COMPANY_DOESNT_EXIST_MSG = 'Some companies in this data set are not in the db: '
 
 @pytest.mark.django_db
 class PublishCompaniesTestCase(TestCase):
-
     def setUp(self):
-        superuser = User.objects.create_superuser(
-            username='admin', email='admin@example.com', password='test'
-        )
+        superuser = User.objects.create_superuser(username='admin', email='admin@example.com', password='test')
         self.client = Client()
         self.client.force_login(superuser)
 
@@ -50,34 +45,31 @@ class PublishCompaniesTestCase(TestCase):
         )
         published_company_isd = factories.CompanyFactory(is_published_investment_support_directory=True)
 
-        numbers = '{num1},{num2}'.format(
-            num1=companies[0].number, num2=companies[3].number)
+        numbers = '{num1},{num2}'.format(num1=companies[0].number, num2=companies[3].number)
 
         response = self.client.post(
             reverse('admin:company_company_publish'),
-            {'company_numbers': numbers,
-             'directories': [
-                 'investment_support_directory',
-                 'find_a_supplier'
-             ],
-             },
+            {
+                'company_numbers': numbers,
+                'directories': ['investment_support_directory', 'find_a_supplier'],
+            },
         )
 
         assert response.status_code == http.client.FOUND
         assert response.url == reverse('admin:company_company_changelist')
 
-        published_isd = models.Company.objects.filter(
-            is_published_investment_support_directory=True
-        ).values_list('number', flat=True)
+        published_isd = models.Company.objects.filter(is_published_investment_support_directory=True).values_list(
+            'number', flat=True
+        )
 
         assert len(published_isd) == 3
         assert companies[0].number in published_isd
         assert companies[3].number in published_isd
         assert published_company_isd.number in published_isd
 
-        published_fas = models.Company.objects.filter(
-            is_published_find_a_supplier=True
-        ).values_list('number', flat=True)
+        published_fas = models.Company.objects.filter(is_published_find_a_supplier=True).values_list(
+            'number', flat=True
+        )
 
         assert len(published_fas) == 2
         assert companies[0].number in published_fas
@@ -95,14 +87,11 @@ class PublishCompaniesTestCase(TestCase):
 
 @pytest.mark.django_db
 class CompanyAdminAuthTestCase(TestCase):
-
     def setUp(self):
         self.client = Client()
 
     def test_nonsuperuser_cannot_access_company_publish_view_get(self):
-        user = User.objects.create_user(
-            username='user', email='user@example.com', password='test'
-        )
+        user = User.objects.create_user(username='user', email='user@example.com', password='test')
         self.client.force_login(user)
         url = reverse('admin:company_company_publish')
 
@@ -115,8 +104,7 @@ class CompanyAdminAuthTestCase(TestCase):
         self.client.force_login(user)
         url = reverse('admin:company_company_publish')
 
-        response = self.client.post(
-            url, {'company_numbers': company.number})
+        response = self.client.post(url, {'company_numbers': company.number})
 
         assert response.status_code == 401
 
@@ -126,27 +114,22 @@ class CompanyAdminAuthTestCase(TestCase):
         response = self.client.get(url)
 
         assert response.status_code == http.client.FOUND
-        assert response.url == '/admin/login/?next={redirect_to}'.format(
-            redirect_to=url)
+        assert response.url == '/admin/login/?next={redirect_to}'.format(redirect_to=url)
 
     def test_guest_cannot_access_company_publish_view_post(self):
         url = reverse('admin:company_company_publish')
         company = factories.CompanyFactory()
 
-        response = self.client.post(
-            url, {'company_numbers': company.number})
+        response = self.client.post(url, {'company_numbers': company.number})
 
         assert response.status_code == http.client.FOUND
-        assert response.url == '/admin/login/?next={redirect_to}'.format(
-            redirect_to=url)
+        assert response.url == '/admin/login/?next={redirect_to}'.format(redirect_to=url)
 
 
 @pytest.mark.django_db
 def test_companies_publish_form_doesnt_allow_numbers_that_dont_exist():
     # all don't exist
-    data = {
-        'company_numbers': '12345678,23456789,34567890'
-    }
+    data = {'company_numbers': '12345678,23456789,34567890'}
     form = admin.PublishByCompanyHouseNumberForm(data=data)
 
     assert form.is_valid() is False
@@ -155,9 +138,7 @@ def test_companies_publish_form_doesnt_allow_numbers_that_dont_exist():
 
     # some exist, some don't
     company = factories.CompanyFactory()
-    data = {
-        'company_numbers': '{num},23456789'.format(num=company.number)
-    }
+    data = {'company_numbers': '{num},23456789'.format(num=company.number)}
     form = admin.PublishByCompanyHouseNumberForm(data=data)
 
     assert form.is_valid() is False
@@ -169,13 +150,10 @@ def test_companies_publish_form_doesnt_allow_numbers_that_dont_exist():
 def test_companies_publish_form_handles_whitespace():
     companies = factories.CompanyFactory.create_batch(3)
     data = '    {num1},{num2} , {num3},'.format(
-        num1=companies[0].number, num2=companies[1].number,
-        num3=companies[2].number)
+        num1=companies[0].number, num2=companies[1].number, num3=companies[2].number
+    )
     form = admin.PublishByCompanyHouseNumberForm(
-        data={
-            'company_numbers': data,
-            'directories': ['investment_support_directory']
-        }
+        data={'company_numbers': data, 'directories': ['investment_support_directory']}
     )
 
     assert form.is_valid() is True
@@ -193,9 +171,7 @@ class DownloadCaseStudyCSVTestCase(TestCase):
     )
 
     def setUp(self):
-        superuser = User.objects.create_superuser(
-            username='admin', email='admin@example.com', password='test'
-        )
+        superuser = User.objects.create_superuser(username='admin', email='admin@example.com', password='test')
         self.client = Client()
         self.client.force_login(superuser)
 
@@ -211,15 +187,9 @@ class DownloadCaseStudyCSVTestCase(TestCase):
 
         data = {
             'action': 'download_csv',
-            '_selected_action': models.CompanyCaseStudy.objects.all().values_list(
-                'pk', flat=True
-            )
+            '_selected_action': models.CompanyCaseStudy.objects.all().values_list('pk', flat=True),
         }
-        response = self.client.post(
-            reverse('admin:company_companycasestudy_changelist'),
-            data,
-            follow=True
-        )
+        response = self.client.post(reverse('admin:company_companycasestudy_changelist'), data, follow=True)
 
         row_one = (
             '{company_id},2012-01-14 12:00:00+00:00,{description},{id},,,,,,,,'
@@ -230,7 +200,6 @@ class DownloadCaseStudyCSVTestCase(TestCase):
             title=case_study.title,
             slug=case_study.slug,
             id=case_study.id,
-
         )
         actual = str(response.content, 'utf-8').split('\r\n')
 
@@ -241,15 +210,9 @@ class DownloadCaseStudyCSVTestCase(TestCase):
         case_studies = factories.CompanyCaseStudyFactory.create_batch(3)
         data = {
             'action': 'download_csv',
-            '_selected_action': models.CompanyCaseStudy.objects.all().values_list(
-                'pk', flat=True
-            )
+            '_selected_action': models.CompanyCaseStudy.objects.all().values_list('pk', flat=True),
         }
-        response = self.client.post(
-            reverse('admin:company_companycasestudy_changelist'),
-            data,
-            follow=True
-        )
+        response = self.client.post(reverse('admin:company_companycasestudy_changelist'), data, follow=True)
 
         row_one = (
             '{company_id},2012-01-14 12:00:00+00:00,{description},{id},,,,,,,,'
@@ -293,17 +256,14 @@ class DownloadCaseStudyCSVTestCase(TestCase):
 
     def test_create_companies_form_success(self):
 
-        file_path = os.path.join(
-            settings.BASE_DIR,
-            'company/tests/fixtures/valid-companies-upload.csv'
-        )
+        file_path = os.path.join(settings.BASE_DIR, 'company/tests/fixtures/valid-companies-upload.csv')
 
         response = self.client.post(
             reverse('admin:company_company_enrol'),
             {
                 'generated_for': constants.UK_ISD,
                 'csv_file': open(file_path, 'rb'),
-            }
+            },
         )
 
         assert response.status_code == 200
@@ -321,9 +281,7 @@ class DownloadCaseStudyCSVTestCase(TestCase):
         assert company_one.website == 'http://www.example-compass.co.uk'
         assert company_one.twitter_url == 'https://www.twitter.com/one'
         assert company_one.facebook_url == 'https://www.facebook.com/one'
-        assert company_one.linkedin_url == (
-            'https://www.linkedin.com/company/one'
-        )
+        assert company_one.linkedin_url == ('https://www.linkedin.com/company/one')
         assert company_one.company_type == company_types.COMPANIES_HOUSE
         assert company_one.is_uk_isd_company is True
 
@@ -337,9 +295,7 @@ class DownloadCaseStudyCSVTestCase(TestCase):
         assert company_two.website == 'http://www.example-asscoiates.com'
         assert company_two.twitter_url == 'https://www.twitter.com/two'
         assert company_two.facebook_url == 'https://www.facebook.com/two'
-        assert company_two.linkedin_url == (
-            'https://www.linkedin.com/company/two'
-        )
+        assert company_two.linkedin_url == ('https://www.linkedin.com/company/two')
         assert company_two.company_type == company_types.SOLE_TRADER
         assert company_two.is_uk_isd_company is True
 
@@ -365,7 +321,7 @@ class DownloadCaseStudyCSVTestCase(TestCase):
                 'url': (
                     'http://profile.trade.great:8006/profile/enrol/'
                     'pre-verified/?key=' + signer.sign(company_one.number)
-                )
+                ),
             },
             {
                 'name': 'Example Associates Ltd',
@@ -374,8 +330,8 @@ class DownloadCaseStudyCSVTestCase(TestCase):
                 'url': (
                     'http://profile.trade.great:8006/profile/enrol/'
                     'pre-verified/?key=' + signer.sign(company_two.number)
-                )
-            }
+                ),
+            },
         ]
 
     def test_upload_expertise_companies_form_success(self):
@@ -399,16 +355,13 @@ class DownloadCaseStudyCSVTestCase(TestCase):
             name='Test 4',
         )
 
-        file_path = os.path.join(
-            settings.BASE_DIR,
-            'company/tests/fixtures/expertise-company-upload.csv'
-        )
+        file_path = os.path.join(settings.BASE_DIR, 'company/tests/fixtures/expertise-company-upload.csv')
 
         response = self.client.post(
             reverse('admin:upload_company_expertise'),
             {
                 'csv_file': open(file_path, 'rb'),
-            }
+            },
         )
 
         company_1.refresh_from_db()
@@ -417,66 +370,52 @@ class DownloadCaseStudyCSVTestCase(TestCase):
 
         assert company_1.expertise_products_services == (
             {
-             'Finance': ['Raising capital'],
-             'Management Consulting': ['Workforce development'],
-             'Human Resources': ['Sourcing and hiring', 'Succession planning'],
-             'Publicity': ['Social media'],
-             'Business Support': ['Planning consultants']
+                'Finance': ['Raising capital'],
+                'Management Consulting': ['Workforce development'],
+                'Human Resources': ['Sourcing and hiring', 'Succession planning'],
+                'Publicity': ['Social media'],
+                'Business Support': ['Planning consultants'],
             }
         )
-        assert company_2.expertise_products_services == (
-            {
-                'Finance': ['Insurance']
-            }
-        )
+        assert company_2.expertise_products_services == ({'Finance': ['Insurance']})
         assert company_3.expertise_products_services == {
             'Legal': ['Immigration'],
-            'Business Support': ['Facilities (such as WiFI or electricity)']
+            'Business Support': ['Facilities (such as WiFI or electricity)'],
         }
         assert response.context['errors'] == [
-            '[Row 3] "Unable to find following products & services '
-            '[\'Unkown Skill\']"',
-            '[Row 5] "More then one company returned - '
-            'Name:Test 4 Number:00000000)"',
-            '[Row 6] "Company not found - Name:Test 9999 Number:00000000)"'
+            '[Row 3] "Unable to find following products & services [\'Unkown Skill\']"',
+            '[Row 5] "More then one company returned - Name:Test 4 Number:00000000)"',
+            '[Row 6] "Company not found - Name:Test 9999 Number:00000000)"',
         ]
         assert len(response.context['updated_companies']) == 3
 
     def test_create_companies_form_invalid_enrolment(self):
-        file_path = os.path.join(
-            settings.BASE_DIR,
-            'company/tests/fixtures/invalid-companies-upload.csv'
-        )
+        file_path = os.path.join(settings.BASE_DIR, 'company/tests/fixtures/invalid-companies-upload.csv')
 
         response = self.client.post(
             reverse('admin:company_company_enrol'),
             {
                 'csv_file': open(file_path, 'rb'),
                 'generated_for': constants.UK_ISD,
-            }
+            },
         )
 
         assert response.status_code == 200
-        assert response.context_data['form'].errors == {
-            'csv_file': ['[Row 3] {"name": ["This field is required."]}']
-        }
+        assert response.context_data['form'].errors == {'csv_file': ['[Row 3] {"name": ["This field is required."]}']}
 
     def test_create_companies_form_existing(self):
 
         company = factories.CompanyFactory(number=12355434)
         assert company.is_uk_isd_company is False
 
-        file_path = os.path.join(
-            settings.BASE_DIR,
-            'company/tests/fixtures/valid-companies-upload.csv'
-        )
+        file_path = os.path.join(settings.BASE_DIR, 'company/tests/fixtures/valid-companies-upload.csv')
 
         response = self.client.post(
             reverse('admin:company_company_enrol'),
             {
                 'generated_for': constants.UK_ISD,
                 'csv_file': open(file_path, 'rb'),
-            }
+            },
         )
 
         assert response.status_code == 200
@@ -504,11 +443,8 @@ def test_company_case_study_search_fields_exist():
 
 @pytest.mark.django_db
 class DownloadCSVTestCase(TestCase):
-
     def setUp(self):
-        superuser = User.objects.create_superuser(
-            username='admin', email='admin@example.com', password='test'
-        )
+        superuser = User.objects.create_superuser(username='admin', email='admin@example.com', password='test')
         self.client = Client()
         self.client.force_login(superuser)
 
@@ -519,90 +455,84 @@ class DownloadCSVTestCase(TestCase):
         self.freezer.stop()
 
     def test_download_csv(self):
-        company = models.Company.objects.create(
-            **COMPANY_DATA,
-            sectors=['TEST', 'FOO'],
-            hs_codes=['1', '2']
-        )
+        company = models.Company.objects.create(**COMPANY_DATA, sectors=['TEST', 'FOO'], hs_codes=['1', '2'])
         company_user = models.CompanyUser.objects.create(company=company, **SUPPLIER_DATA)
 
         data = {
             'action': 'download_csv',
-            '_selected_action': models.CompanyUser.objects.all().values_list('pk', flat=True)
+            '_selected_action': models.CompanyUser.objects.all().values_list('pk', flat=True),
         }
-        response = self.client.post(
-            reverse('admin:company_companyuser_changelist'),
-            data,
-            follow=True
+        response = self.client.post(reverse('admin:company_companyuser_changelist'), data, follow=True)
+        expected_data = OrderedDict(
+            [
+                ('company__address_line_1', 'test_address_line_1'),
+                ('company__address_line_2', 'test_address_line_2'),
+                ('company__companies_house_company_status', ''),
+                ('company__company_export_plans', ''),
+                ('company__country', 'test_country'),
+                ('company__created', '2012-01-14 12:00:00+00:00'),
+                ('company__date_identity_check_message_sent', ''),
+                ('company__date_of_creation', '2010-10-10'),
+                ('company__date_published', ''),
+                ('company__date_registration_letter_sent', ''),
+                ('company__date_verification_letter_sent', ''),
+                ('company__description', 'Company description'),
+                ('company__email_address', ''),
+                ('company__email_full_name', ''),
+                ('company__employees', ''),
+                ('company__expertise_countries', "['GB']"),
+                ('company__expertise_industries', "['INS']"),
+                ('company__expertise_languages', "['ENG']"),
+                ('company__expertise_products_services', '{}'),
+                ('company__expertise_regions', "['UKG3']"),
+                ('company__export_destinations', "['DE']"),
+                ('company__export_destinations_other', 'LY'),
+                ('company__facebook_url', ''),
+                ('company__has_case_study', 'False'),
+                ('company__has_exported_before', 'True'),
+                ('company__hs_codes', '"[\'1\', \'2\']"'),
+                ('company__id', str(company_user.company.pk)),
+                ('company__is_exporting_goods', 'False'),
+                ('company__is_exporting_services', 'False'),
+                ('company__is_identity_check_message_sent', 'False'),
+                ('company__is_published_find_a_supplier', 'False'),
+                ('company__is_published_investment_support_directory', 'False'),
+                ('company__is_registration_letter_sent', 'False'),
+                ('company__is_showcase_company', 'False'),
+                ('company__is_uk_isd_company', 'False'),
+                ('company__is_verification_letter_sent', 'False'),
+                ('company__keywords', ''),
+                ('company__linkedin_url', ''),
+                ('company__locality', 'test_locality'),
+                ('company__logo', ''),
+                ('company__mobile_number', '07505605132'),
+                ('company__modified', '2012-01-14 12:00:00+00:00'),
+                ('company__name', 'Test Company'),
+                ('company__number', '11234567'),
+                ('company__number_of_case_studies', '0'),
+                ('company__number_of_sectors', '2'),
+                ('company__po_box', ''),
+                ('company__postal_code', 'test_postal_code'),
+                ('company__postal_full_name', 'test_full_name'),
+                ('company__sectors', '"TEST,FOO"'),
+                ('company__slug', 'test-company'),
+                ('company__summary', ''),
+                ('company__twitter_url', ''),
+                ('company__verified_with_code', 'False'),
+                ('company__verified_with_companies_house_oauth2', 'False'),
+                ('company__verified_with_identity_check', 'False'),
+                ('company__verified_with_preverified_enrolment', 'False'),
+                ('company__website', 'http://example.com'),
+                ('company_email', 'gargoyle@example.com'),
+                ('date_joined', '2017-03-21 13:12:00+00:00'),
+                ('is_active', 'True'),
+                ('mobile_number', ''),
+                ('name', ''),
+                ('role', 'EDITOR'),
+                ('sso_id', '1'),
+                ('unsubscribed', 'False'),
+            ]
         )
-        expected_data = OrderedDict([
-            ('company__address_line_1', 'test_address_line_1'),
-            ('company__address_line_2', 'test_address_line_2'),
-            ('company__companies_house_company_status', ''),
-            ('company__company_export_plans', ''),
-            ('company__country', 'test_country'),
-            ('company__created', '2012-01-14 12:00:00+00:00'),
-            ('company__date_identity_check_message_sent', ''),
-            ('company__date_of_creation', '2010-10-10'),
-            ('company__date_published', ''),
-            ('company__date_registration_letter_sent', ''),
-            ('company__date_verification_letter_sent', ''),
-            ('company__description', 'Company description'),
-            ('company__email_address', ''),
-            ('company__email_full_name', ''),
-            ('company__employees', ''),
-            ('company__expertise_countries', "['GB']"),
-            ('company__expertise_industries', "['INS']"),
-            ('company__expertise_languages', "['ENG']"),
-            ('company__expertise_products_services', '{}'),
-            ('company__expertise_regions', "['UKG3']"),
-            ('company__export_destinations', "['DE']"),
-            ('company__export_destinations_other', 'LY'),
-            ('company__facebook_url', ''),
-            ('company__has_case_study', 'False'),
-            ('company__has_exported_before', 'True'),
-            ('company__hs_codes', '"[\'1\', \'2\']"'),
-            ('company__id', str(company_user.company.pk)),
-            ('company__is_exporting_goods', 'False'),
-            ('company__is_exporting_services', 'False'),
-            ('company__is_identity_check_message_sent', 'False'),
-            ('company__is_published_find_a_supplier', 'False'),
-            ('company__is_published_investment_support_directory', 'False'),
-            ('company__is_registration_letter_sent', 'False'),
-            ('company__is_showcase_company', 'False'),
-            ('company__is_uk_isd_company', 'False'),
-            ('company__is_verification_letter_sent', 'False'),
-            ('company__keywords', ''),
-            ('company__linkedin_url', ''),
-            ('company__locality', 'test_locality'),
-            ('company__logo', ''),
-            ('company__mobile_number', '07505605132'),
-            ('company__modified', '2012-01-14 12:00:00+00:00'),
-            ('company__name', 'Test Company'),
-            ('company__number', '11234567'),
-            ('company__number_of_case_studies', '0'),
-            ('company__number_of_sectors', '2'),
-            ('company__po_box', ''),
-            ('company__postal_code', 'test_postal_code'),
-            ('company__postal_full_name', 'test_full_name'),
-            ('company__sectors', '"TEST,FOO"'),
-            ('company__slug', 'test-company'),
-            ('company__summary', ''),
-            ('company__twitter_url', ''),
-            ('company__verified_with_code', 'False'),
-            ('company__verified_with_companies_house_oauth2', 'False'),
-            ('company__verified_with_identity_check', 'False'),
-            ('company__verified_with_preverified_enrolment', 'False'),
-            ('company__website', 'http://example.com'),
-            ('company_email', 'gargoyle@example.com'),
-            ('date_joined', '2017-03-21 13:12:00+00:00'),
-            ('is_active', 'True'),
-            ('mobile_number', ''),
-            ('name', ''),
-            ('role', 'EDITOR'),
-            ('sso_id', '1'),
-            ('unsubscribed', 'False'),
-        ])
 
         actual = str(response.content, 'utf-8').split('\r\n')
 
@@ -610,91 +540,85 @@ class DownloadCSVTestCase(TestCase):
         assert actual[1] == ','.join(expected_data.values())
 
     def test_download_csv_company_sectors_is_empty(self):
-        company = models.Company.objects.create(
-            **COMPANY_DATA,
-            sectors=[],
-            hs_codes=[]
-        )
+        company = models.Company.objects.create(**COMPANY_DATA, sectors=[], hs_codes=[])
         company_user = models.CompanyUser.objects.create(company=company, **SUPPLIER_DATA)
 
         data = {
             'action': 'download_csv',
-            '_selected_action': models.CompanyUser.objects.all().values_list('pk', flat=True)
+            '_selected_action': models.CompanyUser.objects.all().values_list('pk', flat=True),
         }
-        response = self.client.post(
-            reverse('admin:company_companyuser_changelist'),
-            data,
-            follow=True
-        )
+        response = self.client.post(reverse('admin:company_companyuser_changelist'), data, follow=True)
 
-        expected_data = OrderedDict([
-            ('company__address_line_1', 'test_address_line_1'),
-            ('company__address_line_2', 'test_address_line_2'),
-            ('company__companies_house_company_status', ''),
-            ('company__company_export_plans', ''),
-            ('company__country', 'test_country'),
-            ('company__created', '2012-01-14 12:00:00+00:00'),
-            ('company__date_identity_check_message_sent', ''),
-            ('company__date_of_creation', '2010-10-10'),
-            ('company__date_published', ''),
-            ('company__date_registration_letter_sent', ''),
-            ('company__date_verification_letter_sent', ''),
-            ('company__description', 'Company description'),
-            ('company__email_address', ''),
-            ('company__email_full_name', ''),
-            ('company__employees', ''),
-            ('company__expertise_countries', "['GB']"),
-            ('company__expertise_industries', "['INS']"),
-            ('company__expertise_languages', "['ENG']"),
-            ('company__expertise_products_services', '{}'),
-            ('company__expertise_regions', "['UKG3']"),
-            ('company__export_destinations', "['DE']"),
-            ('company__export_destinations_other', 'LY'),
-            ('company__facebook_url', ''),
-            ('company__has_case_study', 'False'),
-            ('company__has_exported_before', 'True'),
-            ('company__hs_codes', '[]'),
-            ('company__id', str(company_user.company.pk)),
-            ('company__is_exporting_goods', 'False'),
-            ('company__is_exporting_services', 'False'),
-            ('company__is_identity_check_message_sent', 'False'),
-            ('company__is_published_find_a_supplier', 'False'),
-            ('company__is_published_investment_support_directory', 'False'),
-            ('company__is_registration_letter_sent', 'False'),
-            ('company__is_showcase_company', 'False'),
-            ('company__is_uk_isd_company', 'False'),
-            ('company__is_verification_letter_sent', 'False'),
-            ('company__keywords', ''),
-            ('company__linkedin_url', ''),
-            ('company__locality', 'test_locality'),
-            ('company__logo', ''),
-            ('company__mobile_number', '07505605132'),
-            ('company__modified', '2012-01-14 12:00:00+00:00'),
-            ('company__name', 'Test Company'),
-            ('company__number', '11234567'),
-            ('company__number_of_case_studies', '0'),
-            ('company__number_of_sectors', '0'),
-            ('company__po_box', ''),
-            ('company__postal_code', 'test_postal_code'),
-            ('company__postal_full_name', 'test_full_name'),
-            ('company__sectors', ''),
-            ('company__slug', 'test-company'),
-            ('company__summary', ''),
-            ('company__twitter_url', ''),
-            ('company__verified_with_code', 'False'),
-            ('company__verified_with_companies_house_oauth2', 'False'),
-            ('company__verified_with_identity_check', 'False'),
-            ('company__verified_with_preverified_enrolment', 'False'),
-            ('company__website', 'http://example.com'),
-            ('company_email', 'gargoyle@example.com'),
-            ('date_joined', '2017-03-21 13:12:00+00:00'),
-            ('is_active', 'True'),
-            ('mobile_number', ''),
-            ('name', ''),
-            ('role', 'EDITOR'),
-            ('sso_id', '1'),
-            ('unsubscribed', 'False'),
-        ])
+        expected_data = OrderedDict(
+            [
+                ('company__address_line_1', 'test_address_line_1'),
+                ('company__address_line_2', 'test_address_line_2'),
+                ('company__companies_house_company_status', ''),
+                ('company__company_export_plans', ''),
+                ('company__country', 'test_country'),
+                ('company__created', '2012-01-14 12:00:00+00:00'),
+                ('company__date_identity_check_message_sent', ''),
+                ('company__date_of_creation', '2010-10-10'),
+                ('company__date_published', ''),
+                ('company__date_registration_letter_sent', ''),
+                ('company__date_verification_letter_sent', ''),
+                ('company__description', 'Company description'),
+                ('company__email_address', ''),
+                ('company__email_full_name', ''),
+                ('company__employees', ''),
+                ('company__expertise_countries', "['GB']"),
+                ('company__expertise_industries', "['INS']"),
+                ('company__expertise_languages', "['ENG']"),
+                ('company__expertise_products_services', '{}'),
+                ('company__expertise_regions', "['UKG3']"),
+                ('company__export_destinations', "['DE']"),
+                ('company__export_destinations_other', 'LY'),
+                ('company__facebook_url', ''),
+                ('company__has_case_study', 'False'),
+                ('company__has_exported_before', 'True'),
+                ('company__hs_codes', '[]'),
+                ('company__id', str(company_user.company.pk)),
+                ('company__is_exporting_goods', 'False'),
+                ('company__is_exporting_services', 'False'),
+                ('company__is_identity_check_message_sent', 'False'),
+                ('company__is_published_find_a_supplier', 'False'),
+                ('company__is_published_investment_support_directory', 'False'),
+                ('company__is_registration_letter_sent', 'False'),
+                ('company__is_showcase_company', 'False'),
+                ('company__is_uk_isd_company', 'False'),
+                ('company__is_verification_letter_sent', 'False'),
+                ('company__keywords', ''),
+                ('company__linkedin_url', ''),
+                ('company__locality', 'test_locality'),
+                ('company__logo', ''),
+                ('company__mobile_number', '07505605132'),
+                ('company__modified', '2012-01-14 12:00:00+00:00'),
+                ('company__name', 'Test Company'),
+                ('company__number', '11234567'),
+                ('company__number_of_case_studies', '0'),
+                ('company__number_of_sectors', '0'),
+                ('company__po_box', ''),
+                ('company__postal_code', 'test_postal_code'),
+                ('company__postal_full_name', 'test_full_name'),
+                ('company__sectors', ''),
+                ('company__slug', 'test-company'),
+                ('company__summary', ''),
+                ('company__twitter_url', ''),
+                ('company__verified_with_code', 'False'),
+                ('company__verified_with_companies_house_oauth2', 'False'),
+                ('company__verified_with_identity_check', 'False'),
+                ('company__verified_with_preverified_enrolment', 'False'),
+                ('company__website', 'http://example.com'),
+                ('company_email', 'gargoyle@example.com'),
+                ('date_joined', '2017-03-21 13:12:00+00:00'),
+                ('is_active', 'True'),
+                ('mobile_number', ''),
+                ('name', ''),
+                ('role', 'EDITOR'),
+                ('sso_id', '1'),
+                ('unsubscribed', 'False'),
+            ]
+        )
         actual = str(response.content, 'utf-8').split('\r\n')
 
         assert actual[0].split(',') == list(expected_data.keys())
@@ -704,167 +628,164 @@ class DownloadCSVTestCase(TestCase):
         company_data2 = COMPANY_DATA.copy()
         company_data2['number'] = '01234568'
         supplier_data2 = SUPPLIER_DATA.copy()
-        supplier_data2.update({
-            'sso_id': 2,
-            'company_email': '2@example.com',
-        })
+        supplier_data2.update(
+            {
+                'sso_id': 2,
+                'company_email': '2@example.com',
+            }
+        )
         company1 = models.Company.objects.create(**COMPANY_DATA)
         company2 = models.Company.objects.create(**company_data2)
-        models.CompanyCaseStudy.objects.create(
-            title='foo',
-            description='bar',
-            company=company1
-        )
+        models.CompanyCaseStudy.objects.create(title='foo', description='bar', company=company1)
         models.CompanyUser.objects.create(company=company1, **SUPPLIER_DATA)
         models.CompanyUser.objects.create(company=company2, **supplier_data2)
 
-        supplier_one_expected = OrderedDict([
-            ('company__address_line_1', 'test_address_line_1'),
-            ('company__address_line_2', 'test_address_line_2'),
-            ('company__companies_house_company_status', ''),
-            ('company__company_export_plans', ''),
-            ('company__country', 'test_country'),
-            ('company__created', '2012-01-14 12:00:00+00:00'),
-            ('company__date_identity_check_message_sent', ''),
-            ('company__date_of_creation', '2010-10-10'),
-            ('company__date_published', ''),
-            ('company__date_registration_letter_sent', ''),
-            ('company__date_verification_letter_sent', ''),
-            ('company__description', 'Company description'),
-            ('company__email_address', ''),
-            ('company__email_full_name', ''),
-            ('company__employees', ''),
-            ('company__expertise_countries', "['GB']"),
-            ('company__expertise_industries', "['INS']"),
-            ('company__expertise_languages', "['ENG']"),
-            ('company__expertise_products_services', '{}'),
-            ('company__expertise_regions', "['UKG3']"),
-            ('company__export_destinations', "['DE']"),
-            ('company__export_destinations_other', 'LY'),
-            ('company__facebook_url', ''),
-            ('company__has_case_study', 'True'),
-            ('company__has_exported_before', 'True'),
-            ('company__hs_codes', '[]'),
-            ('company__id', str(company1.pk)),
-            ('company__is_exporting_goods', 'False'),
-            ('company__is_exporting_services', 'False'),
-            ('company__is_identity_check_message_sent', 'False'),
-            ('company__is_published_find_a_supplier', 'False'),
-            ('company__is_published_investment_support_directory', 'False'),
-            ('company__is_registration_letter_sent', 'False'),
-            ('company__is_showcase_company', 'False'),
-            ('company__is_uk_isd_company', 'False'),
-            ('company__is_verification_letter_sent', 'False'),
-            ('company__keywords', ''),
-            ('company__linkedin_url', ''),
-            ('company__locality', 'test_locality'),
-            ('company__logo', ''),
-            ('company__mobile_number', '07505605132'),
-            ('company__modified', '2012-01-14 12:00:00+00:00'),
-            ('company__name', 'Test Company'),
-            ('company__number', '11234567'),
-            ('company__number_of_case_studies', '1'),
-            ('company__number_of_sectors', '0'),
-            ('company__po_box', ''),
-            ('company__postal_code', 'test_postal_code'),
-            ('company__postal_full_name', 'test_full_name'),
-            ('company__sectors', ''),
-            ('company__slug', 'test-company'),
-            ('company__summary', ''),
-            ('company__twitter_url', ''),
-            ('company__verified_with_code', 'False'),
-            ('company__verified_with_companies_house_oauth2', 'False'),
-            ('company__verified_with_identity_check', 'False'),
-            ('company__verified_with_preverified_enrolment', 'False'),
-            ('company__website', 'http://example.com'),
-            ('company_email', 'gargoyle@example.com'),
-            ('date_joined', '2017-03-21 13:12:00+00:00'),
-            ('is_active', 'True'),
-            ('mobile_number', ''),
-            ('name', ''),
-            ('role', 'EDITOR'),
-            ('sso_id', '1'),
-            ('unsubscribed', 'False'),
-        ])
+        supplier_one_expected = OrderedDict(
+            [
+                ('company__address_line_1', 'test_address_line_1'),
+                ('company__address_line_2', 'test_address_line_2'),
+                ('company__companies_house_company_status', ''),
+                ('company__company_export_plans', ''),
+                ('company__country', 'test_country'),
+                ('company__created', '2012-01-14 12:00:00+00:00'),
+                ('company__date_identity_check_message_sent', ''),
+                ('company__date_of_creation', '2010-10-10'),
+                ('company__date_published', ''),
+                ('company__date_registration_letter_sent', ''),
+                ('company__date_verification_letter_sent', ''),
+                ('company__description', 'Company description'),
+                ('company__email_address', ''),
+                ('company__email_full_name', ''),
+                ('company__employees', ''),
+                ('company__expertise_countries', "['GB']"),
+                ('company__expertise_industries', "['INS']"),
+                ('company__expertise_languages', "['ENG']"),
+                ('company__expertise_products_services', '{}'),
+                ('company__expertise_regions', "['UKG3']"),
+                ('company__export_destinations', "['DE']"),
+                ('company__export_destinations_other', 'LY'),
+                ('company__facebook_url', ''),
+                ('company__has_case_study', 'True'),
+                ('company__has_exported_before', 'True'),
+                ('company__hs_codes', '[]'),
+                ('company__id', str(company1.pk)),
+                ('company__is_exporting_goods', 'False'),
+                ('company__is_exporting_services', 'False'),
+                ('company__is_identity_check_message_sent', 'False'),
+                ('company__is_published_find_a_supplier', 'False'),
+                ('company__is_published_investment_support_directory', 'False'),
+                ('company__is_registration_letter_sent', 'False'),
+                ('company__is_showcase_company', 'False'),
+                ('company__is_uk_isd_company', 'False'),
+                ('company__is_verification_letter_sent', 'False'),
+                ('company__keywords', ''),
+                ('company__linkedin_url', ''),
+                ('company__locality', 'test_locality'),
+                ('company__logo', ''),
+                ('company__mobile_number', '07505605132'),
+                ('company__modified', '2012-01-14 12:00:00+00:00'),
+                ('company__name', 'Test Company'),
+                ('company__number', '11234567'),
+                ('company__number_of_case_studies', '1'),
+                ('company__number_of_sectors', '0'),
+                ('company__po_box', ''),
+                ('company__postal_code', 'test_postal_code'),
+                ('company__postal_full_name', 'test_full_name'),
+                ('company__sectors', ''),
+                ('company__slug', 'test-company'),
+                ('company__summary', ''),
+                ('company__twitter_url', ''),
+                ('company__verified_with_code', 'False'),
+                ('company__verified_with_companies_house_oauth2', 'False'),
+                ('company__verified_with_identity_check', 'False'),
+                ('company__verified_with_preverified_enrolment', 'False'),
+                ('company__website', 'http://example.com'),
+                ('company_email', 'gargoyle@example.com'),
+                ('date_joined', '2017-03-21 13:12:00+00:00'),
+                ('is_active', 'True'),
+                ('mobile_number', ''),
+                ('name', ''),
+                ('role', 'EDITOR'),
+                ('sso_id', '1'),
+                ('unsubscribed', 'False'),
+            ]
+        )
 
-        supplier_two_expected = OrderedDict([
-            ('company__address_line_1', 'test_address_line_1'),
-            ('company__address_line_2', 'test_address_line_2'),
-            ('company__companies_house_company_status', ''),
-            ('company__company_export_plans', ''),
-            ('company__country', 'test_country'),
-            ('company__created', '2012-01-14 12:00:00+00:00'),
-            ('company__date_identity_check_message_sent', ''),
-            ('company__date_of_creation', '2010-10-10'),
-            ('company__date_published', ''),
-            ('company__date_registration_letter_sent', ''),
-            ('company__date_verification_letter_sent', ''),
-            ('company__description', 'Company description'),
-            ('company__email_address', ''),
-            ('company__email_full_name', ''),
-            ('company__employees', ''),
-            ('company__expertise_countries', "['GB']"),
-            ('company__expertise_industries', "['INS']"),
-            ('company__expertise_languages', "['ENG']"),
-            ('company__expertise_products_services', '{}'),
-            ('company__expertise_regions', "['UKG3']"),
-            ('company__export_destinations', "['DE']"),
-            ('company__export_destinations_other', 'LY'),
-            ('company__facebook_url', ''),
-            ('company__has_case_study', 'False'),
-            ('company__has_exported_before', 'True'),
-            ('company__hs_codes', '[]'),
-            ('company__id', str(company2.pk)),
-            ('company__is_exporting_goods', 'False'),
-            ('company__is_exporting_services', 'False'),
-            ('company__is_identity_check_message_sent', 'False'),
-            ('company__is_published_find_a_supplier', 'False'),
-            ('company__is_published_investment_support_directory', 'False'),
-            ('company__is_registration_letter_sent', 'False'),
-            ('company__is_showcase_company', 'False'),
-            ('company__is_uk_isd_company', 'False'),
-            ('company__is_verification_letter_sent', 'False'),
-            ('company__keywords', ''),
-            ('company__linkedin_url', ''),
-            ('company__locality', 'test_locality'),
-            ('company__logo', ''),
-            ('company__mobile_number', '07505605132'),
-            ('company__modified', '2012-01-14 12:00:00+00:00'),
-            ('company__name', 'Test Company'),
-            ('company__number', '01234568'),
-            ('company__number_of_case_studies', '0'),
-            ('company__number_of_sectors', '0'),
-            ('company__po_box', ''),
-            ('company__postal_code', 'test_postal_code'),
-            ('company__postal_full_name', 'test_full_name'),
-            ('company__sectors', ''),
-            ('company__slug', 'test-company'),
-            ('company__summary', ''),
-            ('company__twitter_url', ''),
-            ('company__verified_with_code', 'False'),
-            ('company__verified_with_companies_house_oauth2', 'False'),
-            ('company__verified_with_identity_check', 'False'),
-            ('company__verified_with_preverified_enrolment', 'False'),
-            ('company__website', 'http://example.com'),
-            ('company_email', '2@example.com'),
-            ('date_joined', '2017-03-21 13:12:00+00:00'),
-            ('is_active', 'True'),
-            ('mobile_number', ''),
-            ('name', ''),
-            ('role', 'EDITOR'),
-            ('sso_id', '2'),
-            ('unsubscribed', 'False'),
-
-        ])
+        supplier_two_expected = OrderedDict(
+            [
+                ('company__address_line_1', 'test_address_line_1'),
+                ('company__address_line_2', 'test_address_line_2'),
+                ('company__companies_house_company_status', ''),
+                ('company__company_export_plans', ''),
+                ('company__country', 'test_country'),
+                ('company__created', '2012-01-14 12:00:00+00:00'),
+                ('company__date_identity_check_message_sent', ''),
+                ('company__date_of_creation', '2010-10-10'),
+                ('company__date_published', ''),
+                ('company__date_registration_letter_sent', ''),
+                ('company__date_verification_letter_sent', ''),
+                ('company__description', 'Company description'),
+                ('company__email_address', ''),
+                ('company__email_full_name', ''),
+                ('company__employees', ''),
+                ('company__expertise_countries', "['GB']"),
+                ('company__expertise_industries', "['INS']"),
+                ('company__expertise_languages', "['ENG']"),
+                ('company__expertise_products_services', '{}'),
+                ('company__expertise_regions', "['UKG3']"),
+                ('company__export_destinations', "['DE']"),
+                ('company__export_destinations_other', 'LY'),
+                ('company__facebook_url', ''),
+                ('company__has_case_study', 'False'),
+                ('company__has_exported_before', 'True'),
+                ('company__hs_codes', '[]'),
+                ('company__id', str(company2.pk)),
+                ('company__is_exporting_goods', 'False'),
+                ('company__is_exporting_services', 'False'),
+                ('company__is_identity_check_message_sent', 'False'),
+                ('company__is_published_find_a_supplier', 'False'),
+                ('company__is_published_investment_support_directory', 'False'),
+                ('company__is_registration_letter_sent', 'False'),
+                ('company__is_showcase_company', 'False'),
+                ('company__is_uk_isd_company', 'False'),
+                ('company__is_verification_letter_sent', 'False'),
+                ('company__keywords', ''),
+                ('company__linkedin_url', ''),
+                ('company__locality', 'test_locality'),
+                ('company__logo', ''),
+                ('company__mobile_number', '07505605132'),
+                ('company__modified', '2012-01-14 12:00:00+00:00'),
+                ('company__name', 'Test Company'),
+                ('company__number', '01234568'),
+                ('company__number_of_case_studies', '0'),
+                ('company__number_of_sectors', '0'),
+                ('company__po_box', ''),
+                ('company__postal_code', 'test_postal_code'),
+                ('company__postal_full_name', 'test_full_name'),
+                ('company__sectors', ''),
+                ('company__slug', 'test-company'),
+                ('company__summary', ''),
+                ('company__twitter_url', ''),
+                ('company__verified_with_code', 'False'),
+                ('company__verified_with_companies_house_oauth2', 'False'),
+                ('company__verified_with_identity_check', 'False'),
+                ('company__verified_with_preverified_enrolment', 'False'),
+                ('company__website', 'http://example.com'),
+                ('company_email', '2@example.com'),
+                ('date_joined', '2017-03-21 13:12:00+00:00'),
+                ('is_active', 'True'),
+                ('mobile_number', ''),
+                ('name', ''),
+                ('role', 'EDITOR'),
+                ('sso_id', '2'),
+                ('unsubscribed', 'False'),
+            ]
+        )
         data = {
             'action': 'download_csv',
-            '_selected_action': models.CompanyUser.objects.all().values_list('pk', flat=True)
+            '_selected_action': models.CompanyUser.objects.all().values_list('pk', flat=True),
         }
-        response = self.client.post(
-            reverse('admin:company_companyuser_changelist'),
-            data,
-            follow=True
-        )
+        response = self.client.post(reverse('admin:company_companyuser_changelist'), data, follow=True)
         actual = str(response.content, 'utf-8').split('\r\n')
 
         assert actual[0].split(',') == list(supplier_one_expected.keys())
@@ -874,11 +795,8 @@ class DownloadCSVTestCase(TestCase):
 
 @pytest.mark.django_db
 class ResendLetterTestCase(TestCase):
-
     def setUp(self):
-        superuser = User.objects.create_superuser(
-            username='admin', email='admin@example.com', password='test'
-        )
+        superuser = User.objects.create_superuser(username='admin', email='admin@example.com', password='test')
         self.client = Client()
         self.client.force_login(superuser)
 
@@ -905,7 +823,7 @@ class ResendLetterTestCase(TestCase):
 
         data = {
             'action': 'send_verification_letter',
-            '_selected_action': models.CompanyUser.objects.all().values_list('pk', flat=True)
+            '_selected_action': models.CompanyUser.objects.all().values_list('pk', flat=True),
         }
         response = self.client.post(
             reverse('admin:company_companyuser_changelist'),
@@ -916,7 +834,7 @@ class ResendLetterTestCase(TestCase):
         response = self.client.post(
             reverse('admin:resend_verification_letter'),
             data={'obj_ids': f'{[company_user.pk for company_user in models.CompanyUser.objects.all()]}'},
-            follow=True
+            follow=True,
         )
 
         assert mocked_send_letter.called_once_with(company_user.company)

--- a/company/tests/test_fixtures.py
+++ b/company/tests/test_fixtures.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.core.management import call_command
 
 from company import models

--- a/company/tests/test_forms.py
+++ b/company/tests/test_forms.py
@@ -1,102 +1,123 @@
-from directory_constants import company_types
 import pytest
+from directory_constants import company_types
 
 from company import forms
 
 
-@pytest.mark.parametrize('value,expected', (
-    ('', ''),
-    (None, ''),
-    ('very long '*100, ''),
-))
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('', ''),
+        (None, ''),
+        ('very long ' * 100, ''),
+    ),
+)
 def test_mobile_number_clean(value, expected):
     field = forms.MobileNumberField(max_length=100)
     assert field.to_python(value) == expected
 
 
-@pytest.mark.parametrize('value,expected', (
-    ('11536552', '11536552'),
-    ('6872466', '06872466'),
-    ('OC404310', 'OC404310'),
-    ('OC 321831', 'OC321831'),
-    ('THERE IS NO IN ENGLAND ', None),
-    ('0452 5852', '04525852'),
-    ('N/A', None),
-    ('N/a', None),
-    ('n/a', None),
-    (None, None),
-    ('', None),
-))
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('11536552', '11536552'),
+        ('6872466', '06872466'),
+        ('OC404310', 'OC404310'),
+        ('OC 321831', 'OC321831'),
+        ('THERE IS NO IN ENGLAND ', None),
+        ('0452 5852', '04525852'),
+        ('N/A', None),
+        ('N/a', None),
+        ('n/a', None),
+        (None, None),
+        ('', None),
+    ),
+)
 def test_company_number_clean(value, expected):
     field = forms.CompanyNumberField(max_length=8)
     assert field.to_python(value) == expected
 
 
-@pytest.mark.parametrize('value,expected', (
-    ('www.example.com', 'http://www.example.com'),
-    ('https://www.example.co.uk', 'https://www.example.co.uk'),
-    (None, ''),
-    ('', ''),
-    ('www.example.com (pending)', 'http://www.example.com'),
-    ('www.example.com and thing.com', 'http://www.example.com'),
-    ('www.example.com\nthing.com', 'http://www.example.com'),
-    ('in progress', ''),
-))
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('www.example.com', 'http://www.example.com'),
+        ('https://www.example.co.uk', 'https://www.example.co.uk'),
+        (None, ''),
+        ('', ''),
+        ('www.example.com (pending)', 'http://www.example.com'),
+        ('www.example.com and thing.com', 'http://www.example.com'),
+        ('www.example.com\nthing.com', 'http://www.example.com'),
+        ('in progress', ''),
+    ),
+)
 def test_company_url_clean(value, expected):
     field = forms.CompanyUrlField()
     assert field.to_python(value) == expected
 
 
-@pytest.mark.parametrize('value,expected', (
-    ('Foo bar on facebook', ''),
-    ('www.facebook.com/example', 'https://www.facebook.com/example'),
-    ('example', 'https://www.facebook.com/example'),
-    ('@example', 'https://www.facebook.com/example'),
-    ('https://www.facebook.com/example', 'https://www.facebook.com/example'),
-    ('', ''),
-    (None, ''),
-))
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('Foo bar on facebook', ''),
+        ('www.facebook.com/example', 'https://www.facebook.com/example'),
+        ('example', 'https://www.facebook.com/example'),
+        ('@example', 'https://www.facebook.com/example'),
+        ('https://www.facebook.com/example', 'https://www.facebook.com/example'),
+        ('', ''),
+        (None, ''),
+    ),
+)
 def test_facebook_url_clean(value, expected):
     field = forms.FacebookURLField()
     assert field.to_python(value) == expected
 
 
-@pytest.mark.parametrize('value,expected', (
-    ('Foo bar on twitter', ''),
-    ('www.twitter.com/example', 'https://www.twitter.com/example'),
-    ('example', 'https://www.twitter.com/example'),
-    ('@example', 'https://www.twitter.com/example'),
-    ('https://www.twitter.com/example', 'https://www.twitter.com/example'),
-    ('', ''),
-    (None, ''),
-))
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('Foo bar on twitter', ''),
+        ('www.twitter.com/example', 'https://www.twitter.com/example'),
+        ('example', 'https://www.twitter.com/example'),
+        ('@example', 'https://www.twitter.com/example'),
+        ('https://www.twitter.com/example', 'https://www.twitter.com/example'),
+        ('', ''),
+        (None, ''),
+    ),
+)
 def test_twitter_url_clean(value, expected):
     field = forms.TwitterURLField()
     assert field.to_python(value) == expected
 
 
-@pytest.mark.parametrize('value,expected', (
-    ('Foo bar on linked in', ''),
-    ('www.linkedin.com/example', 'https://www.linkedin.com/company/example'),
-    ('foo', 'https://www.linkedin.com/company/foo'),
-    ('@foo', 'https://www.linkedin.com/company/foo'),
-    ('https://www.linkedin.com/foo', 'https://www.linkedin.com/company/foo'),
-    ('', ''),
-    (None, ''),
-))
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('Foo bar on linked in', ''),
+        ('www.linkedin.com/example', 'https://www.linkedin.com/company/example'),
+        ('foo', 'https://www.linkedin.com/company/foo'),
+        ('@foo', 'https://www.linkedin.com/company/foo'),
+        ('https://www.linkedin.com/foo', 'https://www.linkedin.com/company/foo'),
+        ('', ''),
+        (None, ''),
+    ),
+)
 def test_linkedin_url_clean(value, expected):
     field = forms.LinkedInURLField()
     assert field.to_python(value) == expected
 
 
-@pytest.mark.parametrize('value,expected', (
-    ('', company_types.SOLE_TRADER),
-    (None, company_types.SOLE_TRADER),
-    ('1234567', company_types.COMPANIES_HOUSE),
-    ('THERE IS NO IN ENGLAND ', company_types.SOLE_TRADER),
-    ('N/A', company_types.SOLE_TRADER),
-    ('N/a', company_types.SOLE_TRADER),
-    ('n/a', company_types.SOLE_TRADER),
-))
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('', company_types.SOLE_TRADER),
+        (None, company_types.SOLE_TRADER),
+        ('1234567', company_types.COMPANIES_HOUSE),
+        ('THERE IS NO IN ENGLAND ', company_types.SOLE_TRADER),
+        ('N/A', company_types.SOLE_TRADER),
+        ('N/a', company_types.SOLE_TRADER),
+        ('n/a', company_types.SOLE_TRADER),
+    ),
+)
 def test_company_type_parser(value, expected):
     assert forms.company_type_parser(value) == expected

--- a/company/tests/test_gecko.py
+++ b/company/tests/test_gecko.py
@@ -6,20 +6,15 @@ from company.models import CompanyUser
 
 @pytest.mark.django_db
 def test_gecko_num_registered_supplier_correct():
-    CompanyUser.objects.bulk_create([
-        CompanyUser(sso_id=1, company_email='1@example.com', mobile_number='1'),
-        CompanyUser(sso_id=2, company_email='2@example.com', mobile_number='2'),
-        CompanyUser(sso_id=3, company_email='3@example.com', mobile_number='3'),
-    ])
+    CompanyUser.objects.bulk_create(
+        [
+            CompanyUser(sso_id=1, company_email='1@example.com', mobile_number='1'),
+            CompanyUser(sso_id=2, company_email='2@example.com', mobile_number='2'),
+            CompanyUser(sso_id=3, company_email='3@example.com', mobile_number='3'),
+        ]
+    )
 
     gecko_json = gecko.total_registered_company_users()
 
-    expected = {
-      "item": [
-        {
-          "value": 3,
-          "text": "Total registered company users"
-        }
-      ]
-    }
+    expected = {"item": [{"value": 3, "text": "Total registered company users"}]}
     assert gecko_json == expected

--- a/company/tests/test_management.py
+++ b/company/tests/test_management.py
@@ -1,10 +1,10 @@
 from unittest import mock
 
 import pytest
+from directory_constants import user_roles
 from django.conf import settings
 from django.core.management import call_command
 
-from directory_constants import user_roles
 from company.tests import factories
 
 

--- a/company/tests/test_models.py
+++ b/company/tests/test_models.py
@@ -1,14 +1,13 @@
 from unittest import mock
-import pytest
 
+import pytest
 from directory_constants import choices, user_roles
 from directory_validators.string import no_html
-
 from django.db import IntegrityError
-from django_extensions.db.fields import ModificationDateTimeField, CreationDateTimeField
+from django_extensions.db.fields import CreationDateTimeField, ModificationDateTimeField
 
 from company import models
-from company.tests.factories import CompanyFactory, CompanyCaseStudyFactory
+from company.tests.factories import CompanyCaseStudyFactory, CompanyFactory
 
 
 @pytest.mark.django_db
@@ -72,8 +71,7 @@ def test_company_model_has_update_create_timestamps():
 
 
 def test_company_case_study_model_has_update_create_timestamps():
-    field_names = [field.name
-                   for field in models.CompanyCaseStudy._meta.get_fields()]
+    field_names = [field.name for field in models.CompanyCaseStudy._meta.get_fields()]
 
     assert 'created' in field_names
     created_field = models.CompanyCaseStudy._meta.get_field('created')
@@ -124,18 +122,21 @@ def test_public_profile_url(settings):
     assert company.public_profile_url == 'http://profile/1234567'
 
 
-@pytest.mark.parametrize('code,preverfiied,oauth2,identity,expected', [
-    [False, False, False, False, False],
-    [False, False, True,  False,  True],
-    [False, True,  False, False,  True],
-    [False, True,  True,  True,   True],
-    [True,  False, True,  False,  True],
-    [True,  False, True,  False,  True],
-    [True,  False, False, False,  True],
-    [True,  True,  False, False,  True],
-    [False, False, False, True,   True],
-    [True,  True,  True,  True,   True],
-])
+@pytest.mark.parametrize(
+    'code,preverfiied,oauth2,identity,expected',
+    [
+        [False, False, False, False, False],
+        [False, False, True, False, True],
+        [False, True, False, False, True],
+        [False, True, True, True, True],
+        [True, False, True, False, True],
+        [True, False, True, False, True],
+        [True, False, False, False, True],
+        [True, True, False, False, True],
+        [False, False, False, True, True],
+        [True, True, True, True, True],
+    ],
+)
 def test_company_is_verified(code, preverfiied, oauth2, identity, expected):
     company = CompanyFactory.build(
         verified_with_preverified_enrolment=preverfiied,
@@ -146,71 +147,76 @@ def test_company_is_verified(code, preverfiied, oauth2, identity, expected):
     assert company.is_verified is expected
 
 
-@pytest.mark.parametrize('field_name', [
-    'name',
-    'description',
-    'keywords',
-    'summary',
-    'description',
-    'export_destinations_other',
-    'email_full_name',
-    'postal_full_name',
-    'address_line_1',
-    'address_line_2',
-    'locality',
-    'country',
-    'postal_code',
-    'po_box',
-])
+@pytest.mark.parametrize(
+    'field_name',
+    [
+        'name',
+        'description',
+        'keywords',
+        'summary',
+        'description',
+        'export_destinations_other',
+        'email_full_name',
+        'postal_full_name',
+        'address_line_1',
+        'address_line_2',
+        'locality',
+        'country',
+        'postal_code',
+        'po_box',
+    ],
+)
 def test_xss_attack_company(field_name):
     field = models.Company._meta.get_field(field_name)
     assert no_html in field.validators
 
 
-@pytest.mark.parametrize('field_name', [
-    'title',
-    'description',
-    'short_summary',
-    'image_one_caption',
-    'image_two_caption',
-    'image_three_caption',
-    'testimonial',
-    'testimonial_name',
-    'testimonial_job_title',
-    'testimonial_company',
-    'keywords',
-])
+@pytest.mark.parametrize(
+    'field_name',
+    [
+        'title',
+        'description',
+        'short_summary',
+        'image_one_caption',
+        'image_two_caption',
+        'image_three_caption',
+        'testimonial',
+        'testimonial_name',
+        'testimonial_job_title',
+        'testimonial_company',
+        'keywords',
+    ],
+)
 def test_xss_attack_cast_Study(field_name):
     field = models.CompanyCaseStudy._meta.get_field(field_name)
     assert no_html in field.validators
 
 
 @pytest.mark.parametrize(
-    'desciption,summary,email,is_verified,expected', [
+    'desciption,summary,email,is_verified,expected',
+    [
         # has_contact
-        ['',  '',  '',         False, False],
-        ['',  '',  'a@e.com',  False, False],
+        ['', '', '', False, False],
+        ['', '', 'a@e.com', False, False],
         # has_synopsis
-        ['d', '',  '',         False, False],
-        ['d', '',  'a@e.com',  False, False],
-        ['d', 's',  '',        False, False],
-        ['',  's',  '',        False, False],
-        ['d', 's',  'a@e.com', False, False],
-        ['',  's',  'a@e.com', False, False],
+        ['d', '', '', False, False],
+        ['d', '', 'a@e.com', False, False],
+        ['d', 's', '', False, False],
+        ['', 's', '', False, False],
+        ['d', 's', 'a@e.com', False, False],
+        ['', 's', 'a@e.com', False, False],
         # is_verified
-        ['',  '',  '',         True,  False],
-        ['',  '',  'a@e.com',  True,  False],
-        ['d', '',  '',         True,  False],
-        ['d', '',  'a@e.com',  True,  True],
-        ['d', 's',  '',        True,  False],
-        ['',  's',  '',        True,  False],
-        ['d', 's',  'a@e.com', True,  True],
-        ['',  's',  'a@e.com', True,  True],
-    ]
+        ['', '', '', True, False],
+        ['', '', 'a@e.com', True, False],
+        ['d', '', '', True, False],
+        ['d', '', 'a@e.com', True, True],
+        ['d', 's', '', True, False],
+        ['', 's', '', True, False],
+        ['d', 's', 'a@e.com', True, True],
+        ['', 's', 'a@e.com', True, True],
+    ],
 )
-def test_can_publish(
-    desciption, summary, email, is_verified, expected, settings
-):
+def test_can_publish(desciption, summary, email, is_verified, expected, settings):
     mock_verifed = mock.PropertyMock(return_value=is_verified)
     with mock.patch('company.models.Company.is_verified', mock_verifed):
         company = CompanyFactory.build(

--- a/company/tests/test_search.py
+++ b/company/tests/test_search.py
@@ -1,15 +1,14 @@
-from unittest.mock import patch, Mock, PropertyMock
 import datetime
+from unittest.mock import Mock, PropertyMock, patch
 
-from freezegun import freeze_time
-from freezegun.api import datetime_to_fakedatetime, date_to_fakedate
 import pytest
-
 from django.conf import settings
+from freezegun import freeze_time
+from freezegun.api import date_to_fakedate, datetime_to_fakedatetime
 
-from core.tests.test_views import reload_urlconf
 from company import documents, helpers, serializers
 from company.tests import factories
+from core.tests.test_views import reload_urlconf
 
 
 @pytest.mark.django_db
@@ -17,10 +16,7 @@ from company.tests import factories
 def test_company_doc_type():
     settings.STORAGE_CLASS_NAME = 'local-storage'
     reload_urlconf()
-    company = factories.CompanyFactory(
-        date_of_creation=datetime.date(2000, 10, 10),
-        sectors=['AEROSPACE', 'AIRPORTS']
-    )
+    company = factories.CompanyFactory(date_of_creation=datetime.date(2000, 10, 10), sectors=['AEROSPACE', 'AIRPORTS'])
     case_study = factories.CompanyCaseStudyFactory(company=company)
 
     logo_mock = PropertyMock(return_value=Mock(url='/media/thing.jpg'))
@@ -53,9 +49,7 @@ def test_company_doc_type():
         'expertise_languages': company.expertise_languages,
         'expertise_countries': company.expertise_countries,
         'expertise_products_services': company.expertise_products_services,
-        'expertise_products_services_labels': (
-            expected_expertise_products_services
-        ),
+        'expertise_products_services_labels': expected_expertise_products_services,
         'sectors_label': ['Aerospace', 'Airports'],
         'expertise_labels': company_parser.expertise_labels_for_search,
         'slug': company.slug,
@@ -95,10 +89,7 @@ def test_company_doc_type():
 
 @pytest.mark.django_db
 def test_company_doc_type_single_sector():
-    company = factories.CompanyFactory(
-        date_of_creation=datetime.date(2000, 10, 10),
-        sectors=['AEROSPACE']
-    )
+    company = factories.CompanyFactory(date_of_creation=datetime.date(2000, 10, 10), sectors=['AEROSPACE'])
 
     doc = documents.company_model_to_document(company)
 

--- a/company/tests/test_serializers.py
+++ b/company/tests/test_serializers.py
@@ -1,16 +1,14 @@
 from datetime import datetime
 from unittest.mock import Mock
 
-import pytest
-
-from freezegun import freeze_time
-
 import directory_validators.string
-from directory_constants import company_types, choices, user_roles
+import pytest
+from directory_constants import choices, company_types, user_roles
+from freezegun import freeze_time
 from pytz import UTC
 
 from company import models, serializers, validators
-from company.tests import factories, VALID_REQUEST_DATA
+from company.tests import VALID_REQUEST_DATA, factories
 
 
 @pytest.fixture
@@ -102,7 +100,7 @@ def test_company_serializer_is_published_field_with_isd():
         'date_of_creation': '2010-10-10',
         'firstname': 'test_firstname',
         'is_published_investment_support_directory': True,
-     }
+    }
     serializer = serializers.CompanySerializer(data=data)
 
     assert serializer.is_valid(), serializer.errors
@@ -119,7 +117,7 @@ def test_company_serializer_is_published_field_with_fab():
         'date_of_creation': '2010-10-10',
         'firstname': 'test_firstname',
         'is_published_find_a_supplier': True,
-     }
+    }
     serializer = serializers.CompanySerializer(data=data)
 
     assert serializer.is_valid(), serializer.errors
@@ -230,9 +228,7 @@ def test_company_serializer_save():
 
 
 @pytest.mark.django_db
-def test_company_serializer_nested_case_study(
-    company, company_case_study_one, company_case_study_two
-):
+def test_company_serializer_nested_case_study(company, company_case_study_one, company_case_study_two):
     case_studies = [
         serializers.CompanyCaseStudySerializer(company_case_study_one).data,
         serializers.CompanyCaseStudySerializer(company_case_study_two).data,
@@ -271,42 +267,37 @@ def test_company_case_study_explicit_value(case_study_data):
 
 @pytest.mark.django_db
 def test_company_case_study_with_company(company_case_study_one):
-    serializer = serializers.CompanyCaseStudyWithCompanySerializer(
-        company_case_study_one
-    )
+    serializer = serializers.CompanyCaseStudyWithCompanySerializer(company_case_study_one)
     assert isinstance(serializer.data['company'], dict)
 
 
 def test_company_search_serializer():
-    serializer = serializers.SearchSerializer(
-        data={'page': 1, 'size': 10, 'term': 'thing'}
-    )
+    serializer = serializers.SearchSerializer(data={'page': 1, 'size': 10, 'term': 'thing'})
 
     assert serializer.is_valid() is True
 
 
 def test_company_search_serializer_empty_term_sector():
-    serializer = serializers.SearchSerializer(
-        data={'page': 1, 'size': 10}
-    )
+    serializer = serializers.SearchSerializer(data={'page': 1, 'size': 10})
 
     message = serializers.SearchSerializer.MESSAGE_MISSING_QUERY
     assert serializer.is_valid() is False
     assert serializer.errors == {'non_field_errors': [message]}
 
 
-@pytest.mark.parametrize('field, field_value', [
-    ['expertise_industries', [choices.INDUSTRIES[1][0]]],
-    ['expertise_regions', [choices.EXPERTISE_REGION_CHOICES[1][0]]],
-    ['expertise_countries', [choices.COUNTRY_CHOICES[1][0]]],
-    ['expertise_languages', [choices.EXPERTISE_LANGUAGES[1][0]]],
-    ['expertise_products_services_labels', ['IT']],
-])
+@pytest.mark.parametrize(
+    'field, field_value',
+    [
+        ['expertise_industries', [choices.INDUSTRIES[1][0]]],
+        ['expertise_regions', [choices.EXPERTISE_REGION_CHOICES[1][0]]],
+        ['expertise_countries', [choices.COUNTRY_CHOICES[1][0]]],
+        ['expertise_languages', [choices.EXPERTISE_LANGUAGES[1][0]]],
+        ['expertise_products_services_labels', ['IT']],
+    ],
+)
 def test_company_search_serializer_optional_field(field, field_value):
 
-    serializer = serializers.SearchSerializer(
-        data={'page': 1, 'size': 10, field: field_value}
-    )
+    serializer = serializers.SearchSerializer(data={'page': 1, 'size': 10, field: field_value})
 
     assert serializer.is_valid() is True
 
@@ -320,7 +311,7 @@ def test_add_collaborator_serializer_save():
         'company': company.number,
         'company_email': 'abc@def.com',
         'mobile_number': 9876543210,
-        'role': user_roles.MEMBER
+        'role': user_roles.MEMBER,
     }
     serializer = serializers.AddCollaboratorSerializer(data=data)
 
@@ -334,12 +325,7 @@ def test_add_collaborator_serializer_save():
 @pytest.mark.django_db
 def test_add_collaborator_serializer_fail():
     company = factories.CompanyFactory(name='Test Company')
-    data = {
-        'name': 'Abc',
-        'company': company.number,
-        'company_email': 'abc@def.com',
-        'role': user_roles.MEMBER
-    }
+    data = {'name': 'Abc', 'company': company.number, 'company_email': 'abc@def.com', 'role': user_roles.MEMBER}
     serializer = serializers.AddCollaboratorSerializer(data=data)
 
     assert serializer.is_valid() is False
@@ -347,12 +333,7 @@ def test_add_collaborator_serializer_fail():
 
 @pytest.mark.django_db
 def test_add_collaborator_serializer_company_not_found():
-    data = {
-        'name': 'Abc',
-        'company': -1,
-        'company_email': 'abc@def.com',
-        'role': user_roles.MEMBER
-    }
+    data = {'name': 'Abc', 'company': -1, 'company_email': 'abc@def.com', 'role': user_roles.MEMBER}
     serializer = serializers.AddCollaboratorSerializer(data=data)
     assert serializer.is_valid() is False
 
@@ -411,11 +392,13 @@ def test_supplier_serializer_defaults_to_empty_string():
 
 @pytest.mark.django_db
 def test_supplier_serializer_save():
-    serializer = serializers.CompanyUserSerializer(data={
-        "sso_id": 1,
-        "company_email": "gargoyle@example.com",
-        "date_joined": "2017-03-21T13:12:00Z",
-    })
+    serializer = serializers.CompanyUserSerializer(
+        data={
+            "sso_id": 1,
+            "company_email": "gargoyle@example.com",
+            "date_joined": "2017-03-21T13:12:00Z",
+        }
+    )
     serializer.is_valid(raise_exception=True)
 
     supplier = serializer.save()
@@ -430,12 +413,14 @@ def test_supplier_serializer_save():
 @pytest.mark.django_db
 def test_supplier_with_company_serializer_save():
     company = factories.CompanyFactory.create(number='01234567')
-    serializer = serializers.CompanyUserSerializer(data={
-        'sso_id': 1,
-        'company_email': 'gargoyle@example.com',
-        'date_joined': '2017-03-21T13:12:00Z',
-        'company': company.pk
-    })
+    serializer = serializers.CompanyUserSerializer(
+        data={
+            'sso_id': 1,
+            'company_email': 'gargoyle@example.com',
+            'date_joined': '2017-03-21T13:12:00Z',
+            'company': company.pk,
+        }
+    )
     serializer.is_valid(raise_exception=True)
 
     supplier = serializer.save()

--- a/company/tests/test_validators.py
+++ b/company/tests/test_validators.py
@@ -1,5 +1,4 @@
 import pytest
-
 from rest_framework.serializers import ValidationError
 
 from company import validators

--- a/company/tests/test_views.py
+++ b/company/tests/test_views.py
@@ -4,26 +4,28 @@ import http
 from io import BytesIO
 from unittest import mock
 
-from directory_constants import company_types, choices, sectors, user_roles
+import pytest
+from directory_constants import choices, company_types, sectors, user_roles
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
 from elasticsearch_dsl import Index
 from elasticsearch_dsl.connections import connections
-import pytest
 from freezegun import freeze_time
-from rest_framework.test import APIClient
-from rest_framework import status
 from PIL import Image
+from rest_framework import status
+from rest_framework.test import APIClient
 
-from django.conf import settings
-from django.urls import reverse
-from django.core.files.uploadedfile import SimpleUploadedFile
-
-from core.helpers import SSOUser, CompaniesHouseClient
-from core.tests.test_views import reload_urlconf, reload_module
 from company import helpers, models, serializers
 from company.tests import (
-    factories, MockInvalidSerializer, MockValidSerializer, VALID_REQUEST_DATA, VALID_SUPPLIER_REQUEST_DATA
+    VALID_REQUEST_DATA,
+    VALID_SUPPLIER_REQUEST_DATA,
+    MockInvalidSerializer,
+    MockValidSerializer,
+    factories,
 )
-
+from core.helpers import CompaniesHouseClient, SSOUser
+from core.tests.test_views import reload_module, reload_urlconf
 
 default_public_profile_data = {
     'name': 'private company',
@@ -63,9 +65,7 @@ def test_company_retrieve_no_company(authed_client, authed_supplier):
 @freeze_time('2016-11-23T11:21:10.977518Z')
 @pytest.mark.django_db
 def test_company_retrieve_view(authed_client, authed_supplier):
-    company = factories.CompanyFactory(
-        name='Test Company', date_of_creation=datetime.date(2000, 10, 10)
-    )
+    company = factories.CompanyFactory(name='Test Company', date_of_creation=datetime.date(2000, 10, 10))
     authed_supplier.company = company
     authed_supplier.save()
 
@@ -201,9 +201,7 @@ def test_company_partial_update(authed_client, authed_supplier):
     authed_supplier.company = company
     authed_supplier.save()
 
-    response = authed_client.patch(
-        reverse('company'), VALID_REQUEST_DATA, format='json'
-    )
+    response = authed_client.patch(reverse('company'), VALID_REQUEST_DATA, format='json')
 
     expected = {
         'company_type': company_types.COMPANIES_HOUSE,
@@ -264,10 +262,7 @@ def test_company_partial_update_no_company(authed_client, authed_supplier):
         'sectors': ['SOFTWARE_AND_COMPUTER_SERVICES'],
         'hs_codes': ['3'],
         'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS],
-        'expertise_countries': [
-            choices.COUNTRY_CHOICES[23][0],
-            choices.COUNTRY_CHOICES[24][0]
-        ],
+        'expertise_countries': [choices.COUNTRY_CHOICES[23][0], choices.COUNTRY_CHOICES[24][0]],
     }
 
     response = authed_client.patch(reverse('company'), data, format='json')
@@ -293,10 +288,7 @@ def test_company_not_update_modified(authed_client, authed_supplier):
     authed_supplier.company = company
     authed_supplier.save()
 
-    data = {
-        **VALID_REQUEST_DATA,
-        'modified': '2013-03-09T23:28:53.977518Z'
-    }
+    data = {**VALID_REQUEST_DATA, 'modified': '2013-03-09T23:28:53.977518Z'}
     for method in [authed_client.put, authed_client.patch]:
         response = method(reverse('company'), data, format='json')
         assert response.status_code == status.HTTP_200_OK
@@ -389,9 +381,7 @@ def api_client():
 @pytest.fixture
 def company():
     return models.Company.objects.create(
-        verified_with_code=True,
-        email_address='test@example.com',
-        **VALID_REQUEST_DATA
+        verified_with_code=True, email_address='test@example.com', **VALID_REQUEST_DATA
     )
 
 
@@ -415,18 +405,14 @@ def public_profile():
 
 @pytest.fixture
 def public_profile_with_case_study():
-    company = factories.CompanyFactory(
-        is_published_find_a_supplier=True
-    )
+    company = factories.CompanyFactory(is_published_find_a_supplier=True)
     factories.CompanyCaseStudyFactory(company=company)
     return company
 
 
 @pytest.fixture
 def public_profile_with_case_studies():
-    company = factories.CompanyFactory(
-        is_published_find_a_supplier=True
-    )
+    company = factories.CompanyFactory(is_published_find_a_supplier=True)
     factories.CompanyCaseStudyFactory(company=company)
     factories.CompanyCaseStudyFactory(company=company)
     return company
@@ -497,18 +483,9 @@ def search_data(settings):
         is_published_find_a_supplier=True,
         keywords='Packs, Hunting, Stark, Teeth',
         expertise_industries=[sectors.AEROSPACE, sectors.AIRPORTS],
-        expertise_regions=[
-            choices.EXPERTISE_REGION_CHOICES[4][0],
-            choices.EXPERTISE_REGION_CHOICES[5][0]
-        ],
-        expertise_languages=[
-            choices.EXPERTISE_LANGUAGES[0][0],
-            choices.EXPERTISE_LANGUAGES[2][0]
-        ],
-        expertise_countries=[
-            choices.COUNTRY_CHOICES[23][0],
-            choices.COUNTRY_CHOICES[24][0]
-        ],
+        expertise_regions=[choices.EXPERTISE_REGION_CHOICES[4][0], choices.EXPERTISE_REGION_CHOICES[5][0]],
+        expertise_languages=[choices.EXPERTISE_LANGUAGES[0][0], choices.EXPERTISE_LANGUAGES[2][0]],
+        expertise_countries=[choices.COUNTRY_CHOICES[23][0], choices.COUNTRY_CHOICES[24][0]],
         expertise_products_services={'other': ['Regulatory', 'Finance', 'IT']},
         id=1,
     )
@@ -534,14 +511,9 @@ def search_data(settings):
         is_published_find_a_supplier=True,
         keywords='Pirates, Ocean, Ship',
         expertise_industries=[sectors.AIRPORTS, sectors.FOOD_AND_DRINK],
-        expertise_regions=[choices.EXPERTISE_REGION_CHOICES[5][0],
-                           choices.EXPERTISE_REGION_CHOICES[8][0]
-                           ],
-        expertise_languages=[choices.EXPERTISE_LANGUAGES[2][0],
-                             choices.EXPERTISE_LANGUAGES[6][0]],
-        expertise_countries=[choices.COUNTRY_CHOICES[24][0],
-                             choices.COUNTRY_CHOICES[27][0]
-                             ],
+        expertise_regions=[choices.EXPERTISE_REGION_CHOICES[5][0], choices.EXPERTISE_REGION_CHOICES[8][0]],
+        expertise_languages=[choices.EXPERTISE_LANGUAGES[2][0], choices.EXPERTISE_LANGUAGES[6][0]],
+        expertise_countries=[choices.COUNTRY_CHOICES[24][0], choices.COUNTRY_CHOICES[27][0]],
         expertise_products_services={'other': ['Regulatory', 'IT']},
         id=3,
     )
@@ -568,9 +540,9 @@ def search_companies_highlighting_data(settings):
             'Providing the stealth and prowess of wolves. This is a very long '
             'thing about wolf stuff. Lets see what happens in the test when '
             'ES encounters a long  description. Perhaps it will concatenate. '
-        ) + ('It is known. ' * 30) + (
-            'The wolf cries at night.'
-        ),
+        )
+        + ('It is known. ' * 30)
+        + ('The wolf cries at night.'),
         summary='Hunts in packs',
         is_published_find_a_supplier=True,
         keywords='Packs, Hunting, Stark, Teeth',
@@ -597,9 +569,9 @@ def search_highlighting_data(settings):
             'Providing the stealth and prowess of wolves. This is a very long '
             'thing about wolf stuff. Lets see what happens in the test when '
             'ES encounters a long  description. Perhaps it will concatenate. '
-        ) + ('It is known. ' * 30) + (
-            'The wolf cries at night.'
-        ),
+        )
+        + ('It is known. ' * 30)
+        + ('The wolf cries at night.'),
         summary='Hunts in packs',
         is_published_find_a_supplier=True,
         is_published_investment_support_directory=True,
@@ -626,9 +598,7 @@ def search_data_and_or(settings):
         expertise_regions=['NORTH_EAST'],
         expertise_countries=['AF'],
         expertise_languages=['ab'],
-        expertise_products_services={
-            'financial': ['Accounting and tax']
-        },
+        expertise_products_services={'financial': ['Accounting and tax']},
         is_published_investment_support_directory=True,
         is_published_find_a_supplier=True,
         id=1,
@@ -639,9 +609,7 @@ def search_data_and_or(settings):
         expertise_regions=['NORTH_WEST'],
         expertise_languages=['aa'],
         expertise_countries=['AL'],
-        expertise_products_services={
-            'management-consulting': ['Business development']
-        },
+        expertise_products_services={'management-consulting': ['Business development']},
         is_published_investment_support_directory=True,
         is_published_find_a_supplier=True,
         id=2,
@@ -655,7 +623,7 @@ def search_data_and_or(settings):
         expertise_products_services={},
         is_published_investment_support_directory=True,
         is_published_find_a_supplier=True,
-        id=3
+        id=3,
     )
     factories.CompanyFactory(
         name='Ultra Wolf',
@@ -663,9 +631,7 @@ def search_data_and_or(settings):
         expertise_regions=['NORTH_WEST'],
         expertise_languages=['aa'],
         expertise_countries=[],
-        expertise_products_services={
-            'management-consulting': ['Business development']
-        },
+        expertise_products_services={'management-consulting': ['Business development']},
         is_published_investment_support_directory=True,
         is_published_find_a_supplier=True,
         id=4,
@@ -676,9 +642,7 @@ def search_data_and_or(settings):
         expertise_regions=['NORTH_WEST'],
         expertise_languages=[],
         expertise_countries=['AL'],
-        expertise_products_services={
-            'management-consulting': ['Business development']
-        },
+        expertise_products_services={'management-consulting': ['Business development']},
         is_published_investment_support_directory=True,
         is_published_find_a_supplier=True,
         id=5,
@@ -689,9 +653,7 @@ def search_data_and_or(settings):
         expertise_regions=[],
         expertise_languages=['aa'],
         expertise_countries=['AL'],
-        expertise_products_services={
-            'management-consulting': ['Business development']
-        },
+        expertise_products_services={'management-consulting': ['Business development']},
         is_published_investment_support_directory=True,
         is_published_find_a_supplier=True,
         id=6,
@@ -702,9 +664,7 @@ def search_data_and_or(settings):
         expertise_regions=['NORTH_WEST'],
         expertise_languages=['aa'],
         expertise_countries=['AL'],
-        expertise_products_services={
-            'management-consulting': ['Business development']
-        },
+        expertise_products_services={'management-consulting': ['Business development']},
         is_published_investment_support_directory=True,
         is_published_find_a_supplier=True,
         id=7,
@@ -715,9 +675,7 @@ def search_data_and_or(settings):
         expertise_regions=['NORTH_WEST'],
         expertise_languages=['aa'],
         expertise_countries=['AL'],
-        expertise_products_services={
-            'management-consulting': ['Business development']
-        },
+        expertise_products_services={'management-consulting': ['Business development']},
         is_published_investment_support_directory=True,
         is_published_find_a_supplier=True,
         id=8,
@@ -728,9 +686,7 @@ def search_data_and_or(settings):
         expertise_regions=['NORTH_WEST'],
         expertise_languages=['aa'],
         expertise_countries=['AL'],
-        expertise_products_services={
-            'management-consulting': ['Business development']
-        },
+        expertise_products_services={'management-consulting': ['Business development']},
         is_published_investment_support_directory=False,  # not published
         is_published_find_a_supplier=False,  # not published
         id=9,
@@ -791,22 +747,10 @@ def search_companies_ordering_data(settings):
     factories.CompanyCaseStudyFactory(company=wolf_two_company)
     factories.CompanyCaseStudyFactory(company=wolf_two_company)
     factories.CompanyCaseStudyFactory(company=wolf_two_company)
-    factories.CompanyCaseStudyFactory(
-        company=wolf_three,
-        title='cannons better than grapeshot',
-        description='guns'
-    )
+    factories.CompanyCaseStudyFactory(company=wolf_three, title='cannons better than grapeshot', description='guns')
     factories.CompanyCaseStudyFactory(company=wolf_three)
-    factories.CompanyCaseStudyFactory(
-        company=grapeshot_company,
-        title='cannons',
-        description='guns'
-    )
-    factories.CompanyCaseStudyFactory(
-        company=grapeshot_company,
-        title='cannons',
-        description='naval guns'
-    )
+    factories.CompanyCaseStudyFactory(company=grapeshot_company, title='cannons', description='guns')
+    factories.CompanyCaseStudyFactory(company=grapeshot_company, title='cannons', description='naval guns')
     Index(settings.ELASTICSEARCH_COMPANY_INDEX_ALIAS).refresh()
 
 
@@ -870,10 +814,7 @@ def search_companies_stopwords(settings):
 
 @pytest.fixture
 def companies_house_oauth_invalid_access_token(requests_mocker):
-    return requests_mocker.get(
-        'https://account.companieshouse.gov.uk/oauth2/verify',
-        status_code=400
-    )
+    return requests_mocker.get('https://account.companieshouse.gov.uk/oauth2/verify', status_code=400)
 
 
 @pytest.fixture
@@ -887,37 +828,33 @@ def companies_house_oauth_wrong_company(requests_mocker, authed_supplier):
         json={
             'scope': scope,
             'expires_in': 6000,
-        }
+        },
     )
 
 
 @pytest.fixture
 def companies_house_oauth_expired_token(requests_mocker, authed_supplier):
-    scope = CompaniesHouseClient.endpoints['profile'].format(
-        number=authed_supplier.company.number
-    )
+    scope = CompaniesHouseClient.endpoints['profile'].format(number=authed_supplier.company.number)
     return requests_mocker.get(
         'https://account.companieshouse.gov.uk/oauth2/verify',
         status_code=200,
         json={
             'scope': scope,
             'expires_in': -1,
-        }
+        },
     )
 
 
 @pytest.fixture
 def companies_house_oauth_valid_token(requests_mocker, authed_supplier):
-    scope = CompaniesHouseClient.endpoints['profile'].format(
-        number=authed_supplier.company.number
-    )
+    scope = CompaniesHouseClient.endpoints['profile'].format(number=authed_supplier.company.number)
     return requests_mocker.get(
         'https://account.companieshouse.gov.uk/oauth2/verify',
         status_code=200,
         json={
             'scope': scope,
             'expires_in': 6000,
-        }
+        },
     )
 
 
@@ -945,20 +882,14 @@ def test_company_case_study_create(
     authed_supplier.company = company
     authed_supplier.save()
 
-    response = authed_client.post(
-        reverse('company-case-study'), case_study_data, format='multipart'
-    )
+    response = authed_client.post(reverse('company-case-study'), case_study_data, format='multipart')
     assert response.status_code == http.client.CREATED
 
     instance = models.CompanyCaseStudy.objects.get(pk=response.data['pk'])
     assert instance.testimonial == case_study_data['testimonial']
     assert instance.testimonial_name == case_study_data['testimonial_name']
-    assert instance.testimonial_job_title == (
-        case_study_data['testimonial_job_title']
-    )
-    assert instance.testimonial_company == (
-        case_study_data['testimonial_company']
-    )
+    assert instance.testimonial_job_title == (case_study_data['testimonial_job_title'])
+    assert instance.testimonial_company == (case_study_data['testimonial_company'])
     assert instance.website == case_study_data['website']
     assert instance.company == company
     assert instance.description == case_study_data['description']
@@ -987,9 +918,7 @@ def test_company_case_study_create_invalid_image(authed_client, authed_supplier,
         'testimonial_job_title': 'Evil overlord',
         'testimonial_company': 'Death Eaters',
     }
-    response = authed_client.post(
-        reverse('company-case-study'), case_study_data, format='multipart'
-    )
+    response = authed_client.post(reverse('company-case-study'), case_study_data, format='multipart')
 
     assert response.status_code == http.client.BAD_REQUEST
 
@@ -1014,9 +943,7 @@ def test_company_case_study_create_not_an_image(video, authed_client, authed_sup
         'testimonial_job_title': 'Evil overlord',
         'testimonial_company': 'Death Eaters',
     }
-    response = authed_client.post(
-        reverse('company-case-study'), case_study_data, format='multipart'
-    )
+    response = authed_client.post(reverse('company-case-study'), case_study_data, format='multipart')
 
     assert response.status_code == http.client.BAD_REQUEST
 
@@ -1045,14 +972,10 @@ def test_company_case_study_create_company_not_published(video, authed_client, a
         'testimonial_job_title': 'Evil overlord',
         'testimonial_company': 'Death Eaters',
     }
-    response = authed_client.post(
-        reverse('company-case-study'), case_study_data, format='multipart'
-    )
+    response = authed_client.post(reverse('company-case-study'), case_study_data, format='multipart')
     assert response.status_code == http.client.CREATED
 
-    url = reverse(
-        'public-case-study-detail', kwargs={'pk': response.data['pk']}
-    )
+    url = reverse('public-case-study-detail', kwargs={'pk': response.data['pk']})
     response = authed_client.get(url)
 
     assert response.status_code == http.client.NOT_FOUND
@@ -1065,9 +988,7 @@ def test_company_case_study_update(
     authed_supplier.company = company_user_case_study.company
     authed_supplier.save()
 
-    url = reverse(
-        'company-case-study-detail', kwargs={'pk': company_user_case_study.pk}
-    )
+    url = reverse('company-case-study-detail', kwargs={'pk': company_user_case_study.pk})
     data = {'title': '2015'}
 
     assert company_user_case_study.title != data['title']
@@ -1085,9 +1006,7 @@ def test_company_case_study_delete(company_user_case_study, authed_supplier, aut
     authed_supplier.save()
 
     pk = company_user_case_study.pk
-    url = reverse(
-        'company-case-study-detail', kwargs={'pk': pk}
-    )
+    url = reverse('company-case-study-detail', kwargs={'pk': pk})
 
     response = authed_client.delete(url)
 
@@ -1100,9 +1019,7 @@ def test_company_case_study_get(company_user_case_study, authed_supplier, authed
     authed_supplier.company = company_user_case_study.company
     authed_supplier.save()
 
-    url = reverse(
-        'company-case-study-detail', kwargs={'pk': company_user_case_study.pk}
-    )
+    url = reverse('company-case-study-detail', kwargs={'pk': company_user_case_study.pk})
 
     response = authed_client.get(url)
     data = response.json()
@@ -1110,12 +1027,8 @@ def test_company_case_study_get(company_user_case_study, authed_supplier, authed
     assert response.status_code == http.client.OK
     assert data['testimonial'] == company_user_case_study.testimonial
     assert data['testimonial_name'] == company_user_case_study.testimonial_name
-    assert data['testimonial_job_title'] == (
-        company_user_case_study.testimonial_job_title
-    )
-    assert data['testimonial_company'] == (
-        company_user_case_study.testimonial_company
-    )
+    assert data['testimonial_job_title'] == company_user_case_study.testimonial_job_title
+    assert data['testimonial_company'] == company_user_case_study.testimonial_company
     assert data['website'] == company_user_case_study.website
     assert data['description'] == company_user_case_study.description
     assert data['title'] == company_user_case_study.title
@@ -1131,9 +1044,7 @@ def test_public_company_case_study_get(company_user_case_study, supplier, api_cl
     company.is_published_investment_support_directory = True
     company.save()
 
-    url = reverse(
-        'public-case-study-detail', kwargs={'pk': company_user_case_study.pk}
-    )
+    url = reverse('public-case-study-detail', kwargs={'pk': company_user_case_study.pk})
 
     response = api_client.get(url)
     data = response.json()
@@ -1141,12 +1052,8 @@ def test_public_company_case_study_get(company_user_case_study, supplier, api_cl
     assert response.status_code == http.client.OK
     assert data['testimonial'] == company_user_case_study.testimonial
     assert data['testimonial_name'] == company_user_case_study.testimonial_name
-    assert data['testimonial_job_title'] == (
-        company_user_case_study.testimonial_job_title
-    )
-    assert data['testimonial_company'] == (
-        company_user_case_study.testimonial_company
-    )
+    assert data['testimonial_job_title'] == (company_user_case_study.testimonial_job_title)
+    assert data['testimonial_company'] == (company_user_case_study.testimonial_company)
     assert data['website'] == company_user_case_study.website
     assert data['description'] == company_user_case_study.description
     assert data['title'] == company_user_case_study.title
@@ -1162,22 +1069,20 @@ def test_public_company_case_study_get(company_user_case_study, supplier, api_cl
         [True, False],
         [False, True],
         [True, True],
-    ]
+    ],
 )
 @pytest.mark.django_db
 def test_company_profile_public_retrieve_public_profile(
-    is_investment_support_directory, is_find_a_supplier, public_profile, api_client,
+    is_investment_support_directory,
+    is_find_a_supplier,
+    public_profile,
+    api_client,
 ):
-    public_profile.is_published_investment_support_directory = (
-        is_investment_support_directory)
-    public_profile.is_published_find_a_supplier = (
-        is_find_a_supplier)
+    public_profile.is_published_investment_support_directory = is_investment_support_directory
+    public_profile.is_published_find_a_supplier = is_find_a_supplier
 
     public_profile.save()
-    url = reverse(
-        'company-public-profile-detail',
-        kwargs={'companies_house_number': public_profile.number}
-    )
+    url = reverse('company-public-profile-detail', kwargs={'companies_house_number': public_profile.number})
     response = api_client.get(url)
 
     assert response.status_code == http.client.OK
@@ -1186,10 +1091,7 @@ def test_company_profile_public_retrieve_public_profile(
 
 @pytest.mark.django_db
 def test_company_profile_public_404_private_profile(private_profile, api_client):
-    url = reverse(
-        'company-public-profile-detail',
-        kwargs={'companies_house_number': private_profile.number}
-    )
+    url = reverse('company-public-profile-detail', kwargs={'companies_house_number': private_profile.number})
     response = api_client.get(url)
 
     assert response.status_code == http.client.NOT_FOUND
@@ -1198,20 +1100,22 @@ def test_company_profile_public_404_private_profile(private_profile, api_client)
 @pytest.mark.django_db
 def test_verify_company_with_code(authed_client, authed_supplier, settings):
     with mock.patch('requests.post'):
-        company = models.Company.objects.create(**{
-            'number': '11234567',
-            'name': 'Test Company',
-            'website': 'http://example.com',
-            'description': 'Company description',
-            'has_exported_before': True,
-            'date_of_creation': '2010-10-10',
-            'postal_full_name': 'test_full_name',
-            'address_line_1': 'test_address_line_1',
-            'address_line_2': 'test_address_line_2',
-            'locality': 'test_locality',
-            'postal_code': 'test_postal_code',
-            'country': 'test_country',
-        })
+        company = models.Company.objects.create(
+            **{
+                'number': '11234567',
+                'name': 'Test Company',
+                'website': 'http://example.com',
+                'description': 'Company description',
+                'has_exported_before': True,
+                'date_of_creation': '2010-10-10',
+                'postal_full_name': 'test_full_name',
+                'address_line_1': 'test_address_line_1',
+                'address_line_2': 'test_address_line_2',
+                'locality': 'test_locality',
+                'postal_code': 'test_postal_code',
+                'country': 'test_country',
+            }
+        )
 
     authed_supplier.company = company
     authed_supplier.save()
@@ -1220,9 +1124,7 @@ def test_verify_company_with_code(authed_client, authed_supplier, settings):
     assert company.verification_code
 
     url = reverse('company-verify')
-    response = authed_client.post(
-        url, {'code': company.verification_code}, format='json'
-    )
+    response = authed_client.post(url, {'code': company.verification_code}, format='json')
 
     assert response.status_code == http.client.OK
 
@@ -1233,29 +1135,29 @@ def test_verify_company_with_code(authed_client, authed_supplier, settings):
 @pytest.mark.django_db
 def test_verify_company_with_code_invalid_code(authed_client, authed_supplier, settings):
     with mock.patch('requests.post'):
-        company = models.Company.objects.create(**{
-            'number': '11234567',
-            'name': 'Test Company',
-            'website': 'http://example.com',
-            'description': 'Company description',
-            'has_exported_before': True,
-            'date_of_creation': '2010-10-10',
-            'postal_full_name': 'test_full_name',
-            'address_line_1': 'test_address_line_1',
-            'address_line_2': 'test_address_line_2',
-            'locality': 'test_locality',
-            'postal_code': 'test_postal_code',
-            'country': 'test_country',
-        })
+        company = models.Company.objects.create(
+            **{
+                'number': '11234567',
+                'name': 'Test Company',
+                'website': 'http://example.com',
+                'description': 'Company description',
+                'has_exported_before': True,
+                'date_of_creation': '2010-10-10',
+                'postal_full_name': 'test_full_name',
+                'address_line_1': 'test_address_line_1',
+                'address_line_2': 'test_address_line_2',
+                'locality': 'test_locality',
+                'postal_code': 'test_postal_code',
+                'country': 'test_country',
+            }
+        )
 
     authed_supplier.company = company
     authed_supplier.save()
 
     company.refresh_from_db()
     assert company.verification_code
-    response = authed_client.post(
-         reverse('company-verify'), {'code': 'invalid'}, format='json'
-    )
+    response = authed_client.post(reverse('company-verify'), {'code': 'invalid'}, format='json')
 
     assert response.status_code == http.client.BAD_REQUEST
 
@@ -1294,9 +1196,19 @@ def test_search(mock_get_search_results, url, api_client):
 
 @pytest.mark.rebuild_elasticsearch
 @pytest.mark.parametrize('url', search_urls)
-@pytest.mark.parametrize('page_number,expected_start', [
-    [1, 0], [2, 5], [3, 10], [4, 15], [5, 20], [6, 25], [7, 30], [8, 35],
-])
+@pytest.mark.parametrize(
+    'page_number,expected_start',
+    [
+        [1, 0],
+        [2, 5],
+        [3, 10],
+        [4, 15],
+        [5, 20],
+        [6, 25],
+        [7, 30],
+        [8, 35],
+    ],
+)
 def test_search_paginate_first_page(url, page_number, expected_start, api_client, settings):
     es = connections.get_connection('default')
     with mock.patch.object(es, 'search', return_value={}) as mock_search:
@@ -1353,9 +1265,7 @@ def test_search_wildcard_filters_multiple(url, api_client, settings):
     with mock.patch.object(es, 'search', return_value={}):
         data = {
             'term': 'bees',
-            'expertise_industries': [
-                sectors.ADVANCED_MANUFACTURING,
-                sectors.AIRPORTS],
+            'expertise_industries': [sectors.ADVANCED_MANUFACTURING, sectors.AIRPORTS],
             'expertise_products_services_labels': ['IT', 'REGULATION'],
             'size': 5,
             'page': 1,
@@ -1368,88 +1278,65 @@ def test_search_wildcard_filters_multiple(url, api_client, settings):
 @pytest.mark.rebuild_elasticsearch
 @pytest.mark.django_db
 @pytest.mark.parametrize('url', search_urls)
-@pytest.mark.parametrize('term,filter_name,filter_value ,expected', [
-    # term
-    ['Wolf', '', '', ['1']],
-    ['Tongue', '', '', ['2']],
-    ['common', '', '', ['1', '2', '3']],
-    ['common', 'expertise_industries', [sectors.AEROSPACE], ['1', '2']],
-    # expertise_industries
-    ['', 'expertise_industries', [sectors.AEROSPACE], ['1', '2']],
+@pytest.mark.parametrize(
+    'term,filter_name,filter_value ,expected',
     [
-        '',
-        'expertise_industries',
-        [sectors.AEROSPACE, sectors.AIRPORTS],
-        ['1', '2', '3'],
-    ],
-    # expertise_industries via q
-    [sectors.AEROSPACE, '', '', ['1', '2']],
-    # expertise_products_services_labels via q
-    ['Regulatory', '', '', ['1', '2', '3']],
-    [
-        '',
-        'expertise_industries',
-        [sectors.AEROSPACE, sectors.AIRPORTS],
-        ['1', '2', '3']
-    ],
-    # expertise_regions
-    [
-        '',
-        'expertise_regions',
-        [choices.EXPERTISE_REGION_CHOICES[4][0]],
-        ['1', '2']
-    ],
-    [
-        '',
-        'expertise_regions',
+        # term
+        ['Wolf', '', '', ['1']],
+        ['Tongue', '', '', ['2']],
+        ['common', '', '', ['1', '2', '3']],
+        ['common', 'expertise_industries', [sectors.AEROSPACE], ['1', '2']],
+        # expertise_industries
+        ['', 'expertise_industries', [sectors.AEROSPACE], ['1', '2']],
         [
-            choices.EXPERTISE_REGION_CHOICES[4][0],
-            choices.EXPERTISE_REGION_CHOICES[5][0],
+            '',
+            'expertise_industries',
+            [sectors.AEROSPACE, sectors.AIRPORTS],
+            ['1', '2', '3'],
         ],
-        ['1', '2', '3']
-    ],
-    # expertise_languages
-    [
-        '',
-        'expertise_languages',
-        [choices.EXPERTISE_LANGUAGES[0][0]],
-        ['1', '2'],
-    ],
-    [
-        '',
-        'expertise_languages',
+        # expertise_industries via q
+        [sectors.AEROSPACE, '', '', ['1', '2']],
+        # expertise_products_services_labels via q
+        ['Regulatory', '', '', ['1', '2', '3']],
+        ['', 'expertise_industries', [sectors.AEROSPACE, sectors.AIRPORTS], ['1', '2', '3']],
+        # expertise_regions
+        ['', 'expertise_regions', [choices.EXPERTISE_REGION_CHOICES[4][0]], ['1', '2']],
         [
-            choices.EXPERTISE_LANGUAGES[0][0],
-            choices.EXPERTISE_LANGUAGES[2][0]
+            '',
+            'expertise_regions',
+            [
+                choices.EXPERTISE_REGION_CHOICES[4][0],
+                choices.EXPERTISE_REGION_CHOICES[5][0],
+            ],
+            ['1', '2', '3'],
         ],
-        ['1', '2', '3']
-    ],
-    # expertise_countries
-    ['', 'expertise_countries', [choices.COUNTRY_CHOICES[23][0]], ['1', '2']],
-    [
-        '',
-        'expertise_countries',
+        # expertise_languages
         [
-            choices.COUNTRY_CHOICES[23][0],
-            choices.COUNTRY_CHOICES[24][0]
+            '',
+            'expertise_languages',
+            [choices.EXPERTISE_LANGUAGES[0][0]],
+            ['1', '2'],
         ],
-        ['1', '2', '3']
+        [
+            '',
+            'expertise_languages',
+            [choices.EXPERTISE_LANGUAGES[0][0], choices.EXPERTISE_LANGUAGES[2][0]],
+            ['1', '2', '3'],
+        ],
+        # expertise_countries
+        ['', 'expertise_countries', [choices.COUNTRY_CHOICES[23][0]], ['1', '2']],
+        ['', 'expertise_countries', [choices.COUNTRY_CHOICES[23][0], choices.COUNTRY_CHOICES[24][0]], ['1', '2', '3']],
+        # expertise_products_services
+        ['', 'expertise_products_services_labels', ['Finance'], ['1', '2']],
+        ['', 'expertise_products_services_labels', ['Finance', 'IT'], ['1', '2', '3']],
     ],
-    # expertise_products_services
-    ['', 'expertise_products_services_labels', ['Finance'], ['1', '2']],
-    [
-        '',
-        'expertise_products_services_labels',
-        ['Finance', 'IT'],
-        ['1', '2', '3']
-    ],
-])
+)
 def test_search_results(url, term, filter_name, filter_value, expected, search_data, api_client):
     data = {
         'term': term,
         'page': '1',
         'size': '5',
-        filter_name:  filter_value,
+        filter_name: filter_value,
     }
 
     response = api_client.get(url, data=data)
@@ -1486,12 +1373,15 @@ def test_search_results_stopwords(url, stop_term, search_companies_stopwords, ap
 @pytest.mark.parametrize('url', search_urls)
 @pytest.mark.rebuild_elasticsearch
 @pytest.mark.django_db
-@pytest.mark.parametrize('term, expected', [
-    [sectors.AEROSPACE, ['1', '2']],
-    [choices.COUNTRY_CHOICES[23][0], ['1', '2']],
-    [choices.EXPERTISE_REGION_CHOICES[4][0], ['1', '2']],
-    [choices.EXPERTISE_LANGUAGES[0][0], ['1', '2']],
-])
+@pytest.mark.parametrize(
+    'term, expected',
+    [
+        [sectors.AEROSPACE, ['1', '2']],
+        [choices.COUNTRY_CHOICES[23][0], ['1', '2']],
+        [choices.EXPERTISE_REGION_CHOICES[4][0], ['1', '2']],
+        [choices.EXPERTISE_LANGUAGES[0][0], ['1', '2']],
+    ],
+)
 def test_search_term_expertise(url, term, expected, search_data, api_client):
 
     data = {
@@ -1512,75 +1402,71 @@ def test_search_term_expertise(url, term, expected, search_data, api_client):
 
 
 @pytest.mark.parametrize('url', search_urls)
-@pytest.mark.parametrize('filters,expected', [
-    (
-        {
-            'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS],
-            'expertise_regions': ['NORTH_EAST', 'NORTH_WEST'],
-            'expertise_countries': [
-                'AF',  # Afghanistan
-                'AL',  # Albania
-            ],
-            'expertise_languages': [
-                'ab',  # Abkhazian
-                'aa',  # Afar
-            ],
-            'expertise_products_services_labels': [
-                'Accounting and tax',    # from financial filter
-                'Business development',  # from management consulting filter
-            ],
-
-        },
-        ['1', '2']
-    ),
-    (
-        {
-            'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS],
-            'expertise_regions': ['NORTH_EAST', 'NORTH_WEST'],
-            'expertise_languages': [
-                'ab',  # Abkhazian
-                'aa',  # Afar
-            ],
-            'expertise_products_services_labels': [
-                'Accounting and tax',    # from financial filter
-                'Business development',  # from management consulting filter
-            ],
-        },
-        ['1', '2', '4']
-    ),
-    (
-        {
-            'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS],
-            'expertise_languages': [
-                'ab',  # Abkhazian
-                'aa',  # Afar
-            ],
-            'expertise_products_services_labels': [
-                'Accounting and tax',    # from financial filter
-                'Business development',  # from management consulting filter
-            ],
-        },
-        ['1', '2', '4', '6']
-    ),
-    (
-        {
-            'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS],
-            'expertise_languages': [
-                'ab',  # Abkhazian
-                'aa',  # Afar
-            ],
-        },
-        ['1', '2', '3', '4', '6']
-    ),
-    (
-        {'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS]},
-        ['1', '2', '3', '4', '5', '6']
-    ),
-    (
-        {},
-        ['1', '2', '3', '4', '5', '6', '7']
-    ),
-])
+@pytest.mark.parametrize(
+    'filters,expected',
+    [
+        (
+            {
+                'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS],
+                'expertise_regions': ['NORTH_EAST', 'NORTH_WEST'],
+                'expertise_countries': [
+                    'AF',  # Afghanistan
+                    'AL',  # Albania
+                ],
+                'expertise_languages': [
+                    'ab',  # Abkhazian
+                    'aa',  # Afar
+                ],
+                'expertise_products_services_labels': [
+                    'Accounting and tax',  # from financial filter
+                    'Business development',  # from management consulting filter
+                ],
+            },
+            ['1', '2'],
+        ),
+        (
+            {
+                'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS],
+                'expertise_regions': ['NORTH_EAST', 'NORTH_WEST'],
+                'expertise_languages': [
+                    'ab',  # Abkhazian
+                    'aa',  # Afar
+                ],
+                'expertise_products_services_labels': [
+                    'Accounting and tax',  # from financial filter
+                    'Business development',  # from management consulting filter
+                ],
+            },
+            ['1', '2', '4'],
+        ),
+        (
+            {
+                'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS],
+                'expertise_languages': [
+                    'ab',  # Abkhazian
+                    'aa',  # Afar
+                ],
+                'expertise_products_services_labels': [
+                    'Accounting and tax',  # from financial filter
+                    'Business development',  # from management consulting filter
+                ],
+            },
+            ['1', '2', '4', '6'],
+        ),
+        (
+            {
+                'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS],
+                'expertise_languages': [
+                    'ab',  # Abkhazian
+                    'aa',  # Afar
+                ],
+            },
+            ['1', '2', '3', '4', '6'],
+        ),
+        ({'expertise_industries': [sectors.AEROSPACE, sectors.AIRPORTS]}, ['1', '2', '3', '4', '5', '6']),
+        ({}, ['1', '2', '3', '4', '5', '6', '7']),
+    ],
+)
 @pytest.mark.rebuild_elasticsearch
 @pytest.mark.django_db
 def test_search_filter_and_or(url, filters, expected, api_client, search_data_and_or):
@@ -1608,23 +1494,10 @@ def test_search_filter_and_or_single(url, api_client, settings):
         name='Wolf limited',
         is_published_investment_support_directory=True,
         expertise_products_services={
-            'Legal': [
-                'Company incorporation',
-                'Employment',
-                'Immigration'
-            ],
-            'Human Resources': [
-                'Staff onboarding',
-                'Employment and talent research'
-            ],
-            'Business Support': [
-                'Business relocation',
-                'Staff and family relocation'
-            ],
-            'Management Consulting': [
-                'Workforce development',
-                'Strategy and long-term planning'
-            ]
+            'Legal': ['Company incorporation', 'Employment', 'Immigration'],
+            'Human Resources': ['Staff onboarding', 'Employment and talent research'],
+            'Business Support': ['Business relocation', 'Staff and family relocation'],
+            'Management Consulting': ['Workforce development', 'Strategy and long-term planning'],
         },
         expertise_languages=['en,', 'zh', 'fr', 'es', 'pa', 'hi', 'pt', 'ar'],
         expertise_countries=['CN', 'IN', 'PK', 'US', 'ZA', 'EG', 'BR'],
@@ -1649,7 +1522,7 @@ def test_search_filter_and_or_single(url, api_client, settings):
             'Food and drink',
             'Healthcare and medical',
             'Software and computer services',
-            'Retail and luxury'
+            'Retail and luxury',
         ],
         id=1,
     )
@@ -1658,10 +1531,7 @@ def test_search_filter_and_or_single(url, api_client, settings):
     data = {
         'expertise_regions': ['NORTH_EAST'],
         'expertise_languages': ['es'],
-        'expertise_products_services_labels': [
-            'Accounting and tax',
-            'Regulatory support'
-        ],
+        'expertise_products_services_labels': ['Accounting and tax', 'Regulatory support'],
         'page': '1',
         'size': '10',
     }
@@ -1682,22 +1552,10 @@ def test_search_filter_partial_match(url, api_client, settings):
         name='Wolf limited',
         is_published_investment_support_directory=True,
         expertise_products_services={
-            'Legal': [
-                'Company incorporation',
-                'Immigration'
-            ],
-            'Human Resources': [
-                'Staff onboarding',
-                'Employment and talent research'
-            ],
-            'Business Support': [
-                'Business relocation',
-                'Staff and family relocation'
-            ],
-            'Management Consulting': [
-                'Workforce development',
-                'Strategy and long-term planning'
-            ]
+            'Legal': ['Company incorporation', 'Immigration'],
+            'Human Resources': ['Staff onboarding', 'Employment and talent research'],
+            'Business Support': ['Business relocation', 'Staff and family relocation'],
+            'Management Consulting': ['Workforce development', 'Strategy and long-term planning'],
         },
         expertise_languages=['en,', 'zh', 'fr', 'es', 'pa', 'hi', 'pt', 'ar'],
         expertise_countries=['CN', 'IN', 'PK', 'US', 'ZA', 'EG', 'BR'],
@@ -1722,7 +1580,7 @@ def test_search_filter_partial_match(url, api_client, settings):
             'Food and drink',
             'Healthcare and medical',
             'Software and computer services',
-            'Retail and luxury'
+            'Retail and luxury',
         ],
         id=1,
     )
@@ -1965,17 +1823,17 @@ def test_search_results_highlight(url, search_highlighting_data, api_client):
     results = response.json()
     hits = results['hits']['hits']
 
-    assert hits[0]['highlight'] == {
-        'description': [
-            'Providing the <em>power</em> and beauty of Aardvarks.'
-        ]
-    }
+    assert hits[0]['highlight'] == {'description': ['Providing the <em>power</em> and beauty of Aardvarks.']}
 
 
 @pytest.mark.django_db
 @pytest.mark.rebuild_elasticsearch
 @pytest.mark.parametrize('url', search_urls)
-def test_search_results_highlight_long(url, search_highlighting_data, api_client,):
+def test_search_results_highlight_long(
+    url,
+    search_highlighting_data,
+    api_client,
+):
     data = {
         'term': 'wolf',
         'page': 1,
@@ -1990,7 +1848,7 @@ def test_search_results_highlight_long(url, search_highlighting_data, api_client
 
     assert hits[0]['highlight']['description'] == [
         'This is a very long thing about <em>wolf</em> stuff.',
-        'The <em>wolf</em> cries at night.'
+        'The <em>wolf</em> cries at night.',
     ]
 
 
@@ -2015,9 +1873,7 @@ def test_verify_companies_house_invalid_access_token(
     response = authed_client.post(url, {'access_token': '123'})
 
     assert response.status_code == 400
-    assert response.json() == {
-        'access_token': [serializer.MESSAGE_BAD_ACCESS_TOKEN]
-    }
+    assert response.json() == {'access_token': [serializer.MESSAGE_BAD_ACCESS_TOKEN]}
     company = authed_supplier.company
     company.refresh_from_db()
     assert company.verified_with_companies_house_oauth2 is False
@@ -2032,9 +1888,7 @@ def test_verify_companies_house_wrong_company_access_token(
     response = authed_client.post(url, {'access_token': '123'})
 
     assert response.status_code == 400
-    assert response.json() == {
-        'access_token': [serializer.MESSAGE_SCOPE_ERROR]
-    }
+    assert response.json() == {'access_token': [serializer.MESSAGE_SCOPE_ERROR]}
     company = authed_supplier.company
     company.refresh_from_db()
     assert company.verified_with_companies_house_oauth2 is False
@@ -2049,9 +1903,7 @@ def test_verify_companies_house_expired_access_token(
     response = authed_client.post(url, {'access_token': '123'})
 
     assert response.status_code == 400
-    assert response.json() == {
-        'access_token': [serializer.MESSAGE_EXPIRED]
-    }
+    assert response.json() == {'access_token': [serializer.MESSAGE_EXPIRED]}
     company = authed_supplier.company
     company.refresh_from_db()
     assert company.verified_with_companies_house_oauth2 is False
@@ -2135,7 +1987,7 @@ def test_collaboration_request_create(authed_supplier, authed_client):
     url = reverse('collaborator-request')
     data = {
         'role': user_roles.ADMIN,
-     }
+    }
     response = authed_client.post(url, data, format='json')
     assert response.status_code == 201
     collaboration_request = models.CollaborationRequest.objects.get(requestor=authed_supplier)
@@ -2152,15 +2004,15 @@ def test_collaboration_request_list(authed_supplier, authed_client):
     response = authed_client.get(reverse('collaborator-request'))
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == [
-            {
-                'uuid': str(collaboration_request.uuid),
-                'requestor': collaboration_request.requestor.id,
-                'requestor_sso_id': collaboration_request.requestor.sso_id,
-                'name': collaboration_request.name,
-                'role': collaboration_request.role,
-                'accepted': False,
-                'accepted_date': None
-            }
+        {
+            'uuid': str(collaboration_request.uuid),
+            'requestor': collaboration_request.requestor.id,
+            'requestor_sso_id': collaboration_request.requestor.sso_id,
+            'name': collaboration_request.name,
+            'role': collaboration_request.role,
+            'accepted': False,
+            'accepted_date': None,
+        }
     ]
 
 
@@ -2226,7 +2078,8 @@ def test_request_identity_verification(mock_send_request_identity_message, authe
 @pytest.mark.django_db
 def test_add_collaborator_view(authed_client):
     company = factories.CompanyFactory(
-        name='Test Company', date_of_creation=datetime.date(2000, 10, 10),
+        name='Test Company',
+        date_of_creation=datetime.date(2000, 10, 10),
     )
     data = {
         'sso_id': 300,
@@ -2237,10 +2090,7 @@ def test_add_collaborator_view(authed_client):
     }
 
     url = reverse('register-company-collaborator-request')
-    response = authed_client.post(
-        url,
-        data=data
-    )
+    response = authed_client.post(url, data=data)
 
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json() == {**data, 'role': user_roles.ADMIN}
@@ -2322,7 +2172,7 @@ def test_collaboration_invite_update(authed_client, authed_supplier):
         'company_user': invite.company_user.pk,
         'accepted_date': mock.ANY,
         'role': invite.role,
-        'accepted': True
+        'accepted': True,
     }
     company_user = models.CompanyUser.objects.get(company_email=invite.collaborator_email)
     assert company_user.company == invite.company
@@ -2393,9 +2243,7 @@ def test_company_user_retrieve(authed_client, authed_supplier):
 
 @pytest.mark.django_db
 def test_company_user_update(authed_client, authed_supplier):
-    response = authed_client.patch(
-        reverse('supplier'), {'company_email': 'a@b.co'}, format='json'
-    )
+    response = authed_client.patch(reverse('supplier'), {'company_email': 'a@b.co'}, format='json')
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json()['company_email'] == 'a@b.co'
@@ -2420,14 +2268,7 @@ def test_gecko_num_registered_company_user_view_returns_correct_json():
 
     response = client.get(reverse('gecko-total-registered-suppliers'))
 
-    expected = {
-        "item": [
-            {
-              "value": 1,
-              "text": "Total registered company users"
-            }
-          ]
-    }
+    expected = {"item": [{"value": 1, "text": "Total registered company users"}]}
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == expected
 
@@ -2445,8 +2286,7 @@ def test_gecko_num_registered_company_user_view_requires_auth():
 def test_gecko_num_registered_company_user_view_rejects_incorrect_creds():
     client = APIClient()
     # correct creds are gecko:X
-    encoded_creds = base64.b64encode(
-        'user:pass'.encode('ascii')).decode("ascii")
+    encoded_creds = base64.b64encode('user:pass'.encode('ascii')).decode("ascii")
     client.credentials(HTTP_AUTHORIZATION='Basic ' + encoded_creds)
 
     response = client.get(reverse('gecko-total-registered-suppliers'))
@@ -2467,9 +2307,7 @@ def test_unsubscribe_company_user(mock_task, authed_client, authed_supplier):
 
 @pytest.mark.django_db
 @mock.patch('notifications.notifications.company_user_unsubscribed')
-def test_unsubscribe_company_user_email_confirmation(
-    mock_company_user_unsubscribed, authed_client, authed_supplier
-):
+def test_unsubscribe_company_user_email_confirmation(mock_company_user_unsubscribed, authed_client, authed_supplier):
     authed_client.post(reverse('unsubscribe-supplier'))
 
     mock_company_user_unsubscribed.assert_called_once_with(company_user=authed_supplier)
@@ -2509,11 +2347,7 @@ def test_external_company_user_details_get_sso_auth(authed_client, authed_suppli
 
 @pytest.mark.django_db
 def test_external_company_user_details_post(authed_client):
-    response = authed_client.post(
-        reverse('external-supplier-details'),
-        {},
-        HTTP_AUTHORIZATION='Bearer 123'
-    )
+    response = authed_client.post(reverse('external-supplier-details'), {}, HTTP_AUTHORIZATION='Bearer 123')
 
     assert response.status_code == 405
 
@@ -2522,11 +2356,7 @@ def test_external_company_user_details_post(authed_client):
 def test_external_company_user_details_get_no_supplier(authed_client, authed_supplier):
     authed_supplier.delete()
 
-    response = authed_client.get(
-        reverse('external-supplier-details'),
-        {},
-        HTTP_AUTHORIZATION='Bearer 123'
-    )
+    response = authed_client.get(reverse('external-supplier-details'), {}, HTTP_AUTHORIZATION='Bearer 123')
 
     assert response.status_code == 404
 
@@ -2599,9 +2429,7 @@ def test_company_collaborators_profile_owner_collaborators(authed_supplier, auth
     response = authed_client.get(url)
 
     assert response.status_code == 200
-    assert response.json() == [
-        serializers.CompanyUserSerializer(authed_supplier).data
-    ]
+    assert response.json() == [serializers.CompanyUserSerializer(authed_supplier).data]
 
 
 @pytest.mark.django_db
@@ -2616,21 +2444,14 @@ def test_company_user_csv_dump(mocked_get_file_from_s3, authed_client):
 
     mocked_body = mock.Mock()
     mocked_body.read.return_value = b'company_name\r\nacme\r\n'
-    mocked_get_file_from_s3.return_value = {
-        'Body': mocked_body
-    }
-    response = authed_client.get(
-        reverse('supplier-csv-dump'),
-        {'token': settings.CSV_DUMP_AUTH_TOKEN}
-    )
+    mocked_get_file_from_s3.return_value = {'Body': mocked_body}
+    response = authed_client.get(reverse('supplier-csv-dump'), {'token': settings.CSV_DUMP_AUTH_TOKEN})
     assert response.status_code == status.HTTP_200_OK
     assert response.content == b'company_name\r\nacme\r\n'
     assert response._headers['content-type'] == ('Content-Type', 'text/csv')
     assert response._headers['content-disposition'] == (
         'Content-Disposition',
-        'attachment; filename="{filename}"'.format(
-            filename=settings.SUPPLIERS_CSV_FILE_NAME
-        )
+        'attachment; filename="{filename}"'.format(filename=settings.SUPPLIERS_CSV_FILE_NAME),
     )
 
 
@@ -2681,11 +2502,10 @@ def test_company_user_retrieve_sso_id(client):
 @pytest.mark.django_db
 def test_company_delete_endpoint_signal_user(authed_client, authed_supplier):
     response = authed_client.delete(
-        reverse('company-delete-by-sso-id',
-                kwargs={
-                    'sso_id': authed_supplier.sso_id,
-                    'request_key': settings.DIRECTORY_SSO_API_SECRET
-                })
+        reverse(
+            'company-delete-by-sso-id',
+            kwargs={'sso_id': authed_supplier.sso_id, 'request_key': settings.DIRECTORY_SSO_API_SECRET},
+        )
     )
     assert response.status_code == 204
 
@@ -2702,11 +2522,10 @@ def test_company_delete_endpoint_multiple_users(authed_client, authed_supplier):
     assert authed_supplier.company.company_users.all().count() == 3
 
     response = authed_client.delete(
-        reverse('company-delete-by-sso-id',
-                kwargs={
-                    'sso_id': authed_supplier.sso_id,
-                    'request_key': settings.DIRECTORY_SSO_API_SECRET
-                })
+        reverse(
+            'company-delete-by-sso-id',
+            kwargs={'sso_id': authed_supplier.sso_id, 'request_key': settings.DIRECTORY_SSO_API_SECRET},
+        )
     )
     assert response.status_code == 204
 
@@ -2726,11 +2545,7 @@ def test_company_delete_endpoint_multiple_users(authed_client, authed_supplier):
 @pytest.mark.django_db
 def test_company_delete_endpoint_for_random_user(authed_client):
     response = authed_client.delete(
-        reverse('company-delete-by-sso-id',
-                kwargs={
-                    'sso_id': 999,
-                    'request_key': settings.DIRECTORY_SSO_API_SECRET
-                })
+        reverse('company-delete-by-sso-id', kwargs={'sso_id': 999, 'request_key': settings.DIRECTORY_SSO_API_SECRET})
     )
     assert response.status_code == 204
 
@@ -2738,11 +2553,7 @@ def test_company_delete_endpoint_for_random_user(authed_client):
 @pytest.mark.django_db
 def test_company_delete_endpoint_for_random_request_key(authed_client):
     response = authed_client.delete(
-        reverse('company-delete-by-sso-id',
-                kwargs={
-                    'sso_id': 999,
-                    'request_key': 'Random'
-                })
+        reverse('company-delete-by-sso-id', kwargs={'sso_id': 999, 'request_key': 'Random'})
     )
     assert response.status_code == 401
 
@@ -2755,12 +2566,11 @@ def test_company_delete_endpoint_for_user_not_associated_with_company(authed_cli
     assert user_before_delete_count == 1
 
     response = authed_client.delete(
-        reverse('company-delete-by-sso-id',
-                kwargs={
-                    'sso_id': non_company_user.sso_id,
-                    'request_key': settings.DIRECTORY_SSO_API_SECRET
-                })
+        reverse(
+            'company-delete-by-sso-id',
+            kwargs={'sso_id': non_company_user.sso_id, 'request_key': settings.DIRECTORY_SSO_API_SECRET},
         )
+    )
 
     assert response.status_code == 204
     user_after_delete_count = models.CompanyUser.objects.filter(sso_id=non_company_user.sso_id).count()

--- a/company/validators.py
+++ b/company/validators.py
@@ -2,7 +2,6 @@ from rest_framework.serializers import ValidationError
 
 from company.models import Company
 
-
 COMPANY_NOT_UNIQUE_MESSAGE = 'Already registered.'
 
 

--- a/conf/celery.py
+++ b/conf/celery.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import os
 from ssl import CERT_NONE
 
-from django.conf import settings
-
 from celery import Celery
+from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'conf.settings')
@@ -18,12 +18,7 @@ app = Celery('api')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
 if settings.FEATURE_REDIS_USE_SSL:
-    ssl_conf = {
-        'ssl_cert_reqs': CERT_NONE,
-        'ssl_ca_certs': None,
-        'ssl_certfile': None,
-        'ssl_keyfile': None
-    }
+    ssl_conf = {'ssl_cert_reqs': CERT_NONE, 'ssl_ca_certs': None, 'ssl_certfile': None, 'ssl_keyfile': None}
     app.conf.broker_use_ssl = ssl_conf
     app.conf.redis_backend_use_ssl = ssl_conf
 

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -1,16 +1,15 @@
 import os
 
-from django.urls import reverse_lazy
+import directory_healthcheck.backends
 import dj_database_url
 import environ
+import sentry_sdk
+from django.urls import reverse_lazy
 from elasticsearch import RequestsHttpConnection
 from elasticsearch_dsl.connections import connections
-
-import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
-import healthcheck.backends
-import directory_healthcheck.backends
 
+import healthcheck.backends
 
 env = environ.Env()
 for env_file in env.list('ENV_FILES', default=[]):
@@ -90,7 +89,7 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages'
+                'django.contrib.messages.context_processors.messages',
             ],
             'loaders': [
                 'django.template.loaders.filesystem.Loader',
@@ -113,9 +112,7 @@ else:
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
-DATABASES = {
-    'default': dj_database_url.config()
-}
+DATABASES = {'default': dj_database_url.config()}
 
 # Caches
 CACHES = {
@@ -124,7 +121,7 @@ CACHES = {
         'LOCATION': REDIS_URL,
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-        }
+        },
     }
 }
 
@@ -152,10 +149,7 @@ if not os.path.exists(STATIC_ROOT):
     os.makedirs(STATIC_ROOT)
 STATIC_HOST = env.str('STATIC_HOST', '')
 STATIC_URL = STATIC_HOST + '/api-static/'
-STATICFILES_STORAGE = env.str(
-    'STATICFILES_STORAGE',
-    'whitenoise.storage.CompressedManifestStaticFilesStorage'
-)
+STATICFILES_STORAGE = env.str('STATICFILES_STORAGE', 'whitenoise.storage.CompressedManifestStaticFilesStorage')
 
 # S3 storage does not use these settings, needed only for dev local storage
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
@@ -166,9 +160,7 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 6 * 1024 * 1024
 FILE_UPLOAD_MAX_MEMORY_SIZE = 6 * 1024 * 1024
 
 # Extra places for collectstatic to find static files.
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'static'),
-)
+STATICFILES_DIRS = (os.path.join(BASE_DIR, 'static'),)
 
 for static_dir in STATICFILES_DIRS:
     if not os.path.exists(static_dir):
@@ -179,7 +171,7 @@ FEATURE_ENFORCE_STAFF_SSO_ENABLED = env.bool('FEATURE_ENFORCE_STAFF_SSO_ENABLED'
 if FEATURE_ENFORCE_STAFF_SSO_ENABLED:
     AUTHENTICATION_BACKENDS = [
         'django.contrib.auth.backends.ModelBackend',
-        'authbroker_client.backends.AuthbrokerBackend'
+        'authbroker_client.backends.AuthbrokerBackend',
     ]
 
     LOGIN_URL = reverse_lazy('authbroker_client:login')
@@ -195,27 +187,17 @@ SECRET_KEY = env.str('SECRET_KEY')
 
 # DRF
 REST_FRAMEWORK = {
-    'DEFAULT_FILTER_BACKENDS': (
-        'django_filters.rest_framework.DjangoFilterBackend',
-    ),
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'core.authentication.SessionAuthenticationSSO',
-    ),
-    'DEFAULT_PERMISSION_CLASSES': (
-        'core.permissions.IsAuthenticatedSSO',
-    ),
-    'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework.renderers.JSONRenderer',
-    )
+    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
+    'DEFAULT_AUTHENTICATION_CLASSES': ('core.authentication.SessionAuthenticationSSO',),
+    'DEFAULT_PERMISSION_CLASSES': ('core.permissions.IsAuthenticatedSSO',),
+    'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',),
 }
 
 
 # Sentry
 if env.str('SENTRY_DSN', ''):
     sentry_sdk.init(
-        dsn=env.str('SENTRY_DSN'),
-        environment=env.str('SENTRY_ENVIRONMENT'),
-        integrations=[DjangoIntegration()]
+        dsn=env.str('SENTRY_DSN'), environment=env.str('SENTRY_ENVIRONMENT'), integrations=[DjangoIntegration()]
     )
 
 
@@ -223,11 +205,7 @@ if DEBUG:
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,
-        'filters': {
-            'require_debug_false': {
-                '()': 'django.utils.log.RequireDebugFalse'
-            }
-        },
+        'filters': {'require_debug_false': {'()': 'django.utils.log.RequireDebugFalse'}},
         'handlers': {
             'console': {
                 'level': 'DEBUG',
@@ -265,7 +243,7 @@ if DEBUG:
                 'level': 'DEBUG',
                 'propagate': False,
             },
-        }
+        },
     }
 
 
@@ -275,7 +253,7 @@ COMPANIES_HOUSE_API_KEY = env.str('COMPANIES_HOUSE_API_KEY', '')
 # Email
 EMAIL_BACKED_CLASSES = {
     'default': 'django.core.mail.backends.smtp.EmailBackend',
-    'console': 'django.core.mail.backends.console.EmailBackend'
+    'console': 'django.core.mail.backends.console.EmailBackend',
 }
 EMAIL_BACKED_CLASS_NAME = env.str('EMAIL_BACKEND_CLASS_NAME', 'default')
 EMAIL_BACKEND = EMAIL_BACKED_CLASSES[EMAIL_BACKED_CLASS_NAME]
@@ -288,12 +266,10 @@ DEFAULT_FROM_EMAIL = env.str('DEFAULT_FROM_EMAIL', '')
 FAS_FROM_EMAIL = env.str('FAS_FROM_EMAIL', '')
 FAB_FROM_EMAIL = env.str('FAB_FROM_EMAIL', '')
 OWNERSHIP_INVITE_SUBJECT = env.str(
-    'OWNERSHIP_INVITE_SUBJECT',
-    'Confirm ownership of {company_name}’s Find a buyer profile'
+    'OWNERSHIP_INVITE_SUBJECT', 'Confirm ownership of {company_name}’s Find a buyer profile'
 )
 COLLABORATOR_INVITE_SUBJECT = env.str(
-    'COLLABORATOR_INVITE_SUBJECT',
-    'Confirm you’ve been added to {company_name}’s Find a buyer profile'
+    'COLLABORATOR_INVITE_SUBJECT', 'Confirm you’ve been added to {company_name}’s Find a buyer profile'
 )
 
 # Public storage for company profile logo
@@ -346,42 +322,33 @@ DIRECTORY_FORMS_API_ZENDESK_SEVICE_NAME = env.str('DIRECTORY_FORMS_API_ZENDESK_S
 
 # Verification letters sent with govnotify
 GOVNOTIFY_VERIFICATION_LETTER_TEMPLATE_ID = env.str(
-    'GOVNOTIFY_VERIFICATION_LETTER_TEMPLATE_ID',
-    '22d1803a-8af5-4b06-bc6c-ffc6573c4c7d'
+    'GOVNOTIFY_VERIFICATION_LETTER_TEMPLATE_ID', '22d1803a-8af5-4b06-bc6c-ffc6573c4c7d'
 )
 
 # Registration letters template id
 GOVNOTIFY_REGISTRATION_LETTER_TEMPLATE_ID = env.str(
-    'GOVNOTIFY_REGISTRATION_LETTER_TEMPLATE_ID',
-    '8840eba9-5c5b-4f87-b495-6127b7d3e2c9'
+    'GOVNOTIFY_REGISTRATION_LETTER_TEMPLATE_ID', '8840eba9-5c5b-4f87-b495-6127b7d3e2c9'
 )
 GOVNOTIFY_NEW_USER_INVITE_TEMPLATE_ID = env.str(
-    'GOVNOTIFY_NEW_USER_INVITE_TEMPLATE_ID',
-    'a69aaf87-8c9f-423e-985e-2a71ef4b2234'
+    'GOVNOTIFY_NEW_USER_INVITE_TEMPLATE_ID', 'a69aaf87-8c9f-423e-985e-2a71ef4b2234'
 )
 GOVNOTIFY_NEW_USER_INVITE_OTHER_COMPANY_MEMBER_TEMPLATE_ID = env.str(
-    'GOVNOTIFY_NEW_USER_INVITE_OTHER_COMPANY_MEMBER_TEMPLATE_ID',
-    'a0ee28e9-7b46-4ad6-a0e0-641200f66b41'
+    'GOVNOTIFY_NEW_USER_INVITE_OTHER_COMPANY_MEMBER_TEMPLATE_ID', 'a0ee28e9-7b46-4ad6-a0e0-641200f66b41'
 )
 GOVNOTIFY_NEW_USER_ALERT_TEMPLATE_ID = env.str(
-    'GOVNOTIFY_NEW_USER_ALERT_TEMPLATE_ID',
-    '439a8415-52d8-4975-b230-15cd34305bb5'
+    'GOVNOTIFY_NEW_USER_ALERT_TEMPLATE_ID', '439a8415-52d8-4975-b230-15cd34305bb5'
 )
 GOV_NOTIFY_NON_CH_VERIFICATION_REQUEST_TEMPLATE_ID = env.str(
-    'GOV_NOTIFY_NON_CH_VERIFICATION_REQUEST_TEMPLATE_ID',
-    'a63f948f-978e-4554-86da-c525bfabbaff'
+    'GOV_NOTIFY_NON_CH_VERIFICATION_REQUEST_TEMPLATE_ID', 'a63f948f-978e-4554-86da-c525bfabbaff'
 )
 GOV_NOTIFY_USER_REQUEST_DECLINED_TEMPLATE_ID = env.str(
-    'GOV_NOTIFY_USER_REQUEST_DECLINED_TEMPLATE_ID',
-    '3be3c49f-a5ad-4e37-b864-cc0a3833705b'
+    'GOV_NOTIFY_USER_REQUEST_DECLINED_TEMPLATE_ID', '3be3c49f-a5ad-4e37-b864-cc0a3833705b'
 )
 GOV_NOTIFY_USER_REQUEST_ACCEPTED_TEMPLATE_ID = env.str(
-    'GOV_NOTIFY_USER_REQUEST_ACCEPTED_TEMPLATE_ID',
-    '7f4f0e9c-2a04-4c3c-bd85-ef80f495b6f5'
+    'GOV_NOTIFY_USER_REQUEST_ACCEPTED_TEMPLATE_ID', '7f4f0e9c-2a04-4c3c-bd85-ef80f495b6f5'
 )
 GOV_NOTIFY_ADMIN_NEW_COLLABORATION_REQUEST_TEMPLATE_ID = env.str(
-    'GOV_NOTIFY_ADMIN_NEW_COLLABORATION_REQUEST_TEMPLATE_ID',
-    '240cfe51-a5fc-4826-a716-84ebaa429315'
+    'GOV_NOTIFY_ADMIN_NEW_COLLABORATION_REQUEST_TEMPLATE_ID', '240cfe51-a5fc-4826-a716-84ebaa429315'
 )
 
 # Duplicate companies notification
@@ -410,12 +377,11 @@ VERIFICATION_CODE_NOT_GIVEN_DAYS_2ND_EMAIL = env.int('VERIFICATION_CODE_NOT_GIVE
 VERIFICATION_CODE_URL = env.str('VERIFICATION_CODE_URL', 'http://great.gov.uk/verify')
 NEW_COMPANIES_IN_SECTOR_FREQUENCY_DAYS = env.int('NEW_COMPANIES_IN_SECTOR_FREQUENCY_DAYS', 7)
 NEW_COMPANIES_IN_SECTOR_SUBJECT = env.str(
-    'NEW_COMPANIES_IN_SECTOR_SUBJECT',
-    'Find a supplier service - New UK companies in your industry now available'
+    'NEW_COMPANIES_IN_SECTOR_SUBJECT', 'Find a supplier service - New UK companies in your industry now available'
 )
 NEW_COMPANIES_IN_SECTOR_UTM = env.str(
     'NEW_COMPANIES_IN_SECTOR_UTM',
-    'utm_source=system%20emails&utm_campaign=Companies%20in%20a%20sector&utm_medium=email'
+    'utm_source=system%20emails&utm_campaign=Companies%20in%20a%20sector&utm_medium=email',
 )
 ZENDESK_URL = env.str('ZENDESK_URL', 'https://contact-us.export.great.gov.uk/feedback/directory/')
 UNSUBSCRIBED_SUBJECT = env.str('UNSUBSCRIBED_SUBJECT', 'Find a buyer service - unsubscribed from marketing emails')
@@ -455,12 +421,9 @@ DIRECTORY_CONSTANTS_URL_GREAT_DOMESTIC = env.str('DIRECTORY_CONSTANTS_URL_GREAT_
 ELASTICSEARCH_PROVIDER = env.str('ELASTICSEARCH_PROVIDER', 'aws').lower()
 
 if ELASTICSEARCH_PROVIDER == 'govuk-paas':
-    services = {
-        item['instance_name']: item for item in VCAP_SERVICES['elasticsearch']
-    }
+    services = {item['instance_name']: item for item in VCAP_SERVICES['elasticsearch']}
     ELASTICSEARCH_INSTANCE_NAME = env.str(
-        'ELASTICSEARCH_INSTANCE_NAME',
-        VCAP_SERVICES['elasticsearch'][0]['instance_name']
+        'ELASTICSEARCH_INSTANCE_NAME', VCAP_SERVICES['elasticsearch'][0]['instance_name']
     )
     connections.create_connection(
         alias='default',
@@ -473,7 +436,7 @@ elif ELASTICSEARCH_PROVIDER == 'localhost':
         hosts=[env.str('ELASTICSEARCH_URL', 'localhost:9200')],
         use_ssl=False,
         verify_certs=False,
-        connection_class=RequestsHttpConnection
+        connection_class=RequestsHttpConnection,
     )
 else:
     raise NotImplementedError()

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -1,8 +1,7 @@
 import directory_healthcheck.views
-
 import django
 from django.conf import settings
-from django.conf.urls import url, include
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import reverse_lazy
 from django.views.generic import RedirectView
@@ -10,39 +9,27 @@ from django.views.generic import RedirectView
 import activitystream.views
 import buyer.views
 import company.views
+import dataservices.views
 import enrolment.views
+import exporting.views
 import exportplan.views
 import notifications.views
 import personalisation.views
 import testapi.views
-import exporting.views
-import dataservices.views
 
 admin.autodiscover()
 
 healthcheck_urls = [
-    url(
-        r'^$',
-        directory_healthcheck.views.HealthcheckView.as_view(),
-        name='healthcheck'
-    ),
-    url(
-        r'^ping/$',
-        directory_healthcheck.views.PingView.as_view(),
-        name='ping'
-    ),
+    url(r'^$', directory_healthcheck.views.HealthcheckView.as_view(), name='healthcheck'),
+    url(r'^ping/$', directory_healthcheck.views.PingView.as_view(), name='ping'),
 ]
 
 activity_stream_urls = [
-    url(
-        r'^$',
-        activitystream.views.ActivityStreamViewSet.as_view({'get': 'list'}),
-        name='activity-stream'
-    ),
+    url(r'^$', activitystream.views.ActivityStreamViewSet.as_view({'get': 'list'}), name='activity-stream'),
     url(
         r'^company/$',
         activitystream.views.ActivityStreamCompanyViewSet.as_view({'get': 'list'}),
-        name='activity-stream-companies'
+        name='activity-stream-companies',
     ),
 ]
 
@@ -51,11 +38,7 @@ urlpatterns = [
     url(r'^healthcheck/', include((healthcheck_urls, 'healthcheck'), namespace='healthcheck')),
     url(r'^admin/', admin.site.urls),
     url(r'^activity-stream/', include((activity_stream_urls, 'activity-stream'), namespace='activity-stream')),
-    url(
-        r'^enrolment/$',
-        enrolment.views.EnrolmentCreateAPIView.as_view(),
-        name='enrolment'
-    ),
+    url(r'^enrolment/$', enrolment.views.EnrolmentCreateAPIView.as_view(), name='enrolment'),
     url(
         r'^pre-verified-enrolment/$',
         enrolment.views.PreVerifiedEnrolmentRetrieveView.as_view(),
@@ -64,47 +47,35 @@ urlpatterns = [
     url(
         r'^external/supplier-sso/$',
         company.views.CompanyUserSSOListAPIView.as_view(),
-        name='external-supplier-sso-list'
+        name='external-supplier-sso-list',
     ),
-    url(
-        r'^external/supplier/$',
-        company.views.CompanyUserRetrieveAPIView.as_view(),
-        name='external-supplier-details'
-    ),
+    url(r'^external/supplier/$', company.views.CompanyUserRetrieveAPIView.as_view(), name='external-supplier-details'),
     url(
         r'^supplier/gecko/total-registered/$',
         company.views.GeckoTotalRegisteredCompanyUser.as_view(),
-        name='gecko-total-registered-suppliers'
+        name='gecko-total-registered-suppliers',
     ),
     url(
         r'^supplier/(?P<sso_id>[0-9]+)/$',
         company.views.CompanyUserSSORetrieveAPIView.as_view(),
-        name='supplier-retrieve-sso-id'
+        name='supplier-retrieve-sso-id',
     ),
-    url(
-        r'^supplier/company/$',
-        company.views.CompanyRetrieveUpdateAPIView.as_view(),
-        name='company'
-    ),
+    url(r'^supplier/company/$', company.views.CompanyRetrieveUpdateAPIView.as_view(), name='company'),
     url(
         r'^supplier/company/(?P<sso_id>[0-9]+)/(?P<request_key>.*)/$',
         company.views.CompanyDestroyAPIView.as_view(),
-        name='company-delete-by-sso-id'
+        name='company-delete-by-sso-id',
     ),
-    url(
-        r'^supplier/company/verify/$',
-        company.views.VerifyCompanyWithCodeAPIView.as_view(),
-        name='company-verify'
-    ),
+    url(r'^supplier/company/verify/$', company.views.VerifyCompanyWithCodeAPIView.as_view(), name='company-verify'),
     url(
         r'^supplier/company/verify/companies-house/$',
         company.views.VerifyCompanyWithCompaniesHouseView.as_view(),
-        name='company-verify-companies-house'
+        name='company-verify-companies-house',
     ),
     url(
         r'^supplier/company/verify/identity/$',
         company.views.RequestVerificationWithIdentificationView.as_view(),
-        name='company-verify-identity'
+        name='company-verify-identity',
     ),
     url(
         r'^supplier/company/case-study/$',
@@ -114,86 +85,77 @@ urlpatterns = [
     url(
         r'^supplier/company/collaborator-invite/$',
         company.views.CollaborationInviteViewSet.as_view({'post': 'create', 'get': 'list'}),
-        name='collaboration-invite'
+        name='collaboration-invite',
     ),
     url(
         r'^supplier/company/collaborator-invite/(?P<uuid>.*)/',
-        company.views.CollaborationInviteViewSet.as_view({
-            'get': 'retrieve', 'patch': 'partial_update', 'delete': 'destroy'
-        }),
-        name='collaboration-invite-detail'
+        company.views.CollaborationInviteViewSet.as_view(
+            {'get': 'retrieve', 'patch': 'partial_update', 'delete': 'destroy'}
+        ),
+        name='collaboration-invite-detail',
     ),
     url(
         r'^supplier/company/remove-collaborators/',
         company.views.RemoveCollaboratorsView.as_view(),
-        name='remove-collaborators'
+        name='remove-collaborators',
     ),
     url(
         r'^supplier/company/disconnect/',
         company.views.CollaboratorDisconnectView.as_view(),
-        name='company-disconnect-supplier'
+        name='company-disconnect-supplier',
     ),
     url(
         r'^supplier/company/case-study/(?P<pk>[0-9]+)/$',
-        company.views.CompanyCaseStudyViewSet.as_view({
-            'get': 'retrieve',
-            'patch': 'partial_update',
-            'delete': 'destroy',
-        }),
+        company.views.CompanyCaseStudyViewSet.as_view(
+            {
+                'get': 'retrieve',
+                'patch': 'partial_update',
+                'delete': 'destroy',
+            }
+        ),
         name='company-case-study-detail',
     ),
     url(
         r'^supplier/company/collaborators/$',
         company.views.CompanyCollboratorsListView.as_view(),
-        name='supplier-company-collaborators-list'
+        name='supplier-company-collaborators-list',
     ),
     url(
         r'^supplier/company/collaborator-request/$',
-        company.views.CollaborationRequestView.as_view(
-            ({'post': 'create', 'get': 'list'})),
-        name='collaborator-request'
+        company.views.CollaborationRequestView.as_view(({'post': 'create', 'get': 'list'})),
+        name='collaborator-request',
     ),
     url(
         r'^supplier/company/collaborator-request/(?P<uuid>.*)/$',
-        company.views.CollaborationRequestView.as_view(
-            {'patch': 'partial_update', 'delete': 'destroy'}
-        ),
-        name='collaborator-request-detail'
+        company.views.CollaborationRequestView.as_view({'patch': 'partial_update', 'delete': 'destroy'}),
+        name='collaborator-request-detail',
     ),
     url(
         r'^supplier/company/add-collaborator/$',
         company.views.AddCollaboratorView.as_view(),
-        name='register-company-collaborator-request'
+        name='register-company-collaborator-request',
     ),
     url(
         r'^supplier/company/change-collaborator-role/(?P<sso_id>\d+)/$',
         company.views.ChangeCollaboratorRoleView.as_view(),
-        name='change-collaborator-role'
+        name='change-collaborator-role',
     ),
-    url(
-        r'^supplier/$',
-        company.views.CompanyUserRetrieveUpdateAPIView.as_view(),
-        name='supplier'
-    ),
-    url(
-        r'^supplier/unsubscribe/$',
-        company.views.CompanyUserUnsubscribeAPIView.as_view(),
-        name='unsubscribe-supplier'
-    ),
+    url(r'^supplier/$', company.views.CompanyUserRetrieveUpdateAPIView.as_view(), name='supplier'),
+    url(r'^supplier/unsubscribe/$', company.views.CompanyUserUnsubscribeAPIView.as_view(), name='unsubscribe-supplier'),
     url(
         r'^public/case-study/(?P<pk>.*)/$',
         company.views.PublicCaseStudyViewSet.as_view({'get': 'retrieve'}),
-        name='public-case-study-detail'
+        name='public-case-study-detail',
     ),
     url(
         r'^public/company/(?P<companies_house_number>.*)/$',
         company.views.CompanyPublicProfileViewSet.as_view({'get': 'retrieve'}),
-        name='company-public-profile-detail'
+        name='company-public-profile-detail',
     ),
     url(
         r'^validate/company-number/$',
         company.views.CompanyNumberValidatorAPIView.as_view(),
-        name='validate-company-number'
+        name='validate-company-number',
     ),
     url(
         r'^buyer/$',
@@ -203,206 +165,173 @@ urlpatterns = [
     url(
         r'^notifications/anonymous-unsubscribe/$',
         notifications.views.AnonymousUnsubscribeCreateAPIView.as_view(),
-        name='anonymous-unsubscribe'
+        name='anonymous-unsubscribe',
     ),
-    url(
-        r'^company/search/$',
-        company.views.FindASupplierSearchAPIView.as_view(),
-        name='find-a-supplier-search'
-    ),
+    url(r'^company/search/$', company.views.FindASupplierSearchAPIView.as_view(), name='find-a-supplier-search'),
     url(
         r'^investment-support-directory/search/$',
         company.views.InvestmentSupportDirectorySearchAPIView.as_view(),
-        name='investment-support-directory-search'
+        name='investment-support-directory-search',
     ),
     url(
         r'exporting/offices/(?P<postcode>.*)/$',
         exporting.views.RetrieveOfficesByPostCode.as_view(),
-        name='offices-by-postcode'
+        name='offices-by-postcode',
     ),
-    url(
-        r'^personalisation/events/',
-        personalisation.views.EventsView.as_view(),
-        name='personalisation-events'
-    ),
+    url(r'^personalisation/events/', personalisation.views.EventsView.as_view(), name='personalisation-events'),
     url(
         r'^personalisation/export-opportunities/',
         personalisation.views.ExportOpportunitiesView.as_view(),
-        name='personalisation-export-opportunities'
+        name='personalisation-export-opportunities',
     ),
     url(
         r'^personalisation/user-location/$',
         personalisation.views.UserLocationCreateAPIView.as_view(),
-        name='personalisation-user-location-create'
+        name='personalisation-user-location-create',
     ),
     url(
         r'^personalisation/recommended-countries/$',
         personalisation.views.RecommendedCountriesView.as_view(),
-        name='personalisation-recommended-countries'
+        name='personalisation-recommended-countries',
     ),
     url(
         r'^dataservices/suggested-countries/$',
         dataservices.views.SuggestedCountriesView.as_view(),
-        name='dataservices-suggested-countries'
+        name='dataservices-suggested-countries',
     ),
     url(
         r'^exportplan/company-export-plan/$',
         exportplan.views.CompanyExportPlanListCreateAPIView.as_view(),
-        name='export-plan-list-create'
+        name='export-plan-list-create',
     ),
     url(
         r'^exportplan/company-export-plan/(?P<pk>[0-9]+)/$',
         exportplan.views.CompanyExportPlanRetrieveUpdateView.as_view(),
-        name='export-plan-detail-update'
+        name='export-plan-detail-update',
     ),
     url(
         r'^exportplan/company-objectives/(?P<pk>[0-9]+)/$',
         exportplan.views.CompanyObjectivesRetrieveUpdateDestroyView.as_view(),
-        name='export-plan-objectives-detail-update'
+        name='export-plan-objectives-detail-update',
     ),
     url(
         r'^exportplan/company-objectives/$',
         exportplan.views.CompanyObjectivesListCreateAPIView.as_view(),
-        name='export-plan-objectives-list-create'
+        name='export-plan-objectives-list-create',
     ),
     url(
         r'^exportplan/route-to-markets/(?P<pk>[0-9]+)/$',
         exportplan.views.RouteToMarketsUpdateDestroyView.as_view(),
-        name='export-plan-route-to-markets-detail-update'
+        name='export-plan-route-to-markets-detail-update',
     ),
     url(
         r'^exportplan/route-to-markets/$',
         exportplan.views.RouteToMarketsListCreateAPIView.as_view(),
-        name='export-plan-route-to-markets-list-create'
+        name='export-plan-route-to-markets-list-create',
     ),
     url(
         r'^exportplan/target-market-documents/(?P<pk>[0-9]+)/$',
         exportplan.views.TargetMarketDocumentsUpdateDestroyView.as_view(),
-        name='export-plan-target-market-documents-detail-update'
+        name='export-plan-target-market-documents-detail-update',
     ),
     url(
         r'^exportplan/target-market-documents/$',
         exportplan.views.TargetMarketDocumentsCreateAPIView.as_view(),
-        name='export-plan-target-market-documents-list-create'
+        name='export-plan-target-market-documents-list-create',
     ),
     url(
         r'^dataservices/easeofdoingbusiness/(?P<country_code>.*)/$',
         dataservices.views.RetrieveEaseOfBusinessIndex.as_view(),
-        name='dataservices-easeofdoingbusiness-index'
+        name='dataservices-easeofdoingbusiness-index',
     ),
     url(
         r'^dataservices/corruption-perceptions-index/(?P<country_code>.*)/$',
         dataservices.views.RetrieveCorruptionPerceptionsIndex.as_view(),
-        name='dataservices-corruptionperceptionsindex'
+        name='dataservices-corruptionperceptionsindex',
     ),
     url(
         r'^dataservices/world-economic-outlook/(?P<country_code>.*)/$',
         dataservices.views.RetrieveWorldEconomicOutlook.as_view(),
-        name='dataservices-world-economic-outlook'
+        name='dataservices-world-economic-outlook',
     ),
     url(
         r'^dataservices/country-data/(?P<country>.*)/$',
         dataservices.views.RetrieveCountryDataView.as_view(),
-        name='dataservices-country-data'
+        name='dataservices-country-data',
     ),
     url(
         r'^dataservices/lastyearimportdata/$',
         dataservices.views.RetrieveLastYearImportDataView.as_view(),
-        name='last-year-import-data'
+        name='last-year-import-data',
     ),
     url(
         r'^dataservices/lastyearimportdatafromuk/$',
         dataservices.views.RetrieveLastYearImportDataFromUKView.as_view(),
-        name='last-year-import-data-from-uk'
+        name='last-year-import-data-from-uk',
     ),
     url(
         r'^dataservices/cia-factbook-data/$',
         dataservices.views.RetrieveCiaFactbooklDataView.as_view(),
-        name='cia-factbook-data'
+        name='cia-factbook-data',
     ),
     url(
         r'^dataservices/historicalimportdata/$',
         dataservices.views.RetrieveHistoricalImportDataView.as_view(),
-        name='historical-import-data'
+        name='historical-import-data',
     ),
     url(
         r'^dataservices/population-data/$',
         dataservices.views.RetrievePopulationDataView.as_view(),
-        name='population-data'
+        name='population-data',
     ),
     url(
         r'^dataservices/population-data-by-country/$',
         dataservices.views.RetrievePopulationDataViewByCountry.as_view(),
-        name='dataservices-population-data-by-country'
+        name='dataservices-population-data-by-country',
     ),
-    url(
-        r'^testapi/buyer/(?P<email>.*)/$',
-        testapi.views.BuyerTestAPIView.as_view(),
-        name='buyer_by_email'
-    ),
-    url(
-        r'^testapi/test-buyers/$',
-        testapi.views.BuyerTestAPIView.as_view(),
-        name='delete_test_buyers'
-    ),
+    url(r'^testapi/buyer/(?P<email>.*)/$', testapi.views.BuyerTestAPIView.as_view(), name='buyer_by_email'),
+    url(r'^testapi/test-buyers/$', testapi.views.BuyerTestAPIView.as_view(), name='delete_test_buyers'),
     url(
         r'^testapi/company/(?P<ch_id_or_name>.*)/$',
         testapi.views.CompanyTestAPIView.as_view(),
-        name='company_by_ch_id_or_name'
+        name='company_by_ch_id_or_name',
     ),
-    url(
-        r'^testapi/isd_company/$',
-        testapi.views.ISDCompanyTestAPIView.as_view(),
-        name='create_test_isd_company'
-    ),
+    url(r'^testapi/isd_company/$', testapi.views.ISDCompanyTestAPIView.as_view(), name='create_test_isd_company'),
     url(
         r'^testapi/companies/published/$',
         testapi.views.PublishedCompaniesTestAPIView.as_view(),
-        name='published_companies'
+        name='published_companies',
     ),
     url(
         r'^testapi/companies/unpublished/$',
         testapi.views.UnpublishedCompaniesTestAPIView.as_view(),
-        name='unpublished_companies'
+        name='unpublished_companies',
     ),
     url(
         r'^testapi/test-companies/$',
         testapi.views.AutomatedTestsCompaniesTestAPIView.as_view(),
-        name='delete_test_companies'
+        name='delete_test_companies',
     ),
     url(
         r'^enrolment/preverified-company/(?P<key>.*)/claim/$',
         enrolment.views.PreverifiedCompanyClaim.as_view(),
-        name='enrolment-claim-preverified'
+        name='enrolment-claim-preverified',
     ),
     url(
         r'^enrolment/preverified-company/(?P<key>.*)/$',
         enrolment.views.PreverifiedCompanyView.as_view(),
-        name='enrolment-preverified'
+        name='enrolment-preverified',
     ),
 ]
 
 if settings.STORAGE_CLASS_NAME == 'local-storage':
     urlpatterns += [
-        url(
-            r'^media/(?P<path>.*)$',
-            django.views.static.serve,
-            {'document_root': settings.MEDIA_ROOT},
-            name='media'
-        ),
+        url(r'^media/(?P<path>.*)$', django.views.static.serve, {'document_root': settings.MEDIA_ROOT}, name='media'),
     ]
 elif settings.STORAGE_CLASS_NAME == 'default':
     urlpatterns += [
-        url(
-            r'buyer/csv-dump/$',
-            buyer.views.BuyerCSVDownloadAPIView.as_view(),
-            name='buyer-csv-dump'
-        ),
-        url(
-            r'supplier/csv-dump/$',
-            company.views.CompanyUserCSVDownloadAPIView.as_view(),
-            name='supplier-csv-dump'
-        ),
+        url(r'buyer/csv-dump/$', buyer.views.BuyerCSVDownloadAPIView.as_view(), name='buyer-csv-dump'),
+        url(r'supplier/csv-dump/$', company.views.CompanyUserCSVDownloadAPIView.as_view(), name='supplier-csv-dump'),
     ]
 
 
@@ -410,8 +339,10 @@ if settings.FEATURE_ENFORCE_STAFF_SSO_ENABLED:
     authbroker_urls = [
         url(
             r'^admin/login/$',
-            RedirectView.as_view(url=reverse_lazy('authbroker_client:login'),
-                                 query_string=True, )
+            RedirectView.as_view(
+                url=reverse_lazy('authbroker_client:login'),
+                query_string=True,
+            ),
         ),
         url('^auth/', include('authbroker_client.urls')),
     ]

--- a/conf/wsgi.py
+++ b/conf/wsgi.py
@@ -11,7 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "conf.settings")
 
 application = get_wsgi_application()

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,13 @@
-import logging
 import http
+import logging
 import re
 from unittest import mock
 from urllib.parse import urljoin
 
 import pytest
 import requests_mock
-from rest_framework.test import APIClient
-
 from django.core.management import call_command
+from rest_framework.test import APIClient
 
 from company import documents
 from company.tests import factories
@@ -54,7 +53,7 @@ def sso_session_request_active_user(authed_supplier, requests_mocker, settings):
             'id': authed_supplier.sso_id,
             'email': authed_supplier.company_email,
             'user_profile': {'first_name': 'supplier1', 'last_name': 'bloggs'},
-        }
+        },
     )
 
 
@@ -136,6 +135,7 @@ def elasticsearch_marker(request, django_db_blocker):
             call_command('elasticsearch_migrate')
         yield None
     else:
+
         class CompanyDocument(documents.CompanyDocument):
             def save(self, *args, **kwargs):
                 pass

--- a/contact/admin.py
+++ b/contact/admin.py
@@ -10,56 +10,46 @@ from contact.models import MessageToSupplier
 @admin.register(MessageToSupplier)
 class MessageToSupplierAdmin(admin.ModelAdmin):
     search_fields = (
-        'sender_email', 'sender_name', 'sender_company_name',
-        'sender_country', 'sector', 'recipient__name',
-        'recipient__email_address', 'recipient__email_full_name'
+        'sender_email',
+        'sender_name',
+        'sender_company_name',
+        'sender_country',
+        'sector',
+        'recipient__name',
+        'recipient__email_address',
+        'recipient__email_full_name',
     )
-    list_display = (
-        'sender_email', 'sender_name',
-        'recipient', 'created'
-    )
+    list_display = ('sender_email', 'sender_name', 'recipient', 'created')
     list_filter = ('sector', 'is_sent')
     readonly_fields = ('created', 'modified')
     actions = ['download_csv']
-    csv_excluded_fields = (
-        'is_sent',
-        'sector',
-        'modified',
-        'id',
-        'recipient'
-    )
-    csv_filename = 'find-a-buyer_message_to_supplier_{}.csv'.format(
-                datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
+    csv_excluded_fields = ('is_sent', 'sector', 'modified', 'id', 'recipient')
+    csv_filename = 'find-a-buyer_message_to_supplier_{}.csv'.format(datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
 
     def download_csv(self, request, queryset):
         """
         Generates CSV report of selected case studies.
         """
-        fieldnames = [field.name for field in
-                      MessageToSupplier._meta.get_fields() if field.name
-                      not in self.csv_excluded_fields]
-        fieldnames.extend((
-            'recipient__name',
-            'recipient__number',
-            'recipient__date_of_creation',
-            'recipient__email_address',
-            'recipient__postal_full_name',
-            'recipient__address_line_1',
-            'recipient__address_line_2',
-            'recipient__postal_code'
-        ))
-        fieldnames = sorted(fieldnames)
-        messages_to_supplier = queryset.select_related(
-            'recipient'
-        ).values(
-            *fieldnames
+        fieldnames = [
+            field.name for field in MessageToSupplier._meta.get_fields() if field.name not in self.csv_excluded_fields
+        ]
+        fieldnames.extend(
+            (
+                'recipient__name',
+                'recipient__number',
+                'recipient__date_of_creation',
+                'recipient__email_address',
+                'recipient__postal_full_name',
+                'recipient__address_line_1',
+                'recipient__address_line_2',
+                'recipient__postal_code',
+            )
         )
+        fieldnames = sorted(fieldnames)
+        messages_to_supplier = queryset.select_related('recipient').values(*fieldnames)
 
         response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = (
-            'attachment; filename="{filename}"'.format(
-                filename=self.csv_filename)
-        )
+        response['Content-Disposition'] = 'attachment; filename="{filename}"'.format(filename=self.csv_filename)
         writer = csv.DictWriter(response, fieldnames=fieldnames)
         writer.writeheader()
 
@@ -68,6 +58,4 @@ class MessageToSupplierAdmin(admin.ModelAdmin):
 
         return response
 
-    download_csv.short_description = (
-        "Download CSV report for selected messages to suppliers"
-    )
+    download_csv.short_description = "Download CSV report for selected messages to suppliers"

--- a/contact/models.py
+++ b/contact/models.py
@@ -1,9 +1,8 @@
+from directory_constants import choices
 from django.db import models
 
-from directory_constants import choices
-
-from core.helpers import TimeStampedModel
 from company.models import Company
+from core.helpers import TimeStampedModel
 
 
 # Deprecated in favour of sending via gov notify

--- a/contact/tests/test_admin.py
+++ b/contact/tests/test_admin.py
@@ -1,29 +1,23 @@
 from collections import OrderedDict
 from unittest import TestCase
 
+import pytest
+from django.contrib.auth.models import User
 from django.test import Client
 from django.urls import reverse
-from django.contrib.auth.models import User
-
-import pytest
-
 from freezegun import freeze_time
 
 from company.models import Company
-from contact.models import MessageToSupplier
 from company.tests import VALID_REQUEST_DATA
-
+from contact.models import MessageToSupplier
 
 COMPANY_DATA = VALID_REQUEST_DATA.copy()
 
 
 @pytest.mark.django_db
 class DownloadMessageToSupplierCSVTestCase(TestCase):
-
     def setUp(self):
-        superuser = User.objects.create_superuser(
-            username='admin', email='admin@example.com', password='test'
-        )
+        superuser = User.objects.create_superuser(username='admin', email='admin@example.com', password='test')
         self.client = Client()
         self.client.force_login(superuser)
 
@@ -35,41 +29,39 @@ class DownloadMessageToSupplierCSVTestCase(TestCase):
 
     def test_download_csv(self):
         recipient = Company.objects.create(**COMPANY_DATA)
-        MessageToSupplier.objects.create(**dict(
-            sender_email='foo@bar.com',
-            sender_name='Testo Useri',
-            sender_company_name='Acme',
-            sender_country='Antartica',
-            recipient=recipient
-        ))
+        MessageToSupplier.objects.create(
+            **dict(
+                sender_email='foo@bar.com',
+                sender_name='Testo Useri',
+                sender_company_name='Acme',
+                sender_country='Antartica',
+                recipient=recipient,
+            )
+        )
 
         data = {
             'action': 'download_csv',
-            '_selected_action': MessageToSupplier.objects.all().values_list(
-                'pk', flat=True
-            )
+            '_selected_action': MessageToSupplier.objects.all().values_list('pk', flat=True),
         }
-        response = self.client.post(
-            reverse('admin:contact_messagetosupplier_changelist'),
-            data,
-            follow=True
-        )
+        response = self.client.post(reverse('admin:contact_messagetosupplier_changelist'), data, follow=True)
 
-        expected_data = OrderedDict([
-            ('created', '2012-01-14 12:00:00+00:00'),
-            ('recipient__address_line_1', 'test_address_line_1'),
-            ('recipient__address_line_2', 'test_address_line_2'),
-            ('recipient__date_of_creation', '2010-10-10'),
-            ('recipient__email_address', ''),
-            ('recipient__name', 'Test Company'),
-            ('recipient__number', '11234567'),
-            ('recipient__postal_code', 'test_postal_code'),
-            ('recipient__postal_full_name', 'test_full_name'),
-            ('sender_company_name', 'Acme'),
-            ('sender_country', 'Antartica'),
-            ('sender_email', 'foo@bar.com'),
-            ('sender_name', 'Testo Useri'),
-        ])
+        expected_data = OrderedDict(
+            [
+                ('created', '2012-01-14 12:00:00+00:00'),
+                ('recipient__address_line_1', 'test_address_line_1'),
+                ('recipient__address_line_2', 'test_address_line_2'),
+                ('recipient__date_of_creation', '2010-10-10'),
+                ('recipient__email_address', ''),
+                ('recipient__name', 'Test Company'),
+                ('recipient__number', '11234567'),
+                ('recipient__postal_code', 'test_postal_code'),
+                ('recipient__postal_full_name', 'test_full_name'),
+                ('sender_company_name', 'Acme'),
+                ('sender_country', 'Antartica'),
+                ('sender_email', 'foo@bar.com'),
+                ('sender_name', 'Testo Useri'),
+            ]
+        )
         actual = str(response.content, 'utf-8').split('\r\n')
 
         assert actual[0] == ','.join(expected_data.keys())

--- a/contact/tests/test_models.py
+++ b/contact/tests/test_models.py
@@ -1,19 +1,21 @@
 import pytest
 
-from contact import models
 from company.tests import factories
+from contact import models
 
 
 @pytest.mark.django_db
 def test_send_message_to_supplier_str():
     company = factories.CompanyFactory.create(number='12345678')
-    message = models.MessageToSupplier.objects.create(**{
-        'sender_email': 'test@sender.email',
-        'sender_name': 'test sender name',
-        'sender_company_name': 'test sender company name',
-        'sender_country': 'test country',
-        'sector': 'AEROSPACE',
-        'recipient': company,
-    })
+    message = models.MessageToSupplier.objects.create(
+        **{
+            'sender_email': 'test@sender.email',
+            'sender_name': 'test sender name',
+            'sender_company_name': 'test sender company name',
+            'sender_country': 'test country',
+            'sector': 'AEROSPACE',
+            'recipient': company,
+        }
+    )
 
     assert str(message) == 'Message from test@sender.email to ' + str(company)

--- a/core/authentication.py
+++ b/core/authentication.py
@@ -1,10 +1,9 @@
 from directory_sso_api_client.client import sso_api_client
-from rest_framework import authentication, exceptions
-from rest_framework.authentication import BasicAuthentication
-
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.utils.crypto import constant_time_compare
+from rest_framework import authentication, exceptions
+from rest_framework.authentication import BasicAuthentication
 
 from core import helpers
 
@@ -38,7 +37,7 @@ class SessionAuthenticationSSO(authentication.BaseAuthentication):
             id=sso_data['id'],
             email=sso_data['email'],
             user_profile=sso_data.get('user_profile'),
-            hashed_uuid=sso_data.get('hashed_uuid')
+            hashed_uuid=sso_data.get('hashed_uuid'),
         )
         return (sso_user, session_id)
 
@@ -67,9 +66,7 @@ class Oauth2AuthenticationSSO(authentication.BaseAuthentication):
         return self.authenticate_credentials(auth[1].decode())
 
     def authenticate_credentials(self, bearer_token):
-        response = sso_api_client.user.get_oauth2_user_profile(
-            bearer_token
-        )
+        response = sso_api_client.user.get_oauth2_user_profile(bearer_token)
         if not response.ok:
             raise exceptions.AuthenticationFailed(self.message_invalid_session)
 

--- a/core/management/commands/distributed_elasticsearch_migrate.py
+++ b/core/management/commands/distributed_elasticsearch_migrate.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 
-from core.management.commands import helpers
 from core import tasks
+from core.management.commands import helpers
 
 
 class Command(helpers.ExclusiveDistributedHandleMixin, BaseCommand):

--- a/core/management/commands/distributed_migrate.py
+++ b/core/management/commands/distributed_migrate.py
@@ -8,7 +8,6 @@ from core.management.commands import helpers
 
 
 class Command(helpers.ExclusiveDistributedHandleMixin, MigrateCommand):
-
     def handle(self, *args, **options):
         if not settings.FEATURE_SKIP_MIGRATE:
             super().handle(*args, **options)

--- a/core/management/commands/mask_personal_data.py
+++ b/core/management/commands/mask_personal_data.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
-from company.tests.factories import CompanyFactory, CompanyUserFactory
 
 from company.models import Company, CompanyUser
+from company.tests.factories import CompanyFactory, CompanyUserFactory
 
 
 class Command(BaseCommand):

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,19 +1,16 @@
 import sigauth.middleware
-
 from django.conf import settings
-from django.utils.deprecation import MiddlewareMixin
 from django.http import HttpResponse
+from django.utils.deprecation import MiddlewareMixin
 
 
-class SignatureCheckMiddleware(
-    sigauth.middleware.SignatureCheckMiddlewareBase
-):
+class SignatureCheckMiddleware(sigauth.middleware.SignatureCheckMiddlewareBase):
     secret = settings.SIGNATURE_SECRET
 
     def should_check(self, request):
-        if request.resolver_match.namespace in [
-            'admin', 'healthcheck', 'authbroker_client'
-        ] or request.path_info.startswith('/admin/login'):
+        if (
+            request.resolver_match.namespace in ['admin', 'healthcheck', 'authbroker_client']
+        ) or request.path_info.startswith('/admin/login'):
             return False
         return super().should_check(request)
 

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -1,7 +1,6 @@
-from rest_framework import permissions
-
 from django.conf import settings
 from django.utils.crypto import constant_time_compare
+from rest_framework import permissions
 
 from core import helpers
 

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -4,7 +4,7 @@ from django.core.management import call_command
 from conf.celery import app
 
 
-@app.task(autoretry_for=(TimeoutError, ))
+@app.task(autoretry_for=(TimeoutError,))
 def send_email(subject, text_body, html_body, recipient_email, from_email):
     message = EmailMultiAlternatives(
         subject=subject,

--- a/core/tests/test_fixtures.py
+++ b/core/tests/test_fixtures.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.core.management import call_command
 
 from company.models import Company, CompanyCaseStudy, CompanyUser

--- a/core/tests/test_helpers.py
+++ b/core/tests/test_helpers.py
@@ -1,10 +1,10 @@
 import http
 import io
-import pytest
 from unittest import mock
 
-from django.conf import settings
+import pytest
 import requests_mock
+from django.conf import settings
 from requests.exceptions import HTTPError
 
 from core import helpers
@@ -40,14 +40,10 @@ def test_upload_file_object_to_s3(mocked_boto3, data_science_settings):
 
 @mock.patch('core.helpers.boto3')
 def test_get_file_from_s3(mocked_boto3, data_science_settings):
-    helpers.get_file_from_s3(
-        bucket=data_science_settings.AWS_STORAGE_BUCKET_NAME_DATA_SCIENCE,
-        key='key'
-    )
+    helpers.get_file_from_s3(bucket=data_science_settings.AWS_STORAGE_BUCKET_NAME_DATA_SCIENCE, key='key')
     assert mocked_boto3.client().get_object.called
     assert mocked_boto3.client().get_object.call_args == mock.call(
-        Bucket=data_science_settings.AWS_STORAGE_BUCKET_NAME_DATA_SCIENCE,
-        Key='key'
+        Bucket=data_science_settings.AWS_STORAGE_BUCKET_NAME_DATA_SCIENCE, Key='key'
     )
 
 
@@ -75,11 +71,7 @@ def test_companies_house_client_logs_unauth(caplog):
 def test_companies_house_client_retrieve_profile():
     profile = {'company_status': 'active'}
     with requests_mock.mock() as mock:
-        mock.get(
-            'https://api.companieshouse.gov.uk/company/01234567',
-            status_code=http.client.OK,
-            json=profile
-        )
+        mock.get('https://api.companieshouse.gov.uk/company/01234567', status_code=http.client.OK, json=profile)
         response = helpers.CompaniesHouseClient.retrieve_profile('01234567')
     assert response.json() == profile
 

--- a/core/tests/test_management_commands.py
+++ b/core/tests/test_management_commands.py
@@ -1,12 +1,11 @@
 from unittest import mock
-import pytest
 
+import pytest
 from django.core.management import call_command
 from django.core.management.commands import migrate
 
-from company.tests.factories import CompanyFactory, CompanyUserFactory
-
 from company.models import Company, CompanyUser
+from company.tests.factories import CompanyFactory, CompanyUserFactory
 from core.management.commands import distributed_migrate
 
 
@@ -57,11 +56,12 @@ def test_distributed_migration_first(mock_is_first_instance, mock_handle):
 @mock.patch.object(migrate.Command, 'handle')
 @mock.patch.object(distributed_migrate.Command, 'is_migration_pending')
 @mock.patch.object(distributed_migrate.Command, 'is_first_instance')
-def test_distributed_migration_second(
-    mock_is_first_instance, mock_is_migration_pending, mock_handle
-):
+def test_distributed_migration_second(mock_is_first_instance, mock_is_migration_pending, mock_handle):
     mock_is_first_instance.return_value = False
-    mock_is_migration_pending.side_effect = (True, False,)
+    mock_is_migration_pending.side_effect = (
+        True,
+        False,
+    )
 
     call_command('distributed_migrate')
 

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -1,8 +1,8 @@
 import pytest
-
-from django.urls import reverse
-from core.tests.test_views import reload_urlconf
 from django.contrib.auth.models import User
+from django.urls import reverse
+
+from core.tests.test_views import reload_urlconf
 
 SIGNATURE_CHECK_REQUIRED_MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/core/tests/test_templates.py
+++ b/core/tests/test_templates.py
@@ -1,13 +1,10 @@
 from django.template.loader import render_to_string
 
-
 UNSUBSCRIBE_LABEL = 'Unsubscribe'
 
 
 def test_email_unsubscribe():
-    context = {
-        'unsubscribe_url': 'http://unsubscribe.com'
-    }
+    context = {'unsubscribe_url': 'http://unsubscribe.com'}
     html = render_to_string('email.html', context)
     assert context['unsubscribe_url'] in html
     assert UNSUBSCRIBE_LABEL in html
@@ -25,14 +22,7 @@ def test_new_companies_in_sector_email_utm(settings):
         'new_companies_in_sector_email.txt',
     ]
     settings.FAS_COMPANY_PROFILE_URL = 'http://profile/{number}'
-    context = {
-        'companies': [
-            {
-                'number': 1234
-            }
-        ],
-        'utm_params': 'thing=abc'
-    }
+    context = {'companies': [{'number': 1234}], 'utm_params': 'thing=abc'}
 
     for template_name in template_names:
         html = render_to_string(template_name, context)

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -2,8 +2,7 @@ import sys
 from importlib import import_module, reload
 
 from django.conf import settings
-from django.urls import clear_url_caches
-from django.urls import reverse
+from django.urls import clear_url_caches, reverse
 
 
 def reload_urlconf():

--- a/core/views.py
+++ b/core/views.py
@@ -1,8 +1,8 @@
 from django.http import HttpResponse
 from rest_framework.views import APIView
 
-from core.permissions import IsAuthenticatedCSVDump
 from core.helpers import get_file_from_s3
+from core.permissions import IsAuthenticatedCSVDump
 
 
 class CSVDumpAPIView(APIView):
@@ -12,15 +12,8 @@ class CSVDumpAPIView(APIView):
     filename = None
 
     def get(self, request, format=None):
-        csv_file = get_file_from_s3(
-            bucket=self.bucket,
-            key=self.key
-        )
-        response = HttpResponse(
-            csv_file['Body'].read(), content_type="text/csv"
-        )
-        content = 'attachment; filename="{filename}"'.format(
-            filename=self.filename
-        )
+        csv_file = get_file_from_s3(bucket=self.bucket, key=self.key)
+        response = HttpResponse(csv_file['Body'].read(), content_type="text/csv")
+        content = 'attachment; filename="{filename}"'.format(filename=self.filename)
         response['Content-Disposition'] = content
         return response

--- a/dataservices/admin.py
+++ b/dataservices/admin.py
@@ -1,36 +1,32 @@
-from import_export import resources
-from dataservices import models
-
 from django import forms
 from django.contrib import admin
-from django.db.models import TextField
 from django.contrib.postgres import fields
+from django.db.models import TextField
 from django_json_widget.widgets import JSONEditorWidget
+from import_export import resources
+
+from dataservices import models
 
 
 class EaseOfDoingBusinessResource(resources.ModelResource):
-
     class Meta:
         model = models.EaseOfDoingBusiness
         fields = ['country_name', 'country_code', 'year_2019']
 
 
 class CorruptionPerceptionsIndexResource(resources.ModelResource):
-
     class Meta:
         model = models.CorruptionPerceptionsIndex
         fields = ['country_name', 'country_code', 'cpi_score_2019', 'rank']
 
 
 class InternetUsageResource(resources.ModelResource):
-
     class Meta:
         model = models.InternetUsage
         fields = ['country_name', 'country_code', 'year_2017', 'year_2018']
 
 
 class CountryResource(resources.ModelResource):
-
     class Meta:
         model = models.Country
         fields = ['name', 'iso1', 'iso2', 'iso3', 'region']
@@ -38,9 +34,7 @@ class CountryResource(resources.ModelResource):
 
 @admin.register(models.EaseOfDoingBusiness)
 class EaseOfDoingBusinessAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
 
     search_fields = (
         'country_name',
@@ -57,16 +51,9 @@ class EaseOfDoingBusinessAdmin(admin.ModelAdmin):
 
 @admin.register(models.CorruptionPerceptionsIndex)
 class CorruptionPerceptionsIndexAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
 
-    search_fields = (
-        'country_name',
-        'country_code',
-        'cpi_score_2019',
-        'rank'
-    )
+    search_fields = ('country_name', 'country_code', 'cpi_score_2019', 'rank')
 
     list_display = (
         'country_name',
@@ -78,9 +65,7 @@ class CorruptionPerceptionsIndexAdmin(admin.ModelAdmin):
 
 @admin.register(models.WorldEconomicOutlook)
 class WorldEconomicOutlookAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
 
     search_fields = (
         'country_name',
@@ -102,9 +87,7 @@ class WorldEconomicOutlookAdmin(admin.ModelAdmin):
 
 @admin.register(models.CIAFactbook)
 class CIAFactbookAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
     formfield_overrides = {
         fields.JSONField: {'widget': JSONEditorWidget},
     }
@@ -122,9 +105,7 @@ class CIAFactbookAdmin(admin.ModelAdmin):
 
 @admin.register(models.InternetUsage)
 class InternetUsageAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
 
     search_fields = (
         'country_name',
@@ -143,9 +124,7 @@ class InternetUsageAdmin(admin.ModelAdmin):
 
 @admin.register(models.ConsumerPriceIndex)
 class ConsumerPriceIndexAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
 
     search_fields = (
         'country_name',
@@ -175,11 +154,10 @@ class CountryAdmin(admin.ModelAdmin):
         'created',
     )
 
-    list_filter = ('region', )
+    list_filter = ('region',)
 
 
 class GDPPerCapitaResource(resources.ModelResource):
-
     class Meta:
         model = models.GDPPerCapita
         fields = ['country_name', 'country_code', 'year_2019']
@@ -202,8 +180,4 @@ class GDPPerCapitaAdmin(admin.ModelAdmin):
 
 @admin.register(models.SuggestedCountry)
 class SuggestedCountryAdmin(admin.ModelAdmin):
-    list_display = (
-        'hs_code',
-        'country',
-        'order'
-    )
+    list_display = ('hs_code', 'country', 'order')

--- a/dataservices/management/commands/import_consumer_price_index_data.py
+++ b/dataservices/management/commands/import_consumer_price_index_data.py
@@ -1,6 +1,7 @@
-from django.core.management import BaseCommand
 import tablib
+from django.core.management import BaseCommand
 from import_export import resources
+
 from dataservices.models import ConsumerPriceIndex
 
 
@@ -13,8 +14,7 @@ class Command(BaseCommand):
         # File customised from world bank
         # https://data.worldbank.org/indicator/IT.NET.USER.ZS
         # TODO refactor merge structures and more intellect import without file manipulation
-        with open('dataservices/resources/Consumer_Price_Index.csv', 'r',
-                  encoding='utf-8-sig') as f:
+        with open('dataservices/resources/Consumer_Price_Index.csv', 'r', encoding='utf-8-sig') as f:
             data = tablib.import_set(f.read(), format='csv', headers=True)
             internet_usage_resource = resources.modelresource_factory(model=ConsumerPriceIndex)()
             result = internet_usage_resource.import_data(data, dry_run=True)

--- a/dataservices/management/commands/import_countries.py
+++ b/dataservices/management/commands/import_countries.py
@@ -1,7 +1,6 @@
 import tablib
-from import_export import resources
-
 from django.core.management import BaseCommand
+from import_export import resources
 
 from dataservices.models import Country
 
@@ -10,10 +9,17 @@ class Command(BaseCommand):
     help = 'Import Countries data'
 
     def handle(self, *args, **options):
-        with open('dataservices/resources/countries-territories-and-regions-1.0.csv', 'r',
-                  encoding='utf-8-sig') as f:
+        with open('dataservices/resources/countries-territories-and-regions-1.0.csv', 'r', encoding='utf-8-sig') as f:
             data = tablib.import_set(f.read(), format='csv', headers=True)
-            dataset = tablib.Dataset(headers=['name', 'iso1', 'iso2', 'iso3', 'region', ])
+            dataset = tablib.Dataset(
+                headers=[
+                    'name',
+                    'iso1',
+                    'iso2',
+                    'iso3',
+                    'region',
+                ]
+            )
 
             # add only contries and selected columns
             for item in data:

--- a/dataservices/management/commands/import_cpi_data.py
+++ b/dataservices/management/commands/import_cpi_data.py
@@ -1,6 +1,7 @@
-from django.core.management import BaseCommand
 import tablib
+from django.core.management import BaseCommand
 from import_export import resources
+
 from dataservices.models import CorruptionPerceptionsIndex
 
 
@@ -8,8 +9,7 @@ class Command(BaseCommand):
     help = 'Import CorruptionPerceptionsIndex data from transparency.org/'
 
     def handle(self, *args, **options):
-        with open('dataservices/resources/CPI2019.csv', 'r',
-                  encoding='utf-8-sig') as f:
+        with open('dataservices/resources/CPI2019.csv', 'r', encoding='utf-8-sig') as f:
             data = tablib.import_set(f.read(), format='csv', headers=True)
 
             corruptionperceptionsindex_resource = resources.modelresource_factory(model=CorruptionPerceptionsIndex)()

--- a/dataservices/management/commands/import_easeofdoingbusiness_data.py
+++ b/dataservices/management/commands/import_easeofdoingbusiness_data.py
@@ -1,6 +1,7 @@
-from django.core.management import BaseCommand
 import tablib
+from django.core.management import BaseCommand
 from import_export import resources
+
 from dataservices.models import EaseOfDoingBusiness
 
 
@@ -8,8 +9,7 @@ class Command(BaseCommand):
     help = 'Import easeofdoingbusiness data from worldbank.'
 
     def handle(self, *args, **options):
-        with open('dataservices/resources/EaseOfDoingBusiness.csv', 'r',
-                  encoding='utf-8-sig') as f:
+        with open('dataservices/resources/EaseOfDoingBusiness.csv', 'r', encoding='utf-8-sig') as f:
             data = tablib.import_set(f.read(), format='csv', headers=True)
             easeofdoingbusiness_resource = resources.modelresource_factory(model=EaseOfDoingBusiness)()
             result = easeofdoingbusiness_resource.import_data(data, dry_run=True)

--- a/dataservices/management/commands/import_gdp_per_capita_data.py
+++ b/dataservices/management/commands/import_gdp_per_capita_data.py
@@ -1,6 +1,6 @@
 import tablib
-from import_export import resources
 from django.core.management import BaseCommand
+from import_export import resources
 
 from dataservices.models import GDPPerCapita
 
@@ -9,13 +9,20 @@ class Command(BaseCommand):
     help = 'Import GDP Per Capita data for 2019 from www.imf.org'
 
     def handle(self, *args, **options):
-        with open('dataservices/resources/API_NY.GDP.PCAP.CD_DS2_en_csv_v2_1637514.csv', 'r',
-                  encoding='utf-8-sig') as f:
+        with open(
+            'dataservices/resources/API_NY.GDP.PCAP.CD_DS2_en_csv_v2_1637514.csv', 'r', encoding='utf-8-sig'
+        ) as f:
             data = tablib.import_set(f.read(), format='csv', headers=True)
             dataset = tablib.Dataset(headers=['country_name', 'country_code', 'year_2019'])
 
             for item in data:
-                dataset.append((item[0], item[1], item[63],))
+                dataset.append(
+                    (
+                        item[0],
+                        item[1],
+                        item[63],
+                    )
+                )
 
             gdp_per_capita_resource = resources.modelresource_factory(model=GDPPerCapita)()
             result = gdp_per_capita_resource.import_data(dataset, dry_run=True)

--- a/dataservices/management/commands/import_internet_usage_data.py
+++ b/dataservices/management/commands/import_internet_usage_data.py
@@ -1,6 +1,7 @@
-from django.core.management import BaseCommand
 import tablib
+from django.core.management import BaseCommand
 from import_export import resources
+
 from dataservices.models import InternetUsage
 
 
@@ -12,8 +13,7 @@ class Command(BaseCommand):
         # https://data.worldbank.org/indicator/IT.NET.USER.ZS
         # File has been manipulated in Excel to fit this shape
         # TODO refactor merge structures and more intellect import without file manipulation
-        with open('dataservices/resources/Internet_Usage.csv', 'r',
-                  encoding='utf-8-sig') as f:
+        with open('dataservices/resources/Internet_Usage.csv', 'r', encoding='utf-8-sig') as f:
             data = tablib.import_set(f.read(), format='csv', headers=True)
             internet_usage_resource = resources.modelresource_factory(model=InternetUsage)()
             result = internet_usage_resource.import_data(data, dry_run=True)

--- a/dataservices/management/commands/import_suggested_countries.py
+++ b/dataservices/management/commands/import_suggested_countries.py
@@ -1,5 +1,4 @@
 import tablib
-
 from django.core.management import BaseCommand
 
 from dataservices.models import Country, SuggestedCountry
@@ -9,8 +8,7 @@ class Command(BaseCommand):
     help = 'Import Countries data'
 
     def handle(self, *args, **options):
-        with open('dataservices/resources/SR.CREST.ALL.csv', 'r',
-                  encoding='utf-8-sig') as f:
+        with open('dataservices/resources/SR.CREST.ALL.csv', 'r', encoding='utf-8-sig') as f:
             data = tablib.import_set(f.read(), format='csv', headers=True)
             suggested_product_countries = []
 
@@ -29,11 +27,9 @@ class Command(BaseCommand):
                 if hs_code and len(suggested_countries) > 0:
                     order = 1
                     for country in suggested_countries:
-                        suggested_product_countries.append(SuggestedCountry(
-                            hs_code=hs_code,
-                            country=country,
-                            order=order
-                        ))
+                        suggested_product_countries.append(
+                            SuggestedCountry(hs_code=hs_code, country=country, order=order)
+                        )
                         order += 1
 
             SuggestedCountry.objects.all().delete()

--- a/dataservices/management/commands/import_weo_data.py
+++ b/dataservices/management/commands/import_weo_data.py
@@ -1,6 +1,6 @@
 import tablib
-from import_export import resources
 from django.core.management import BaseCommand
+from import_export import resources
 
 from dataservices.models import WorldEconomicOutlook
 
@@ -9,8 +9,7 @@ class Command(BaseCommand):
     help = 'Import world economic data from www.imf.org'
 
     def handle(self, *args, **options):
-        with open('dataservices/resources/weo.csv', 'r',
-                  encoding='utf-8-sig') as f:
+        with open('dataservices/resources/weo.csv', 'r', encoding='utf-8-sig') as f:
             data = tablib.import_set(f.read(), format='csv', headers=True)
 
             weo_resource = resources.modelresource_factory(model=WorldEconomicOutlook)()

--- a/dataservices/management/commands/report_population_data_lookups.py
+++ b/dataservices/management/commands/report_population_data_lookups.py
@@ -1,5 +1,6 @@
-from django.core.management import BaseCommand
 from directory_constants import choices
+from django.core.management import BaseCommand
+
 from dataservices import helpers
 
 

--- a/dataservices/management/commands/tests/test_import_data.py
+++ b/dataservices/management/commands/tests/test_import_data.py
@@ -1,19 +1,23 @@
-import pytest
 from unittest import mock
 
+import pytest
 from django.core import management
 from import_export import results
+
 from dataservices import models
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('model_name, management_cmd, object_count', (
-    (models.CorruptionPerceptionsIndex, 'import_cpi_data', 180,),
-    (models.EaseOfDoingBusiness, 'import_easeofdoingbusiness_data', 264),
-    (models.WorldEconomicOutlook, 'import_weo_data', 1552),
-    (models.InternetUsage, 'import_internet_usage_data', 264),
-    (models.ConsumerPriceIndex, 'import_consumer_price_index_data', 264),
-))
+@pytest.mark.parametrize(
+    'model_name, management_cmd, object_count',
+    (
+        (models.CorruptionPerceptionsIndex, 'import_cpi_data', 180),
+        (models.EaseOfDoingBusiness, 'import_easeofdoingbusiness_data', 264),
+        (models.WorldEconomicOutlook, 'import_weo_data', 1552),
+        (models.InternetUsage, 'import_internet_usage_data', 264),
+        (models.ConsumerPriceIndex, 'import_consumer_price_index_data', 264),
+    ),
+)
 def test_import_data_sets(model_name, management_cmd, object_count):
     model_name.objects.create(country_name='abc', country_code='a')
     management.call_command(management_cmd)
@@ -22,20 +26,29 @@ def test_import_data_sets(model_name, management_cmd, object_count):
 
 @pytest.mark.django_db
 @mock.patch.object(results.Result, 'has_errors', mock.Mock(return_value=True))
-@pytest.mark.parametrize('management_cmd', [
-    'import_cpi_data', 'import_easeofdoingbusiness_data', 'import_weo_data', 'import_internet_usage_data',
-    'import_consumer_price_index_data',
-])
+@pytest.mark.parametrize(
+    'management_cmd',
+    [
+        'import_cpi_data',
+        'import_easeofdoingbusiness_data',
+        'import_weo_data',
+        'import_internet_usage_data',
+        'import_consumer_price_index_data',
+    ],
+)
 def test_import_data_sets_error(management_cmd):
     management.call_command(management_cmd)
     assert models.CorruptionPerceptionsIndex.objects.count() == 0
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('model_name, management_cmd, object_count', (
-    (models.Country, 'import_countries', 194),
-    (models.GDPPerCapita, 'import_gdp_per_capita_data', 264),
-))
+@pytest.mark.parametrize(
+    'model_name, management_cmd, object_count',
+    (
+        (models.Country, 'import_countries', 194),
+        (models.GDPPerCapita, 'import_gdp_per_capita_data', 264),
+    ),
+)
 def test_import_countries_data_sets(model_name, management_cmd, object_count):
     management.call_command(management_cmd)
     assert model_name.objects.count() == object_count

--- a/dataservices/models.py
+++ b/dataservices/models.py
@@ -1,8 +1,8 @@
-from django.db import models
 from django.contrib.postgres.fields import JSONField
+from django.db import models
+from django.utils.translation import gettext as _
 
 from core.helpers import TimeStampedModel
-from django.utils.translation import gettext as _
 
 
 class EaseOfDoingBusiness(TimeStampedModel):
@@ -77,6 +77,7 @@ class Country(TimeStampedModel):
     """
     Model to hold all countries
     """
+
     name = models.CharField(unique=True, blank=False, null=False, max_length=255)
     iso1 = models.CharField(unique=True, max_length=10)
     iso2 = models.CharField(unique=True, max_length=10)
@@ -103,10 +104,7 @@ class GDPPerCapita(TimeStampedModel):
 class SuggestedCountry(TimeStampedModel):
     hs_code = models.PositiveIntegerField(_('HS Code'))
     country = models.ForeignKey(
-        'dataservices.Country',
-        verbose_name=_('Suggested Countries'),
-        on_delete=models.SET_NULL,
-        null=True
+        'dataservices.Country', verbose_name=_('Suggested Countries'), on_delete=models.SET_NULL, null=True
     )
 
     order = models.PositiveIntegerField(_('Order'), null=True, blank=True)

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -15,35 +15,30 @@ class EaseOfDoingBusinessSerializer(serializers.ModelSerializer):
 
 
 class CorruptionPerceptionsIndexSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.CorruptionPerceptionsIndex
         exclude = ['created', 'id', 'modified']
 
 
 class WorldEconomicOutlookSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.WorldEconomicOutlook
         exclude = ['created', 'id', 'modified']
 
 
 class InternetUsageSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.InternetUsage
         exclude = ['created', 'id', 'modified']
 
 
 class ConsumerPriceIndexSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.ConsumerPriceIndex
         exclude = ['created', 'id', 'modified']
 
 
 class GDPPerCapitalSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.GDPPerCapita
         exclude = ['created', 'id', 'modified']

--- a/dataservices/tasks.py
+++ b/dataservices/tasks.py
@@ -1,10 +1,11 @@
+import requests
+from django.db import transaction
+
 from conf.celery import app
 from dataservices.models import CIAFactbook
-from django.db import transaction
-import requests
 
 
-@app.task(autoretry_for=(TimeoutError, ))
+@app.task(autoretry_for=(TimeoutError,))
 @transaction.atomic
 def load_cia_factbook_data_from_url(url):
     # This function expects the pass in a URL for the JSON file which is formatted as
@@ -16,8 +17,4 @@ def load_cia_factbook_data_from_url(url):
     for country in data['countries']:
         country_name = data['countries'][country]['data']['name']
         country_data = data['countries'][country]['data']
-        CIAFactbook(
-            country_key=country,
-            country_name=country_name,
-            factbook_data=country_data
-        ).save()
+        CIAFactbook(country_key=country, country_name=country_name, factbook_data=country_data).save()

--- a/dataservices/tests/conftest.py
+++ b/dataservices/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from dataservices import models
 
 
@@ -11,12 +12,7 @@ def internet_usage_data():
             year=2020,
             value=90.97,
         ),
-        models.InternetUsage(
-            country_code='DEU',
-            country_name='Germany',
-            year=2020,
-            value=91.97
-        )
+        models.InternetUsage(country_code='DEU', country_name='Germany', year=2020, value=91.97),
     ]
     yield models.InternetUsage.objects.bulk_create(country_data)
     models.InternetUsage.objects.all().delete()

--- a/dataservices/tests/factories.py
+++ b/dataservices/tests/factories.py
@@ -9,16 +9,20 @@ class CIAFactBookFactory(factory.django.DjangoModelFactory):
     country_key = 'united_kingdom'
     country_name = 'United Kingdom'
     factbook_data = {
-        'population': '60m', 'capital': 'London', 'currency': 'GBP',
+        'population': '60m',
+        'capital': 'London',
+        'currency': 'GBP',
         'people': {
             'languages': {
                 'date': '2012',
                 'note': 'test data',
                 'language': [
-                    {'name': 'English', }
-                ]
+                    {
+                        'name': 'English',
+                    }
+                ],
             }
-        }
+        },
     }
 
     class Meta:

--- a/dataservices/tests/test_helpers.py
+++ b/dataservices/tests/test_helpers.py
@@ -1,117 +1,101 @@
 import json
-import pytest
+import re
 from unittest import mock
 
-import re
+import pytest
+
 from dataservices import helpers, models
 from dataservices.tests import factories
 
 
 @pytest.fixture(autouse=True)
 def comtrade():
-    return helpers.ComTradeData(
-        commodity_code='220.850',
-        reporting_area='Australia'
-    )
+    return helpers.ComTradeData(commodity_code='220.850', reporting_area='Australia')
 
 
 @pytest.fixture()
 def comtrade_data():
-    return {"dataset":
-            [
-                {
-                    "period": 2018,
-                    "rtTitle": "Australia",
-                    "ptTitle": "United Kingdom",
-                    "TradeValue": 200,
-                },
-                {
-                    "period": 2017,
-                    "rtTitle": "Australia",
-                    "ptTitle": "United Kingdom",
-                    "TradeValue": 100,
-                },
-                {
-                    "period": 2016,
-                    "rtTitle": "Italy",
-                    "ptTitle": "United Kingdom",
-                    "TradeValue": 50,
-                },
-            ]}
+    return {
+        "dataset": [
+            {
+                "period": 2018,
+                "rtTitle": "Australia",
+                "ptTitle": "United Kingdom",
+                "TradeValue": 200,
+            },
+            {
+                "period": 2017,
+                "rtTitle": "Australia",
+                "ptTitle": "United Kingdom",
+                "TradeValue": 100,
+            },
+            {
+                "period": 2016,
+                "rtTitle": "Italy",
+                "ptTitle": "United Kingdom",
+                "TradeValue": 50,
+            },
+        ]
+    }
 
 
 @pytest.fixture()
 def comtrade_data_with_a_year_data():
-    return {"dataset":
-            [
-                {
-                    "period": 2018,
-                    "rtTitle": "Australia",
-                    "ptTitle": "United Kingdom",
-                    "TradeValue": 200,
-                },
-
-            ]}
+    return {
+        "dataset": [
+            {
+                "period": 2018,
+                "rtTitle": "Australia",
+                "ptTitle": "United Kingdom",
+                "TradeValue": 200,
+            },
+        ]
+    }
 
 
 @pytest.fixture()
 def comtrade_data_with_various_year_data():
-    return {"dataset":
-            [
-                {
-                    "period": 2018,
-                    "rtTitle": "Australia",
-                    "ptTitle": "United Kingdom",
-                    "TradeValue": 200,
-                },
-                {
-                    "period": 2013,
-                    "rtTitle": "Australia",
-                    "ptTitle": "United Kingdom",
-                    "TradeValue": 200,
-                },
-
-            ]}
+    return {
+        "dataset": [
+            {
+                "period": 2018,
+                "rtTitle": "Australia",
+                "ptTitle": "United Kingdom",
+                "TradeValue": 200,
+            },
+            {
+                "period": 2013,
+                "rtTitle": "Australia",
+                "ptTitle": "United Kingdom",
+                "TradeValue": 200,
+            },
+        ]
+    }
 
 
 @pytest.fixture()
 def comtrade_data_with_various_data_request_mock(comtrade_data_with_various_year_data, requests_mocker):
-    return requests_mocker.get(
-        re.compile('https://comtrade.un.org/.*'),
-        json=comtrade_data_with_various_year_data
-    )
+    return requests_mocker.get(re.compile('https://comtrade.un.org/.*'), json=comtrade_data_with_various_year_data)
 
 
 @pytest.fixture()
 def comtrade_data_with_a_year_data_request_mock(comtrade_data_with_a_year_data, requests_mocker):
-    return requests_mocker.get(
-        re.compile('https://comtrade.un.org/.*'),
-        json=comtrade_data_with_a_year_data
-    )
+    return requests_mocker.get(re.compile('https://comtrade.un.org/.*'), json=comtrade_data_with_a_year_data)
 
 
 @pytest.fixture()
 def empty_comtrade():
-    return helpers.ComTradeData(
-        commodity_code='2120.8350',
-        reporting_area='Australia'
-    )
+    return helpers.ComTradeData(commodity_code='2120.8350', reporting_area='Australia')
 
 
 @pytest.fixture()
 def comtrade_request_mock(comtrade_data, requests_mocker):
-    return requests_mocker.get(
-        re.compile('https://comtrade.un.org/.*'),
-        json=comtrade_data
-    )
+    return requests_mocker.get(re.compile('https://comtrade.un.org/.*'), json=comtrade_data)
 
 
 @pytest.fixture()
 def comtrade_request_mock_empty(comtrade_data, requests_mocker):
-    return requests_mocker.get(
-        re.compile('https://comtrade.un.org/.*'),
-        json={'dataset': []}
-    )
+    return requests_mocker.get(re.compile('https://comtrade.un.org/.*'), json={'dataset': []})
 
 
 def test_get_url(comtrade):
@@ -135,25 +119,24 @@ def test_get_product_code(comtrade):
 def test_get_last_year_import_data(comtrade, comtrade_request_mock):
     last_year_data = comtrade.get_last_year_import_data()
     assert last_year_data == {
-                'year': '2018',
-                'trade_value': '200',
-                'country_name': 'Australia',
-                'year_on_year_change':  '0.5',
-        }
+        'year': '2018',
+        'trade_value': '200',
+        'country_name': 'Australia',
+        'year_on_year_change': '0.5',
+    }
 
 
 def test_get_last_year_import__with_various_year_data(comtrade, comtrade_data_with_various_data_request_mock):
     last_year_data = comtrade.get_last_year_import_data()
     assert last_year_data == {
-                'year': '2018',
-                'trade_value': '200',
-                'country_name': 'Australia',
-                'year_on_year_change':  None,
-        }
+        'year': '2018',
+        'trade_value': '200',
+        'country_name': 'Australia',
+        'year_on_year_change': None,
+    }
 
 
-def test_get_last_year_import_data_with_a_year_data(
-        comtrade, comtrade_data_with_a_year_data_request_mock):
+def test_get_last_year_import_data_with_a_year_data(comtrade, comtrade_data_with_a_year_data_request_mock):
     last_year_data = comtrade.get_last_year_import_data()
     assert last_year_data == {
         'year': '2018',
@@ -166,11 +149,11 @@ def test_get_last_year_import_data_with_a_year_data(
 def test_get_last_year_import_data_from_uk(comtrade, comtrade_request_mock):
     last_year_data = comtrade.get_last_year_import_data(from_uk=True)
     assert last_year_data == {
-                'year': '2018',
-                'trade_value': '200',
-                'country_name': 'Australia',
-                'year_on_year_change':  '0.5',
-        }
+        'year': '2018',
+        'trade_value': '200',
+        'country_name': 'Australia',
+        'year_on_year_change': '0.5',
+    }
 
 
 def test_get_last_year_import_data_empty(empty_comtrade, comtrade_request_mock_empty):
@@ -199,7 +182,7 @@ def test_get_all_historical_import_value(comtrade, comtrade_request_mock):
     historical_data = comtrade.get_all_historical_import_value()
     assert historical_data == {
         'historical_trade_value_partner': {2018: '200', 2017: '100', 2016: '50'},
-        'historical_trade_value_all': {2018: '350', 2017: '350', 2016: '350'}
+        'historical_trade_value_all': {2018: '350', 2017: '350', 2016: '350'},
     }
 
 
@@ -212,9 +195,7 @@ def test_get_ease_of_business_index():
         year_2019=20,
     )
     ease_of_business_data = helpers.get_ease_of_business_index('AUS')
-    assert ease_of_business_data == {
-        'total': 1, 'country_name': 'Australia', 'country_code': 'AUS', 'year_2019': 20
-    }
+    assert ease_of_business_data == {'total': 1, 'country_name': 'Australia', 'country_code': 'AUS', 'year_2019': 20}
 
 
 @pytest.mark.django_db
@@ -228,15 +209,10 @@ def test_get_ease_of_business_index_not_found():
 def test_get_corruption_perceptions_index():
 
     models.CorruptionPerceptionsIndex.objects.create(
-        country_code='AUS',
-        country_name='Australia',
-        cpi_score_2019=24,
-        rank=21
+        country_code='AUS', country_name='Australia', cpi_score_2019=24, rank=21
     )
     cpi_data = helpers.get_corruption_perception_index('AUS')
-    assert cpi_data == {
-        'country_name': 'Australia', 'country_code': 'AUS', 'cpi_score_2019': 24, 'rank': 21
-    }
+    assert cpi_data == {'country_name': 'Australia', 'country_code': 'AUS', 'cpi_score_2019': 24, 'rank': 21}
 
 
 @pytest.mark.django_db
@@ -249,7 +225,7 @@ def test_get_all_historical_import_data_helper(comtrade, comtrade_request_mock):
     historical_data = helpers.get_historical_import_data('AUS', '847.33.22')
     assert historical_data == {
         'historical_trade_value_partner': {2018: '200', 2017: '100', 2016: '50'},
-        'historical_trade_value_all': {2018: '350', 2017: '350', 2016: '350'}
+        'historical_trade_value_all': {2018: '350', 2017: '350', 2016: '350'},
     }
 
 
@@ -257,7 +233,10 @@ def test_get_last_year_import_data_helper(comtrade, comtrade_request_mock):
     historical_data = helpers.get_last_year_import_data('AUS', '847.33.22')
 
     assert historical_data == {
-        'year': '2018', 'trade_value': '200', 'country_name': 'Australia', 'year_on_year_change': '0.5'
+        'year': '2018',
+        'trade_value': '200',
+        'country_name': 'Australia',
+        'year_on_year_change': '0.5',
     }
 
 
@@ -266,15 +245,14 @@ def test_get_last_year_import_data_helper(comtrade, comtrade_request_mock):
 @mock.patch.object(helpers.ComTradeData, 'get_all_historical_import_value')
 @mock.patch.object(helpers.ComTradeData, '__init__')
 def test_get_last_year_import_data_helper_cached(
-        mock_comtrade_init, mock_comtrade_historical, mock_set_cache_value, mock_get_cache_value
+    mock_comtrade_init, mock_comtrade_historical, mock_set_cache_value, mock_get_cache_value
 ):
     mock_get_cache_value.return_value = None
     mock_comtrade_init.return_value = None
 
     comtrade_historical_data = {
-        'historical_trade_value_partner': {2018: '200', 2017: '100',
-                                           2016: '50'},
-        'historical_trade_value_all': {2018: '350', 2017: '350', 2016: '350'}
+        'historical_trade_value_partner': {2018: '200', 2017: '100', 2016: '50'},
+        'historical_trade_value_all': {2018: '350', 2017: '350', 2016: '350'},
     }
 
     mock_comtrade_historical.return_value = comtrade_historical_data
@@ -290,7 +268,7 @@ def test_get_last_year_import_data_helper_cached(
     assert mock_set_cache_value.call_count == 1
     assert mock_set_cache_value.call_args == mock.call(
         json.dumps(['get_historical_import_data', {}, ["AUS", "847.33.22"]], sort_keys=True, separators=(',', ':')),
-        historical_data
+        historical_data,
     )
 
     mock_get_cache_value.return_value = comtrade_historical_data
@@ -313,7 +291,7 @@ def test_get_last_year_import_data_helper_cached(
 @mock.patch.object(helpers.ComTradeData, 'get_all_historical_import_value')
 @mock.patch.object(helpers.ComTradeData, '__init__')
 def test_get_last_year_import_data_helper_not_cached(
-        mock_comtrade_init, mock_comtrade_historical, mock_set_cache_value, mock_get_cache_value
+    mock_comtrade_init, mock_comtrade_historical, mock_set_cache_value, mock_get_cache_value
 ):
     mock_get_cache_value.return_value = None
     mock_comtrade_init.return_value = None
@@ -359,7 +337,6 @@ def test_get_world_economic_outlook_data():
         units='Percent change',
         year_2020=323.21,
         year_2021=1231.1,
-
     )
     models.WorldEconomicOutlook.objects.create(
         country_code='CN',
@@ -369,24 +346,28 @@ def test_get_world_economic_outlook_data():
         units='dollars',
         year_2020=21234141,
         year_2021=32432423,
-
     )
 
     weo_data = helpers.get_world_economic_outlook_data('CN')
     assert weo_data == [
         {
-            "country_code": "CN", "country_name": "China",
+            "country_code": "CN",
+            "country_name": "China",
             "subject": "Gross domestic product per capita, constant prices ",
-            "scale": "international dollars", "units": "dollars",
-            "year_2020": "21234141.000", "year_2021": "32432423.000"},
+            "scale": "international dollars",
+            "units": "dollars",
+            "year_2020": "21234141.000",
+            "year_2021": "32432423.000",
+        },
         {
-            "country_code": "CN", "country_name": "China",
+            "country_code": "CN",
+            "country_name": "China",
             "subject": "Gross domestic product",
-            "scale": "constant prices", "units":
-            "Percent change", "year_2020": "323.210",
-            "year_2021": "1231.100"
-        }
-
+            "scale": "constant prices",
+            "units": "Percent change",
+            "year_2020": "323.210",
+            "year_2021": "1231.100",
+        },
     ]
 
 
@@ -425,7 +406,11 @@ def test_get_cia_factbook_by_keys_some_bad_Keys():
 
 
 @pytest.mark.parametrize(
-    'sex, expected', [['male', 4636], ['female', 4555], ]
+    'sex, expected',
+    [
+        ['male', 4636],
+        ['female', 4555],
+    ],
 )
 @pytest.mark.django_db
 def test_get_population_target_age_sex_data(sex, expected):
@@ -448,7 +433,11 @@ def test_get_population_target_age_sex_data_bad_country():
 
 
 @pytest.mark.parametrize(
-    'classification, expected', [['urban', 56495], ['rural', 10839], ]
+    'classification, expected',
+    [
+        ['urban', 56495],
+        ['rural', 10839],
+    ],
 )
 @pytest.mark.django_db
 def test_get_population_urban_rural_data(classification, expected):
@@ -486,10 +475,7 @@ def test_get_population_total_data_bad_country():
 
 @pytest.mark.parametrize(
     'target_age_groups, expected',
-    [
-        [['0-14'], ['0-4', '5-9', '10-14']],
-        [['15-19', '25-34'], ['15-19', '25-29', '30-34']]
-    ]
+    [[['0-14'], ['0-4', '5-9', '10-14']], [['15-19', '25-34'], ['15-19', '25-29', '30-34']]],
 )
 @pytest.mark.django_db
 def test_get_mapped_age_groups(target_age_groups, expected):
@@ -500,8 +486,7 @@ def test_get_mapped_age_groups(target_age_groups, expected):
 @pytest.mark.django_db
 def test_get_population_data():
     population_data = helpers.PopulationData().get_population_data(
-        country='United Kingdom',
-        target_ages=['25-34', '35-44']
+        country='United Kingdom', target_ages=['25-34', '35-44']
     )
 
     assert population_data == {
@@ -521,10 +506,7 @@ def test_get_population_data():
 
 @pytest.mark.django_db
 def test_get_population_data_bad_country():
-    population_data = helpers.PopulationData().get_population_data(
-        country='ewfwe',
-        target_ages=['25-34', '35-44']
-    )
+    population_data = helpers.PopulationData().get_population_data(country='ewfwe', target_ages=['25-34', '35-44'])
     assert population_data == {'country': 'ewfwe', 'target_ages': ['25-34', '35-44'], 'year': 2020}
 
 
@@ -553,11 +535,14 @@ def test_get_internet_usage_with_no_country():
     assert data == {}
 
 
-@pytest.mark.parametrize("input_1,input_2,expected", [
-    (1, 30, '3.33% (1.00 thousand)'),
-    (1, 0, None),
-    (1, None, None),
-])
+@pytest.mark.parametrize(
+    "input_1,input_2,expected",
+    [
+        (1, 30, '3.33% (1.00 thousand)'),
+        (1, 0, None),
+        (1, None, None),
+    ],
+)
 def test_get_percentage_format(input_1, input_2, expected):
     data = helpers.get_percentage_format(input_1, input_2)
     assert data == expected

--- a/dataservices/tests/test_models.py
+++ b/dataservices/tests/test_models.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dataservices.tests.factories import SuggestedCountriesFactory, CIAFactBookFactory
+from dataservices.tests.factories import CIAFactBookFactory, SuggestedCountriesFactory
 
 
 @pytest.mark.django_db

--- a/dataservices/tests/test_tasks.py
+++ b/dataservices/tests/test_tasks.py
@@ -1,33 +1,29 @@
+import re
+
 import pytest
+
 from dataservices import tasks
 from dataservices.models import CIAFactbook
-import re
 
 
 @pytest.fixture()
 def cia_factbook_data(requests_mocker):
     return {
         "countries": {
-            "world": {
-                "data": {
-                    "name": "the world",
-                    "description": "world"
-                }},
+            "world": {"data": {"name": "the world", "description": "world"}},
             "united_kingdom": {
                 "data": {
                     "name": "United Kingdom",
                     "description": "world",
-                    }},
+                }
+            },
         },
     }
 
 
 @pytest.fixture()
 def cia_factbook_request_mock(requests_mocker, cia_factbook_data):
-    return requests_mocker.get(
-        re.compile('https://raw.githubusercontent.com/.*'),
-        json=cia_factbook_data
-    )
+    return requests_mocker.get(re.compile('https://raw.githubusercontent.com/.*'), json=cia_factbook_data)
 
 
 @pytest.mark.django_db

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -1,12 +1,12 @@
 import json
-import pytest
 from unittest import mock
 
-from django.urls import reverse
+import pytest
 from django.core import management
+from django.urls import reverse
 from rest_framework.test import APIClient
 
-from dataservices import models, helpers
+from dataservices import helpers, models
 from dataservices.tests import factories
 
 
@@ -17,31 +17,15 @@ def api_client():
 
 @pytest.fixture(autouse=True)
 def easeofdoingbusiness_data():
-    models.EaseOfDoingBusiness.objects.create(
-        country_code='CN',
-        country_name='China',
-        year_2019=10
-    )
-    models.EaseOfDoingBusiness.objects.create(
-        country_code='IND',
-        country_name='India',
-        year_2019=5
-    )
+    models.EaseOfDoingBusiness.objects.create(country_code='CN', country_name='China', year_2019=10)
+    models.EaseOfDoingBusiness.objects.create(country_code='IND', country_name='India', year_2019=5)
 
 
 @pytest.fixture(autouse=True)
 def corruptionperceptionsindex_data():
+    models.CorruptionPerceptionsIndex.objects.create(country_code='CN', country_name='China', cpi_score_2019=10, rank=3)
     models.CorruptionPerceptionsIndex.objects.create(
-        country_code='CN',
-        country_name='China',
-        cpi_score_2019=10,
-        rank=3
-    )
-    models.CorruptionPerceptionsIndex.objects.create(
-        country_code='IND',
-        country_name='India',
-        cpi_score_2019=28,
-        rank=9
+        country_code='IND', country_name='India', cpi_score_2019=28, rank=9
     )
 
 
@@ -55,7 +39,6 @@ def worldeconomicoutlook_data():
         units='Percent change',
         year_2020=323.21,
         year_2021=1231.1,
-
     )
     models.WorldEconomicOutlook.objects.create(
         country_code='CN',
@@ -65,7 +48,6 @@ def worldeconomicoutlook_data():
         units='dollars',
         year_2020=21234141,
         year_2021=32432423,
-
     )
     models.WorldEconomicOutlook.objects.create(
         country_code='IND',
@@ -75,30 +57,14 @@ def worldeconomicoutlook_data():
         units='Percent change',
         year_2020=99,
         year_2021=89,
-
     )
 
 
 @pytest.fixture(autouse=True)
 def country_data():
-    models.ConsumerPriceIndex.objects.create(
-        country_code='UK',
-        country_name='United Kingdom',
-        year=2019,
-        value=150.56
-    )
-    models.ConsumerPriceIndex.objects.create(
-        country_code='CNN',
-        country_name='Canada',
-        year=2019,
-        value=20.56
-    )
-    models.InternetUsage.objects.create(
-        country_code='CNN',
-        country_name='Canada',
-        year=2019,
-        value=20.23
-    )
+    models.ConsumerPriceIndex.objects.create(country_code='UK', country_name='United Kingdom', year=2019, value=150.56)
+    models.ConsumerPriceIndex.objects.create(country_code='CNN', country_name='Canada', year=2019, value=20.56)
+    models.InternetUsage.objects.create(country_code='CNN', country_name='Canada', year=2019, value=20.23)
 
 
 @pytest.fixture(autouse=True)
@@ -108,22 +74,16 @@ def cia_factbook_data():
 
 @pytest.mark.django_db
 def test_get_easeofdoingbusiness(api_client):
-    url = reverse(
-        'dataservices-easeofdoingbusiness-index', kwargs={'country_code': 'CN'}
-    )
+    url = reverse('dataservices-easeofdoingbusiness-index', kwargs={'country_code': 'CN'})
 
     response = api_client.get(url)
     assert response.status_code == 200
-    assert response.json() == {
-        'country_name': 'China', 'country_code': 'CN', 'year_2019': 10, 'total': 2
-    }
+    assert response.json() == {'country_name': 'China', 'country_code': 'CN', 'year_2019': 10, 'total': 2}
 
 
 @pytest.mark.django_db
 def test_get_easeofdoingbusiness_not_found(api_client):
-    url = reverse(
-        'dataservices-easeofdoingbusiness-index', kwargs={'country_code': 'xxx'}
-    )
+    url = reverse('dataservices-easeofdoingbusiness-index', kwargs={'country_code': 'xxx'})
 
     response = api_client.get(url)
     assert response.status_code == 200
@@ -132,22 +92,16 @@ def test_get_easeofdoingbusiness_not_found(api_client):
 
 @pytest.mark.django_db
 def test_get_corruptionperceptionsindex(api_client):
-    url = reverse(
-        'dataservices-corruptionperceptionsindex', kwargs={'country_code': 'CN'}
-    )
+    url = reverse('dataservices-corruptionperceptionsindex', kwargs={'country_code': 'CN'})
 
     response = api_client.get(url)
     assert response.status_code == 200
-    assert response.json() == {
-        'country_name': 'China', 'country_code': 'CN', 'cpi_score_2019': 10, 'rank': 3
-    }
+    assert response.json() == {'country_name': 'China', 'country_code': 'CN', 'cpi_score_2019': 10, 'rank': 3}
 
 
 @pytest.mark.django_db
 def test_get_corruptionperceptionsindex_not_found(api_client):
-    url = reverse(
-        'dataservices-corruptionperceptionsindex', kwargs={'country_code': 'xxx'}
-    )
+    url = reverse('dataservices-corruptionperceptionsindex', kwargs={'country_code': 'xxx'})
 
     response = api_client.get(url)
     assert response.status_code == 200
@@ -156,33 +110,36 @@ def test_get_corruptionperceptionsindex_not_found(api_client):
 
 @pytest.mark.django_db
 def test_get_world_economic_outlook(api_client):
-    url = reverse(
-        'dataservices-world-economic-outlook', kwargs={'country_code': 'CN'}
-    )
+    url = reverse('dataservices-world-economic-outlook', kwargs={'country_code': 'CN'})
 
     response = api_client.get(url)
     assert response.status_code == 200
 
     assert response.json() == [
         {
-            'country_code': 'CN', 'country_name': 'China',
+            'country_code': 'CN',
+            'country_name': 'China',
             'subject': 'Gross domestic product per capita, constant prices ',
-            'scale': 'international dollars', 'units': 'dollars',
-            'year_2020': '21234141.000', 'year_2021': '32432423.000'},
+            'scale': 'international dollars',
+            'units': 'dollars',
+            'year_2020': '21234141.000',
+            'year_2021': '32432423.000',
+        },
         {
-            'country_code': 'CN', 'country_name': 'China',
-            'subject': 'Gross domestic product', 'scale': 'constant prices',
-            'units': 'Percent change', 'year_2020': '323.210',
-            'year_2021': '1231.100'
-        }
+            'country_code': 'CN',
+            'country_name': 'China',
+            'subject': 'Gross domestic product',
+            'scale': 'constant prices',
+            'units': 'Percent change',
+            'year_2020': '323.210',
+            'year_2021': '1231.100',
+        },
     ]
 
 
 @pytest.mark.django_db
 def test_get_worldeconomicoutlook_not_found(api_client):
-    url = reverse(
-        'dataservices-world-economic-outlook', kwargs={'country_code': 'xxx'}
-    )
+    url = reverse('dataservices-world-economic-outlook', kwargs={'country_code': 'xxx'})
 
     response = api_client.get(url)
     assert response.status_code == 200
@@ -192,7 +149,12 @@ def test_get_worldeconomicoutlook_not_found(api_client):
 @pytest.mark.django_db
 @mock.patch.object(helpers.ComTradeData, 'get_last_year_import_data')
 def test_last_year_import_data(mock_get_last_year_import_data, api_client):
-    data = {'import_value': {'year': 2019, 'trade_value': 100, }}
+    data = {
+        'import_value': {
+            'year': 2019,
+            'trade_value': 100,
+        }
+    }
     mock_get_last_year_import_data.return_value = data
 
     url = reverse('last-year-import-data')
@@ -207,7 +169,12 @@ def test_last_year_import_data(mock_get_last_year_import_data, api_client):
 @pytest.mark.django_db
 @mock.patch.object(helpers.ComTradeData, 'get_last_year_import_data')
 def test_last_year_import_data_from_uk(mock_get_last_year_import_data, api_client):
-    data = {'import_value': {'year': 2019, 'trade_value': 100, }}
+    data = {
+        'import_value': {
+            'year': 2019,
+            'trade_value': 100,
+        }
+    }
     mock_get_last_year_import_data.return_value = data
 
     url = reverse('last-year-import-data-from-uk')
@@ -241,7 +208,7 @@ def test_historical_import_data(mock_comtrade_constructor, mock_hist_partner, mo
 
     assert response.json() == {
         'historical_trade_value_partner': {'2017': 1000},
-        'historical_trade_value_all': {'2017': 3000}
+        'historical_trade_value_all': {'2017': 3000},
     }
 
 
@@ -258,9 +225,7 @@ def test_get_cia_factbook_data(api_client):
 
 @pytest.mark.django_db
 def test_get_country_data(api_client):
-    url = reverse(
-        'dataservices-country-data', kwargs={'country': 'Canada'}
-    )
+    url = reverse('dataservices-country-data', kwargs={'country': 'Canada'})
 
     response = api_client.get(url)
     assert response.status_code == 200
@@ -271,38 +236,33 @@ def test_get_country_data(api_client):
             'internet_usage': {'country_name': 'Canada', 'country_code': 'CNN', 'value': '20.230', 'year': 2019},
             'corruption_perceptions_index': None,
             'ease_of_doing_bussiness': None,
-            'gdp_per_capita': None
+            'gdp_per_capita': None,
         }
     }
 
 
 @pytest.mark.django_db
 def test_get_country_data_not_found(api_client):
-    url = reverse(
-        'dataservices-country-data', kwargs={'country': 'xyz'}
-    )
+    url = reverse('dataservices-country-data', kwargs={'country': 'xyz'})
 
     response = api_client.get(url)
     assert response.status_code == 200
 
     assert response.json() == {
-        'country_data':
-            {
-                'consumer_price_index': None,
-                'internet_usage': None,
-                'corruption_perceptions_index': None,
-                'ease_of_doing_bussiness': None,
-                'gdp_per_capita': None
-             }
+        'country_data': {
+            'consumer_price_index': None,
+            'internet_usage': None,
+            'corruption_perceptions_index': None,
+            'ease_of_doing_bussiness': None,
+            'gdp_per_capita': None,
+        }
     }
 
 
 @pytest.mark.django_db
 def test_get_country_data_cpi_not_found(api_client):
     models.ConsumerPriceIndex.objects.get(country_name='Canada').delete()
-    url = reverse(
-        'dataservices-country-data', kwargs={'country': 'Canada'}
-    )
+    url = reverse('dataservices-country-data', kwargs={'country': 'Canada'})
 
     response = api_client.get(url)
     assert response.status_code == 200
@@ -313,7 +273,7 @@ def test_get_country_data_cpi_not_found(api_client):
             'internet_usage': {'country_name': 'Canada', 'country_code': 'CNN', 'value': '20.230', 'year': 2019},
             'corruption_perceptions_index': None,
             'ease_of_doing_bussiness': None,
-            'gdp_per_capita': None
+            'gdp_per_capita': None,
         },
     }
 
@@ -321,22 +281,20 @@ def test_get_country_data_cpi_not_found(api_client):
 @pytest.mark.django_db
 def test_get_country_data_internet_not_found(api_client):
     models.InternetUsage.objects.get(country_name='Canada').delete()
-    url = reverse(
-        'dataservices-country-data', kwargs={'country': 'Canada'}
-    )
+    url = reverse('dataservices-country-data', kwargs={'country': 'Canada'})
 
     response = api_client.get(url)
     assert response.status_code == 200
 
-    assert response.json() == {'country_data': {
-        'consumer_price_index': {'country_name': 'Canada',
-                                 'country_code': 'CNN', 'value': '20.560',
-                                 'year': 2019},
-        'internet_usage': None,
-        'corruption_perceptions_index': None,
-        'ease_of_doing_bussiness': None,
-        'gdp_per_capita': None
-    }}
+    assert response.json() == {
+        'country_data': {
+            'consumer_price_index': {'country_name': 'Canada', 'country_code': 'CNN', 'value': '20.560', 'year': 2019},
+            'internet_usage': None,
+            'corruption_perceptions_index': None,
+            'ease_of_doing_bussiness': None,
+            'gdp_per_capita': None,
+        }
+    }
 
 
 @pytest.mark.django_db
@@ -383,20 +341,19 @@ def test_population_data(api_client):
     response = api_client.get(url, data={'country': 'United Kingdom', 'target_ages': ['25-34', '35-44']})
     assert response.status_code == 200
     assert response.json() == {
-        'population_data':
-            {
-                'country': 'United Kingdom',
-                'target_ages': ['25-34', '35-44'],
-                'year': 2020,
-                'total_target_age_population': 18087,
-                'male_target_age_population': 9064,
-                'female_target_age_population': 9023,
-                'urban_population_total': 56495,
-                'rural_population_total': 10839,
-                'total_population': 67888,
-                'urban_percentage': 0.832179,
-                'rural_percentage': 0.167821,
-            }
+        'population_data': {
+            'country': 'United Kingdom',
+            'target_ages': ['25-34', '35-44'],
+            'year': 2020,
+            'total_target_age_population': 18087,
+            'male_target_age_population': 9064,
+            'female_target_age_population': 9023,
+            'urban_population_total': 56495,
+            'rural_population_total': 10839,
+            'total_population': 67888,
+            'urban_percentage': 0.832179,
+            'rural_percentage': 0.167821,
+        }
     }
 
 
@@ -432,10 +389,7 @@ def test_population_data_by_country(api_client, internet_usage_data):
     assert response.json() == [
         {
             'country': 'United Kingdom',
-            'internet_usage': {
-                'value': '90.97',
-                'year': 2020
-            },
+            'internet_usage': {'value': '90.97', 'year': 2020},
             'cpi': {'value': '150.56', 'year': 2019},
             'rural_population_total': 10839,
             'urban_population_total': 56495,
@@ -457,29 +411,23 @@ def test_population_data_by_country_multiple_countries(api_client, internet_usag
     assert response.json() == [
         {
             'country': 'United Kingdom',
-            'internet_usage': {
-                'value': '90.97',
-                'year': 2020
-            },
+            'internet_usage': {'value': '90.97', 'year': 2020},
             'rural_population_total': 10839,
             'urban_population_total': 56495,
             'urban_population_percentage_formatted': '83.22% (56.49 million)',
             'total_population': '67.89 million',
             'rural_population_percentage_formatted': '15.97% (10.84 million)',
-            'cpi': {'value': '150.56', 'year': 2019}
+            'cpi': {'value': '150.56', 'year': 2019},
         },
         {
             'country': 'Germany',
-            'internet_usage': {
-                'value': '91.97',
-                'year': 2020
-            },
+            'internet_usage': {'value': '91.97', 'year': 2020},
             'urban_population_total': 63930,
             'rural_population_total': 18610,
             'total_population': '83.78 million',
             'urban_population_percentage_formatted': '76.30% (63.93 million)',
             'rural_population_percentage_formatted': '22.21% (18.61 million)',
-        }
+        },
     ]
 
 
@@ -489,10 +437,7 @@ def test_suggested_countries_api(client):
     management.call_command('import_countries')
     management.call_command('import_suggested_countries')
 
-    response = client.get(
-        reverse('dataservices-suggested-countries'),
-        data={'hs_code': 1}
-    )
+    response = client.get(reverse('dataservices-suggested-countries'), data={'hs_code': 1})
     assert response.status_code == 200
     json_dict = json.loads(response.content)
     # we have 5 suggested countries for hs_code in imported csv

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -1,23 +1,22 @@
-from rest_framework import status, generics
-
-from dataservices import serializers, models, helpers
-from rest_framework.response import Response
 from django.http import Http404
+from rest_framework import generics, status
+from rest_framework.response import Response
 
+from dataservices import helpers, models, serializers
+from dataservices.helpers import get_serialized_instance_from_model, get_urban_rural_data, millify
 from dataservices.models import (
     ConsumerPriceIndex,
     CorruptionPerceptionsIndex,
-    InternetUsage,
     EaseOfDoingBusiness,
-    GDPPerCapita
+    GDPPerCapita,
+    InternetUsage,
 )
-from dataservices.helpers import millify, get_urban_rural_data, get_serialized_instance_from_model
 from dataservices.serializers import (
     ConsumerPriceIndexSerializer,
     CorruptionPerceptionsIndexSerializer,
-    InternetUsageSerializer,
     EaseOfDoingBusinessSerializer,
-    GDPPerCapitalSerializer
+    GDPPerCapitalSerializer,
+    InternetUsageSerializer,
 )
 
 
@@ -70,10 +69,7 @@ class RetrieveLastYearImportDataView(generics.GenericAPIView):
         comtrade = helpers.ComTradeData(commodity_code=commodity_code, reporting_area=country)
         # from world
         last_year_data = comtrade.get_last_year_import_data(from_uk=False)
-        return Response(
-            status=status.HTTP_200_OK,
-            data={'last_year_data': last_year_data}
-        )
+        return Response(status=status.HTTP_200_OK, data={'last_year_data': last_year_data})
 
 
 class RetrieveLastYearImportDataFromUKView(generics.GenericAPIView):
@@ -84,10 +80,7 @@ class RetrieveLastYearImportDataFromUKView(generics.GenericAPIView):
         country = self.request.GET.get('country', '')
         comtrade = helpers.ComTradeData(commodity_code=commodity_code, reporting_area=country)
         last_year_data = comtrade.get_last_year_import_data(from_uk=True)
-        return Response(
-            status=status.HTTP_200_OK,
-            data={'last_year_data': last_year_data}
-        )
+        return Response(status=status.HTTP_200_OK, data={'last_year_data': last_year_data})
 
 
 class RetrieveHistoricalImportDataView(generics.GenericAPIView):
@@ -100,10 +93,7 @@ class RetrieveHistoricalImportDataView(generics.GenericAPIView):
         comtrade = helpers.ComTradeData(commodity_code=commodity_code, reporting_area=country)
 
         historical_data = comtrade.get_all_historical_import_value()
-        return Response(
-            status=status.HTTP_200_OK,
-            data=historical_data
-        )
+        return Response(status=status.HTTP_200_OK, data=historical_data)
 
 
 class RetrieveCountryDataView(generics.GenericAPIView):
@@ -134,41 +124,21 @@ class RetrieveCountryDataView(generics.GenericAPIView):
 
         country_data = {
             'consumer_price_index': get_serialized_instance_from_model(
-                ConsumerPriceIndex,
-                ConsumerPriceIndexSerializer,
-                filter_args
+                ConsumerPriceIndex, ConsumerPriceIndexSerializer, filter_args
             ),
-            'internet_usage': get_serialized_instance_from_model(
-                InternetUsage,
-                InternetUsageSerializer,
-                filter_args
-            ),
+            'internet_usage': get_serialized_instance_from_model(InternetUsage, InternetUsageSerializer, filter_args),
             'corruption_perceptions_index': get_serialized_instance_from_model(
-                CorruptionPerceptionsIndex,
-                CorruptionPerceptionsIndexSerializer,
-                filter_args
+                CorruptionPerceptionsIndex, CorruptionPerceptionsIndexSerializer, filter_args
             ),
             'ease_of_doing_bussiness': get_serialized_instance_from_model(
-                EaseOfDoingBusiness,
-                EaseOfDoingBusinessSerializer,
-                filter_args
+                EaseOfDoingBusiness, EaseOfDoingBusinessSerializer, filter_args
             ),
-            'gdp_per_capita': get_serialized_instance_from_model(
-                GDPPerCapita,
-                GDPPerCapitalSerializer,
-                filter_args
-            ),
-
+            'gdp_per_capita': get_serialized_instance_from_model(GDPPerCapita, GDPPerCapitalSerializer, filter_args),
         }
-        return Response(
-            status=status.HTTP_200_OK,
-            data={'country_data': country_data}
-        )
+        return Response(status=status.HTTP_200_OK, data={'country_data': country_data})
 
     def map_dit_to_weo_country_data(self, country):
-        return (
-            country if self.dit_to_weo_country_map.get(country) is None else self.dit_to_weo_country_map.get(country)
-        )
+        return country if self.dit_to_weo_country_map.get(country) is None else self.dit_to_weo_country_map.get(country)
 
 
 class RetrieveCiaFactbooklDataView(generics.GenericAPIView):
@@ -193,10 +163,7 @@ class RetrieveCiaFactbooklDataView(generics.GenericAPIView):
         except models.CIAFactbook.DoesNotExist:
             cia_factbook_data = {}
 
-        return Response(
-            status=status.HTTP_200_OK,
-            data={'cia_factbook_data': cia_factbook_data}
-        )
+        return Response(status=status.HTTP_200_OK, data={'cia_factbook_data': cia_factbook_data})
 
 
 class RetrievePopulationDataView(generics.GenericAPIView):
@@ -228,35 +195,34 @@ class RetrievePopulationDataViewByCountry(generics.GenericAPIView):
             country_population = helpers.PopulationData()
             country_data = {'country': country}
             total_population = country_population.get_population_total_data(country=country)
-            population_data = {
-                    'total_population': millify(total_population.get('total_population', 0) * 1000)
-            }
+            population_data = {'total_population': millify(total_population.get('total_population', 0) * 1000)}
 
             # urban population
             urban_population_data = country_population.get_population_urban_rural_data(
-                country=country, classification='urban')
-            urban_population = get_urban_rural_data(urban_population_data,  total_population, 'urban')
+                country=country, classification='urban'
+            )
+            urban_population = get_urban_rural_data(urban_population_data, total_population, 'urban')
 
             # rural population
             rural_population_data = country_population.get_population_urban_rural_data(
-                country=country, classification='rural')
-            rural_population = get_urban_rural_data(rural_population_data,  total_population, 'rural')
+                country=country, classification='rural'
+            )
+            rural_population = get_urban_rural_data(rural_population_data, total_population, 'rural')
 
             internet_usage = helpers.get_internet_usage(country=country)
             cpi = helpers.get_cpi_data(country=country)
 
-            data_set.append({
-                **country_data,
-                **internet_usage,
-                **rural_population,
-                **urban_population,
-                **population_data,
-                **cpi,
-            })
-        return Response(
-            status=status.HTTP_200_OK,
-            data=data_set
-        )
+            data_set.append(
+                {
+                    **country_data,
+                    **internet_usage,
+                    **rural_population,
+                    **urban_population,
+                    **population_data,
+                    **cpi,
+                }
+            )
+        return Response(status=status.HTTP_200_OK, data=data_set)
 
 
 class SuggestedCountriesView(generics.ListAPIView):
@@ -265,15 +231,14 @@ class SuggestedCountriesView(generics.ListAPIView):
 
     def get_queryset(self):
         hs_code = self.request.query_params.get('hs_code', '').lower()
-        queryset = models.SuggestedCountry.objects.filter(hs_code=hs_code).\
-            order_by('order').\
-            values('hs_code', 'country__name', 'country__iso2', 'country__region')
+        queryset = (
+            models.SuggestedCountry.objects.filter(hs_code=hs_code)
+            .order_by('order')
+            .values('hs_code', 'country__name', 'country__iso2', 'country__region')
+        )
         return queryset
 
     def get(self, *args, **kwargs):
         if not self.request.query_params.get('hs_code'):
-            return Response(
-                status=500,
-                data={'error_message': 'hs_code missing in request params'}
-            )
+            return Response(status=500, data={'error_message': 'hs_code missing in request params'})
         return super().get(*args, **kwargs)

--- a/enrolment/admin.py
+++ b/enrolment/admin.py
@@ -2,13 +2,13 @@ import csv
 
 from django.conf.urls import url
 from django.contrib import admin
-from django.urls import reverse_lazy
 from django.http import HttpResponse
+from django.urls import reverse_lazy
 from django.views.generic import FormView, View
 
 from core.helpers import build_preverified_url
-from enrolment.models import PreVerifiedEnrolment
 from enrolment import forms
+from enrolment.models import PreVerifiedEnrolment
 
 
 class GeneratePreVerifiedCompaniesFormView(FormView):
@@ -23,16 +23,12 @@ class GeneratePreVerifiedCompaniesFormView(FormView):
 
 
 class DownloadPreVerifiedTemplate(View):
-
     def get(self, request):
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = 'attachment; filename="template.csv"'
         writer = csv.writer(response)
         writer.writerow(['Company number', 'Email'])
-        writer.writerow([
-            '90000001', 'comany@exmaple.com',
-            'This is an example company. Delete this row.'
-        ])
+        writer.writerow(['90000001', 'comany@exmaple.com', 'This is an example company. Delete this row.'])
         return response
 
 
@@ -45,7 +41,12 @@ class PreVerifiedEnrolmentAdmin(admin.ModelAdmin):
         'generated_for',
         'generated_by__username',
     )
-    list_display = ('company_number', 'company_name', 'email_address', 'generated_for',)
+    list_display = (
+        'company_number',
+        'company_name',
+        'email_address',
+        'generated_for',
+    )
     list_filter = ('is_active', 'generated_for')
 
     def link(self, obj):
@@ -61,18 +62,13 @@ class PreVerifiedEnrolmentAdmin(admin.ModelAdmin):
         additional_urls = [
             url(
                 r'^pre-verify-companies/$',
-                self.admin_site.admin_view(
-                    GeneratePreVerifiedCompaniesFormView.as_view()
-                ),
-                name="pre-verify-companies"
+                self.admin_site.admin_view(GeneratePreVerifiedCompaniesFormView.as_view()),
+                name="pre-verify-companies",
             ),
-
             url(
                 r'^example-template/$',
-                self.admin_site.admin_view(
-                    DownloadPreVerifiedTemplate.as_view()
-                ),
-                name="example-template"
+                self.admin_site.admin_view(DownloadPreVerifiedTemplate.as_view()),
+                name="example-template",
             ),
         ]
         return additional_urls + urls

--- a/enrolment/constants.py
+++ b/enrolment/constants.py
@@ -1,3 +1,1 @@
-EMAIL_STATIC_FILE_BUCKET = (
-    'https://s3-eu-west-1.amazonaws.com/directory-email-static/'
-)
+EMAIL_STATIC_FILE_BUCKET = 'https://s3-eu-west-1.amazonaws.com/directory-email-static/'

--- a/enrolment/forms.py
+++ b/enrolment/forms.py
@@ -23,9 +23,7 @@ class PreVerifiedEnrolmentModelForm(forms.ModelForm):
 class GeneratePreVerifiedCompanies(forms.Form):
     generated_for = forms.CharField(max_length=1000)
     csv_file = forms.FileField(
-        help_text=(
-            '<a href="/admin/enrolment/preverifiedenrolment/example-template/">Download example csv file</a>'
-        )
+        help_text=('<a href="/admin/enrolment/preverifiedenrolment/example-template/">Download example csv file</a>')
     )
 
     def __init__(self, user, *args, **kwargs):
@@ -34,26 +32,28 @@ class GeneratePreVerifiedCompanies(forms.Form):
 
     @transaction.atomic
     def clean_csv_file(self):
-        csv_file = io.TextIOWrapper(
-            self.cleaned_data['csv_file'].file, encoding='utf-8'
-        )
+        csv_file = io.TextIOWrapper(self.cleaned_data['csv_file'].file, encoding='utf-8')
         dialect = csv.Sniffer().sniff(csv_file.read(1024))
         csv_file.seek(0)
         reader = csv.reader(csv_file, dialect=dialect)
         next(reader, None)  # skip the headers
         row_errors = []
         for i, row in enumerate(reader):
-            form = PreVerifiedEnrolmentModelForm(data={
-                'company_number': row[0],
-                'email_address': row[1],
-                'generated_for': self.cleaned_data['generated_for'],
-                'generated_by': self.user.pk,
-            })
+            form = PreVerifiedEnrolmentModelForm(
+                data={
+                    'company_number': row[0],
+                    'email_address': row[1],
+                    'generated_for': self.cleaned_data['generated_for'],
+                    'generated_by': self.user.pk,
+                }
+            )
             if not form.is_valid():
-                row_errors.append('[Row {number}] {errors}'.format(
-                    errors=json.dumps(form.errors),
-                    number=i+2,
-                ))
+                row_errors.append(
+                    '[Row {number}] {errors}'.format(
+                        errors=json.dumps(form.errors),
+                        number=i + 2,
+                    )
+                )
             else:
                 form.save()
         if row_errors:

--- a/enrolment/models.py
+++ b/enrolment/models.py
@@ -1,5 +1,4 @@
 from directory_validators.string import no_html
-
 from django.db import models
 
 from core.helpers import TimeStampedModel

--- a/enrolment/serializers.py
+++ b/enrolment/serializers.py
@@ -53,7 +53,6 @@ class PreVerifiedEnrolmentSerializer(serializers.ModelSerializer):
 
 
 class ClaimPreverifiedCompanySerializer(serializers.ModelSerializer):
-
     class Meta:
         model = CompanyUser
         fields = [
@@ -61,13 +60,15 @@ class ClaimPreverifiedCompanySerializer(serializers.ModelSerializer):
         ]
 
     def create(self, validated_data):
-        user = super().create({
-            'name': validated_data['name'],
-            'company': self.context['company'],
-            'sso_id': self.context['request'].user.id,
-            'company_email': self.context['request'].user.email,
-            'role': user_roles.ADMIN,
-        })
+        user = super().create(
+            {
+                'name': validated_data['name'],
+                'company': self.context['company'],
+                'sso_id': self.context['request'].user.id,
+                'company_email': self.context['request'].user.email,
+                'role': user_roles.ADMIN,
+            }
+        )
         company = self.context['company']
         company.verified_with_preverified_enrolment = True
         company.save()
@@ -76,7 +77,6 @@ class ClaimPreverifiedCompanySerializer(serializers.ModelSerializer):
 
 
 class PreverifiedCompanySerializer(serializers.ModelSerializer):
-
     class Meta:
         model = Company
         fields = [

--- a/enrolment/tests/test_admin.py
+++ b/enrolment/tests/test_admin.py
@@ -1,19 +1,17 @@
 import csv
-import pytest
 import io
 
+import pytest
 from django.contrib.auth.models import User
-from django.urls import reverse
 from django.test import Client
+from django.urls import reverse
 
 from enrolment.models import PreVerifiedEnrolment
 
 
 @pytest.fixture()
 def superuser():
-    return User.objects.create_superuser(
-        username='admin', email='admin@example.com', password='test'
-    )
+    return User.objects.create_superuser(username='admin', email='admin@example.com', password='test')
 
 
 @pytest.fixture()
@@ -50,8 +48,7 @@ def csv_invalid_rows():
 def test_upload_enrolment_form_saves_verified(superuser_client, superuser):
     csv_file = build_csv_file(lineterminator='\r\n')
     response = superuser_client.post(
-        reverse('admin:pre-verify-companies'),
-        {'generated_for': 'COOL LTD', 'csv_file': csv_file}
+        reverse('admin:pre-verify-companies'), {'generated_for': 'COOL LTD', 'csv_file': csv_file}
     )
 
     assert response.status_code == 302
@@ -72,14 +69,10 @@ def test_upload_enrolment_form_saves_verified(superuser_client, superuser):
 
 @pytest.mark.django_db
 def test_upload_enrolment_form_shows_erros(superuser_client, csv_invalid_rows):
-    expected_error_one = (
-         b'[Row 4] {&quot;company_number&quot;: '
-         b'[&quot;This field is required.&quot;]}'
-    )
+    expected_error_one = b'[Row 4] {&quot;company_number&quot;: [&quot;This field is required.&quot;]}'
 
     response = superuser_client.post(
-        reverse('admin:pre-verify-companies'),
-        {'generated_for': 'COOL LTD', 'csv_file': csv_invalid_rows}
+        reverse('admin:pre-verify-companies'), {'generated_for': 'COOL LTD', 'csv_file': csv_invalid_rows}
     )
 
     assert response.status_code == 200
@@ -92,8 +85,7 @@ def test_upload_enrolment_form_rolls_back(superuser_client, csv_invalid_rows):
     # to return the csv to the trade organisation with the validation errors,
     # and only when all rows are valid so we want to save them all
     response = superuser_client.post(
-        reverse('admin:pre-verify-companies'),
-        {'generated_for': 'COOL LTD', 'csv_file': csv_invalid_rows}
+        reverse('admin:pre-verify-companies'), {'generated_for': 'COOL LTD', 'csv_file': csv_invalid_rows}
     )
 
     assert response.status_code == 200
@@ -105,12 +97,7 @@ def test_download_preverified_template(superuser_client):
     response = superuser_client.get(reverse('admin:example-template'))
 
     assert response.content == (
-        b'Company number,Email\r\n'
-        b'90000001,comany@exmaple.com,'
-        b'This is an example company. Delete this row.\r\n'
+        b'Company number,Email\r\n90000001,comany@exmaple.com,This is an example company. Delete this row.\r\n'
     )
-    assert (
-        response['Content-Disposition'] ==
-        'attachment; filename="template.csv"'
-    )
+    assert response['Content-Disposition'] == 'attachment; filename="template.csv"'
     assert response['content-type'] == 'text/csv'

--- a/enrolment/tests/test_models.py
+++ b/enrolment/tests/test_models.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.db.utils import IntegrityError
 
 from enrolment import models
@@ -7,19 +6,14 @@ from enrolment.tests import factories
 
 
 def test_trusted_source_signup_code_str():
-    instance = models.PreVerifiedEnrolment(company_number='12345678',
-                                           email_address='jim@example.com')
+    instance = models.PreVerifiedEnrolment(company_number='12345678', email_address='jim@example.com')
 
     assert str(instance) == '12345678'
 
 
 @pytest.mark.django_db
 def test_unique_together():
-    factories.PreVerifiedEnrolmentFactory(
-        company_number='1111111', email_address='1@a.com'
-    )
+    factories.PreVerifiedEnrolmentFactory(company_number='1111111', email_address='1@a.com')
 
     with pytest.raises(IntegrityError):
-        factories.PreVerifiedEnrolmentFactory(
-            company_number='1111111', email_address='1@a.com'
-        )
+        factories.PreVerifiedEnrolmentFactory(company_number='1111111', email_address='1@a.com')

--- a/enrolment/tests/test_templatetags.py
+++ b/enrolment/tests/test_templatetags.py
@@ -1,5 +1,5 @@
-from enrolment.templatetags.enrolment_email import email_image
 from enrolment import constants
+from enrolment.templatetags.enrolment_email import email_image
 
 
 def test_email_image_returns_constant_image():

--- a/enrolment/tests/test_views.py
+++ b/enrolment/tests/test_views.py
@@ -1,11 +1,10 @@
 from unittest import mock
 
-from rest_framework.test import APIClient
-from directory_constants import user_roles
 import pytest
-
+from directory_constants import user_roles
 from django.core import signing
 from django.urls import reverse
+from rest_framework.test import APIClient
 
 from company.models import Company, CompanyUser
 from company.tests.factories import CompanyFactory
@@ -44,7 +43,7 @@ def test_enrolment_viewset_create(mock_send_registration_letter, settings):
         'locality': 'London',
         'po_box': 'PO 344',
         'postal_code': 'E14 POX',
-        'sso_id': 1
+        'sso_id': 1,
     }
     response = APIClient().post(reverse('enrolment'), data, format='json')
 
@@ -84,7 +83,7 @@ def test_enrolment_viewset_create_optional_fields_unset():
         'company_email': 'jim@example.com',
         'contact_email_address': 'jim@example.com',
         'has_exported_before': True,
-        'sso_id': 1
+        'sso_id': 1,
     }
     response = APIClient().post(reverse('enrolment'), data, format='json')
 
@@ -193,7 +192,7 @@ def test_preverified_enrolment_retrieve_not_found(authed_client, default_enrolme
 def test_preverified_enrolment_retrieve_found(authed_client, default_enrolment_data):
     preverified_enrolment = PreVerifiedEnrolmentFactory.create(
         company_number=default_enrolment_data['company_number'],
-        email_address=default_enrolment_data['contact_email_address']
+        email_address=default_enrolment_data['contact_email_address'],
     )
 
     url = reverse('pre-verified-enrolment')
@@ -221,10 +220,7 @@ def test_preverified_claim_company_succcess(authed_client):
 
     company = CompanyFactory()
 
-    url = reverse(
-        'enrolment-claim-preverified',
-        kwargs={'key': signing.Signer().sign(company.number)}
-    )
+    url = reverse('enrolment-claim-preverified', kwargs={'key': signing.Signer().sign(company.number)})
 
     response = authed_client.post(url, {'name': 'Foo bar'})
 
@@ -244,10 +240,7 @@ def test_preverified_claim_company_succcess(authed_client):
 def test_preverified_retrieve_company_succcess(authed_client):
     company = CompanyFactory()
 
-    url = reverse(
-        'enrolment-preverified',
-        kwargs={'key': signing.Signer().sign(company.number)}
-    )
+    url = reverse('enrolment-preverified', kwargs={'key': signing.Signer().sign(company.number)})
 
     response = authed_client.get(url)
 

--- a/enrolment/views.py
+++ b/enrolment/views.py
@@ -1,22 +1,20 @@
-from rest_framework import status
-from rest_framework import generics
-from rest_framework.response import Response
-from rest_framework.views import APIView
 from directory_constants import user_roles
-
 from django.core import signing
 from django.db import transaction
-from django.shortcuts import get_object_or_404, Http404
+from django.shortcuts import Http404, get_object_or_404
+from rest_framework import generics, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from company.models import Company
-from enrolment import models, serializers
 from company.serializers import CompanyUserSerializer
 from company.signals import send_company_registration_letter
+from enrolment import models, serializers
 
 
 class EnrolmentCreateAPIView(APIView):
 
-    http_method_names = ("post", )
+    http_method_names = ("post",)
     company_serializer_class = serializers.CompanyEnrolmentSerializer
     company_user_serializer_class = CompanyUserSerializer
     permission_classes = []
@@ -39,7 +37,7 @@ class EnrolmentCreateAPIView(APIView):
 
 
 class PreVerifiedEnrolmentRetrieveView(generics.RetrieveAPIView):
-    http_method_names = ("get", )
+    http_method_names = ("get",)
     queryset = models.PreVerifiedEnrolment.objects.filter(is_active=True)
     serializer_class = serializers.PreVerifiedEnrolmentSerializer
 
@@ -66,7 +64,7 @@ class LookupSignedCompanyNumberMixin:
 
 
 class PreverifiedCompanyView(LookupSignedCompanyNumberMixin, generics.RetrieveAPIView):
-    http_method_names = ('get', )
+    http_method_names = ('get',)
     serializer_class = serializers.PreverifiedCompanySerializer
     permission_classes = []
 

--- a/exporting/admin.py
+++ b/exporting/admin.py
@@ -7,9 +7,7 @@ from exporting import models
 
 @admin.register(models.Office)
 class OfficeAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
     search_fields = (
         'name',
         'region_id',

--- a/exporting/helpers.py
+++ b/exporting/helpers.py
@@ -12,10 +12,7 @@ def postcode_to_region_id(postcode):
                                          if the response is not OK (2xx)
 
     """
-    response = requests.get(
-        f'https://api.postcodes.io/postcodes/{postcode}/',
-        timeout=10
-    )
+    response = requests.get(f'https://api.postcodes.io/postcodes/{postcode}/', timeout=10)
     response.raise_for_status()
     parsed = response.json()['result']
     region_id = parsed['region'] or parsed['european_electoral_region']

--- a/exporting/models.py
+++ b/exporting/models.py
@@ -1,5 +1,6 @@
-from core.helpers import TimeStampedModel
 from django.db import models
+
+from core.helpers import TimeStampedModel
 
 
 class Office(TimeStampedModel):

--- a/exporting/tests/test_helpers.py
+++ b/exporting/tests/test_helpers.py
@@ -40,9 +40,9 @@ def postcode_response():
                 "parish": "***",
                 "parliamentary_constituency": "***",
                 "ccg": "***",
-                "nuts": "***"
-            }
-        }
+                "nuts": "***",
+            },
+        },
     }
 
 
@@ -50,10 +50,7 @@ def test_postcode_to_region_id_region_missing(postcode_response):
     postcode_response = deepcopy(postcode_response)
     postcode_response['result']['region'] = ''
     with requests_mock.mock() as mock:
-        mock.get(
-            'https://api.postcodes.io/postcodes/ABC%20123/',
-            json=postcode_response
-        )
+        mock.get('https://api.postcodes.io/postcodes/ABC%20123/', json=postcode_response)
         result = helpers.postcode_to_region_id('ABC 123')
 
     assert result == 'east_east_foolands'
@@ -61,10 +58,7 @@ def test_postcode_to_region_id_region_missing(postcode_response):
 
 def test_postcode_to_region_id_region_present(postcode_response):
     with requests_mock.mock() as mock:
-        mock.get(
-            'https://api.postcodes.io/postcodes/ABC%20123/',
-            json=postcode_response
-        )
+        mock.get('https://api.postcodes.io/postcodes/ABC%20123/', json=postcode_response)
         result = helpers.postcode_to_region_id('ABC 123')
 
     assert result == 'east_east_foolands_region'

--- a/exporting/tests/test_views.py
+++ b/exporting/tests/test_views.py
@@ -2,12 +2,11 @@ from unittest import mock
 
 import pytest
 import requests.exceptions
+from django.urls import reverse
 from rest_framework.test import APIClient
 
-from django.urls import reverse
-
-from exporting.tests import factories
 from exporting.models import Office
+from exporting.tests import factories
 
 
 @pytest.fixture
@@ -22,30 +21,21 @@ def office():
 
 @pytest.mark.django_db
 @mock.patch('exporting.helpers.postcode_to_region_id')
-def test_lookup_by_postcode_success(
-    mock_postcode_to_region_id, api_client, office
-):
+def test_lookup_by_postcode_success(mock_postcode_to_region_id, api_client, office):
 
     mock_postcode_to_region_id.return_value = office.region_id
 
-    url = reverse(
-        'offices-by-postcode',
-        kwargs={'postcode': 'ABC 123'}
-    )
+    url = reverse('offices-by-postcode', kwargs={'postcode': 'ABC 123'})
 
     response = api_client.get(url)
 
     assert response.status_code == 200
 
-    matched_office = list(
-        filter(lambda x: x['is_match'] is True, response.json())
-    )
+    matched_office = list(filter(lambda x: x['is_match'] is True, response.json()))
 
     assert len(matched_office) == 1
 
-    other_offices = list(
-        filter(lambda x: x['is_match'] is False, response.json())
-    )
+    other_offices = list(filter(lambda x: x['is_match'] is False, response.json()))
 
     assert matched_office[0] == {
         'is_match': True,
@@ -62,34 +52,25 @@ def test_lookup_by_postcode_success(
     }
 
     total_offices = Office.objects.all().count()
-    assert len(other_offices) == total_offices-1
+    assert len(other_offices) == total_offices - 1
 
 
 @pytest.mark.django_db
 @mock.patch('exporting.helpers.postcode_to_region_id')
-def test_lookup_by_postcode_unsuppported_post_code(
-    mock_postcode_to_region_id, api_client
-):
+def test_lookup_by_postcode_unsuppported_post_code(mock_postcode_to_region_id, api_client):
     mock_postcode_to_region_id.return_value = 'some-unsupported-office'
 
-    url = reverse(
-        'offices-by-postcode',
-        kwargs={'postcode': 'ABC 123'}
-    )
+    url = reverse('offices-by-postcode', kwargs={'postcode': 'ABC 123'})
 
     response = api_client.get(url)
 
     assert response.status_code == 200
 
-    matched_office = list(
-        filter(lambda x: x['is_match'] is True, response.json())
-    )
+    matched_office = list(filter(lambda x: x['is_match'] is True, response.json()))
 
     assert len(matched_office) == 0
 
-    other_offices = list(
-        filter(lambda x: x['is_match'] is False, response.json())
-    )
+    other_offices = list(filter(lambda x: x['is_match'] is False, response.json()))
 
     total_offices = Office.objects.all().count()
 
@@ -98,31 +79,20 @@ def test_lookup_by_postcode_unsuppported_post_code(
 
 @pytest.mark.django_db
 @mock.patch('exporting.helpers.postcode_to_region_id')
-def test_lookup_by_postcode_unsuppported_error(
-    mock_postcode_to_region_id, api_client
-):
-    mock_postcode_to_region_id.side_effect = (
-        requests.exceptions.RequestException()
-    )
+def test_lookup_by_postcode_unsuppported_error(mock_postcode_to_region_id, api_client):
+    mock_postcode_to_region_id.side_effect = requests.exceptions.RequestException()
 
-    url = reverse(
-        'offices-by-postcode',
-        kwargs={'postcode': 'ABC 123'}
-    )
+    url = reverse('offices-by-postcode', kwargs={'postcode': 'ABC 123'})
 
     response = api_client.get(url)
 
     assert response.status_code == 200
 
-    matched_office = list(
-        filter(lambda x: x['is_match'] is True, response.json())
-    )
+    matched_office = list(filter(lambda x: x['is_match'] is True, response.json()))
 
     assert len(matched_office) == 0
 
-    other_offices = list(
-        filter(lambda x: x['is_match'] is False, response.json())
-    )
+    other_offices = list(filter(lambda x: x['is_match'] is False, response.json()))
 
     total_offices = Office.objects.all().count()
 

--- a/exporting/views.py
+++ b/exporting/views.py
@@ -1,9 +1,8 @@
 import requests.exceptions
-
+from django.db.models import BooleanField, Case, Value, When
 from rest_framework.generics import ListAPIView
 
 from exporting import helpers, models, serializers
-from django.db.models import Case, When, BooleanField, Value
 
 
 class RetrieveOfficesByPostCode(ListAPIView):

--- a/exportplan/admin.py
+++ b/exportplan/admin.py
@@ -7,9 +7,7 @@ from exportplan import models
 
 @admin.register(models.CompanyExportPlan)
 class CompanyExportPlanAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
     search_fields = (
         'company',
         'sso_id',
@@ -26,9 +24,7 @@ class CompanyExportPlanAdmin(admin.ModelAdmin):
 
 @admin.register(models.CompanyObjectives)
 class CompanyCompanyObjectivesAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
     search_fields = (
         'companyexportplan',
         'description',
@@ -46,9 +42,7 @@ class CompanyCompanyObjectivesAdmin(admin.ModelAdmin):
 
 @admin.register(models.RouteToMarkets)
 class RouteToMarketsAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
     search_fields = (
         'route',
         'promote',

--- a/exportplan/apps.py
+++ b/exportplan/apps.py
@@ -7,7 +7,5 @@ class ExportplanConfig(AppConfig):
 
     def ready(self):
         from exportplan import signals
-        pre_save.connect(
-            receiver=signals.add_target_markets_data,
-            sender='exportplan.CompanyExportPlan'
-        )
+
+        pre_save.connect(receiver=signals.add_target_markets_data, sender='exportplan.CompanyExportPlan')

--- a/exportplan/conftest.py
+++ b/exportplan/conftest.py
@@ -1,5 +1,7 @@
-import pytest
 from unittest import mock
+
+import pytest
+
 from dataservices import helpers
 
 
@@ -15,14 +17,19 @@ def cpi_data():
 
 @pytest.fixture(autouse=True)
 def last_year_data():
-    return {'import_value': {'year': 2019, 'trade_value': 100, }}
+    return {
+        'import_value': {
+            'year': 2019,
+            'trade_value': 100,
+        }
+    }
 
 
 @pytest.fixture(autouse=True)
 def historical_import_data():
     return {
         'historical_trade_value_partner': {'2018': 200, '2017': 100, '2016': 50},
-        'historical_trade_value_all': {'2018': 350, '2017': 350, '2016': 350}
+        'historical_trade_value_all': {'2018': 350, '2017': 350, '2016': 350},
     }
 
 
@@ -42,13 +49,7 @@ def mock_historical_import_data(historical_import_data):
 
 @pytest.fixture(autouse=True)
 def world_economic_outlook_data():
-    return [
-        {
-            'country_name': 'Australia',
-            'country_code': 'AUS',
-            'year_2019': 20
-        }
-    ]
+    return [{'country_name': 'Australia', 'country_code': 'AUS', 'year_2019': 20}]
 
 
 @pytest.fixture(autouse=True)

--- a/exportplan/models.py
+++ b/exportplan/models.py
@@ -1,11 +1,10 @@
+from directory_constants import choices
+from directory_validators.string import no_html
+from django.contrib.postgres.fields import JSONField
 from django.db import models
 
-from core.helpers import TimeStampedModel
 from company.models import Company
-from django.contrib.postgres.fields import JSONField
-
-from directory_validators.string import no_html
-from directory_constants import choices
+from core.helpers import TimeStampedModel
 
 
 class CompanyExportPlan(TimeStampedModel):
@@ -54,15 +53,13 @@ class CompanyObjectives(TimeStampedModel):
 
 
 class RouteToMarkets(TimeStampedModel):
-    route = models.CharField(max_length=30,  blank=True, null=True, default='', choices=choices.MARKET_ROUTE_CHOICES)
+    route = models.CharField(max_length=30, blank=True, null=True, default='', choices=choices.MARKET_ROUTE_CHOICES)
     promote = models.CharField(
-        max_length=30, blank=True, null=True,  default='', choices=choices.PRODUCT_PROMOTIONAL_CHOICES
+        max_length=30, blank=True, null=True, default='', choices=choices.PRODUCT_PROMOTIONAL_CHOICES
     )
     market_promotional_channel = models.TextField(blank=True, default='', validators=[no_html])
 
-    companyexportplan = models.ForeignKey(
-        CompanyExportPlan, related_name='route_to_markets', on_delete=models.CASCADE
-    )
+    companyexportplan = models.ForeignKey(CompanyExportPlan, related_name='route_to_markets', on_delete=models.CASCADE)
 
 
 class ExportPlanActions(TimeStampedModel):

--- a/exportplan/serializers.py
+++ b/exportplan/serializers.py
@@ -1,24 +1,15 @@
+from django.contrib.postgres.fields import JSONField
 from django.db import transaction
 from rest_framework import serializers
 
 from exportplan import models
-from django.contrib.postgres.fields import JSONField
 
 
 class CompanyObjectivesSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.CompanyObjectives
         id = serializers.IntegerField(label='ID', read_only=False)
-        fields = (
-            'description',
-            'planned_reviews',
-            'owner',
-            'start_date',
-            'end_date',
-            'companyexportplan',
-            'pk'
-        )
+        fields = ('description', 'planned_reviews', 'owner', 'start_date', 'end_date', 'companyexportplan', 'pk')
         extra_kwargs = {
             # passed in by CompanyExportPlanSerializer created/updated
             'companyexportplan': {'required': False},
@@ -26,17 +17,10 @@ class CompanyObjectivesSerializer(serializers.ModelSerializer):
 
 
 class RouteToMarketsSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.RouteToMarkets
         id = serializers.IntegerField(label='ID', read_only=False)
-        fields = (
-            'route',
-            'promote',
-            'market_promotional_channel',
-            'companyexportplan',
-            'pk'
-        )
+        fields = ('route', 'promote', 'market_promotional_channel', 'companyexportplan', 'pk')
         extra_kwargs = {
             # passed in by RouteToMarketsSerializer created/updated
             'companyexportplan': {'required': False},
@@ -44,16 +28,10 @@ class RouteToMarketsSerializer(serializers.ModelSerializer):
 
 
 class TargetMarketDocumentsSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.TargetMarketDocuments
         id = serializers.IntegerField(label='ID', read_only=False)
-        fields = (
-            'document_name',
-            'note',
-            'companyexportplan',
-            'pk'
-        )
+        fields = ('document_name', 'note', 'companyexportplan', 'pk')
         extra_kwargs = {
             # passed in by RouteToMarketsSerializer created/updated
             'companyexportplan': {'required': False},
@@ -61,7 +39,6 @@ class TargetMarketDocumentsSerializer(serializers.ModelSerializer):
 
 
 class ExportPlanActionsSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.ExportPlanActions
         fields = (
@@ -74,7 +51,6 @@ class ExportPlanActionsSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             # passed in by CompanyExportPlanSerializer created/updated
             'companyexportplan': {'required': False},
-
         }
 
 
@@ -89,9 +65,9 @@ class ExportPlanCommodityCodeSerializer(serializers.Serializer):
 
 
 class CompanyExportPlanSerializer(serializers.ModelSerializer):
-    company_objectives = CompanyObjectivesSerializer(many=True,  required=False, read_only=False)
+    company_objectives = CompanyObjectivesSerializer(many=True, required=False, read_only=False)
     export_plan_actions = ExportPlanActionsSerializer(many=True, required=False, read_only=False)
-    route_to_markets = RouteToMarketsSerializer(many=True,  required=False, read_only=False)
+    route_to_markets = RouteToMarketsSerializer(many=True, required=False, read_only=False)
     target_market_documents = TargetMarketDocumentsSerializer(many=True, required=False, read_only=False)
 
     class Meta:
@@ -156,9 +132,8 @@ class CompanyExportPlanSerializer(serializers.ModelSerializer):
         for field_name in validated_data.keys():
             field_value = getattr(instance, field_name)
             # Check if the field we are updating is JSON Type and ensure contents are JSON
-            if (
-                    isinstance(models.CompanyExportPlan._meta.get_field(field_name), JSONField) and
-                    isinstance(field_value, dict)
+            if isinstance(models.CompanyExportPlan._meta.get_field(field_name), JSONField) and isinstance(
+                field_value, dict
             ):
                 # For every field for in incoming dictionary update the field from DB
                 for k, v in validated_data[field_name].items():

--- a/exportplan/signals.py
+++ b/exportplan/signals.py
@@ -1,7 +1,8 @@
-import pytz
 from datetime import datetime
-from conf import settings
 
+import pytz
+
+from conf import settings
 from dataservices import helpers
 from exportplan import helpers as export_helpers
 
@@ -25,8 +26,7 @@ def add_target_markets_data(sender, instance, *args, **kwargs):
                 commodity_code=commodity_code, country=country
             )
             if settings.FEATURE_COMTRADE_HISTORICAL_DATA_ENABLED:
-                target_market[
-                    'historical_import_data'] = helpers.get_historical_import_data(
+                target_market['historical_import_data'] = helpers.get_historical_import_data(
                     commodity_code=commodity_code, country=country
                 )
         else:
@@ -34,14 +34,16 @@ def add_target_markets_data(sender, instance, *args, **kwargs):
 
         if country_code:
             timezone = export_helpers.get_timezone(country_code)
-            target_market.update({
-                'easeofdoingbusiness': helpers.get_ease_of_business_index(country_code),
-                'corruption_perceptions_index': helpers.get_corruption_perception_index(country_code),
-                'timezone': timezone,
-                'utz_offset': datetime.now(pytz.timezone(timezone)).strftime('%z'),
-                'world_economic_outlook_data': helpers.get_world_economic_outlook_data(country_code),
-            })
+            target_market.update(
+                {
+                    'easeofdoingbusiness': helpers.get_ease_of_business_index(country_code),
+                    'corruption_perceptions_index': helpers.get_corruption_perception_index(country_code),
+                    'timezone': timezone,
+                    'utz_offset': datetime.now(pytz.timezone(timezone)).strftime('%z'),
+                    'world_economic_outlook_data': helpers.get_world_economic_outlook_data(country_code),
+                }
+            )
 
-        target_market['cia_factbook_data'] = helpers.get_cia_factbook_data(country_name=country, data_keys=[
-            'languages', 'government', 'transportation', 'people'
-        ])
+        target_market['cia_factbook_data'] = helpers.get_cia_factbook_data(
+            country_name=country, data_keys=['languages', 'government', 'transportation', 'people']
+        )

--- a/exportplan/tests/factories.py
+++ b/exportplan/tests/factories.py
@@ -1,9 +1,9 @@
 import factory
 import factory.fuzzy
-
-from exportplan import models
-from company.tests import factories
 from directory_constants import choices
+
+from company.tests import factories
+from exportplan import models
 
 
 class CompanyExportPlanFactory(factory.django.DjangoModelFactory):

--- a/exportplan/tests/test_serializers.py
+++ b/exportplan/tests/test_serializers.py
@@ -1,6 +1,7 @@
 import pytest
-from exportplan import serializers
+
 from company.tests import factories
+from exportplan import serializers
 
 
 @pytest.mark.django_db
@@ -9,13 +10,15 @@ def test_company_exportplan_serializer_save():
     export_commodity_codes = [{'commodity_name': 'gin', 'commodity_code': '101.2002.123'}]
     export_countries = [{'country_name': 'China', 'country_iso2_code': 'CN'}]
     ui_options = {'target_ages': ['25-34', '35-44']}
-    serializer = serializers.CompanyExportPlanSerializer(data={
-        'company': company.pk,
-        'sso_id': 5,
-        "export_commodity_codes": export_commodity_codes,
-        "export_countries": export_countries,
-        "ui_options": ui_options
-    })
+    serializer = serializers.CompanyExportPlanSerializer(
+        data={
+            'company': company.pk,
+            'sso_id': 5,
+            "export_commodity_codes": export_commodity_codes,
+            "export_countries": export_countries,
+            "ui_options": ui_options,
+        }
+    )
 
     assert serializer.is_valid() is True
 
@@ -31,11 +34,13 @@ def test_company_exportplan_serializer_save():
 @pytest.mark.django_db
 def test_company_exportplan_serializer_export_countries_fail():
     company = factories.CompanyFactory.create(number='01234567')
-    serializer = serializers.CompanyExportPlanSerializer(data={
-        'company': company.pk,
-        'sso_id': 5,
-        "export_countries": [{'country_name': None, 'country_iso2_code': 'CN'}],
-    })
+    serializer = serializers.CompanyExportPlanSerializer(
+        data={
+            'company': company.pk,
+            'sso_id': 5,
+            "export_countries": [{'country_name': None, 'country_iso2_code': 'CN'}],
+        }
+    )
 
     assert serializer.is_valid() is False
     assert serializer.errors['export_countries']['country_name']
@@ -44,11 +49,13 @@ def test_company_exportplan_serializer_export_countries_fail():
 @pytest.mark.django_db
 def test_company_exportplan_serializer_commodity_codes_fail():
     company = factories.CompanyFactory.create(number='01234567')
-    serializer = serializers.CompanyExportPlanSerializer(data={
-        'company': company.pk,
-        'sso_id': 5,
-        'export_commodity_codes': [{'commodity_name': None, 'commodity_code': '101.2002.123'}],
-    })
+    serializer = serializers.CompanyExportPlanSerializer(
+        data={
+            'company': company.pk,
+            'sso_id': 5,
+            'export_commodity_codes': [{'commodity_name': None, 'commodity_code': '101.2002.123'}],
+        }
+    )
 
     assert serializer.is_valid() is False
     assert serializer.errors['export_commodity_codes']['commodity_name']

--- a/exportplan/tests/test_signals.py
+++ b/exportplan/tests/test_signals.py
@@ -1,25 +1,39 @@
-import pytest
 from unittest import mock
+
+import pytest
 
 from exportplan.tests.factories import CompanyExportPlanFactory
 
 
 @pytest.mark.django_db
 def test_export_plan_target_markets_create(
-        mock_ease_of_business_index, mock_cpi, mock_last_year_data,
-        mock_world_economic_outlook, mock_cia_factbook, cpi_data, last_year_data, ease_of_business_data,
-        world_economic_outlook_data, cia_factbook_data
+    mock_ease_of_business_index,
+    mock_cpi,
+    mock_last_year_data,
+    mock_world_economic_outlook,
+    mock_cia_factbook,
+    cpi_data,
+    last_year_data,
+    ease_of_business_data,
+    world_economic_outlook_data,
+    cia_factbook_data,
 ):
 
-    export_plan = CompanyExportPlanFactory.create(target_markets=[{'country': 'Australia', }])
+    export_plan = CompanyExportPlanFactory.create(
+        target_markets=[
+            {
+                'country': 'Australia',
+            }
+        ]
+    )
     export_plan.save()
     assert mock_ease_of_business_index.call_args == mock.call('AUS')
     assert mock_cpi.call_args == mock.call('AUS')
     assert mock_last_year_data.call_args == mock.call(commodity_code='101.2002.123', country='Australia')
     assert mock_world_economic_outlook.call_args == mock.call('AUS')
-    assert mock_cia_factbook.call_args == mock.call(country_name='Australia', data_keys=[
-            'languages', 'government', 'transportation', 'people'
-        ])
+    assert mock_cia_factbook.call_args == mock.call(
+        country_name='Australia', data_keys=['languages', 'government', 'transportation', 'people']
+    )
 
     assert mock_ease_of_business_index.call_count == 1
     assert mock_cpi.call_count == 1
@@ -37,10 +51,22 @@ def test_export_plan_target_markets_create(
 
 @pytest.mark.django_db
 def test_export_plan_target_markets_create_no_bad_country(
-        mock_ease_of_business_index, mock_cpi, mock_last_year_data,
-        cpi_data, last_year_data, ease_of_business_data, world_economic_outlook_data, cia_factbook_data
+    mock_ease_of_business_index,
+    mock_cpi,
+    mock_last_year_data,
+    cpi_data,
+    last_year_data,
+    ease_of_business_data,
+    world_economic_outlook_data,
+    cia_factbook_data,
 ):
-    export_plan = CompanyExportPlanFactory.create(target_markets=[{'country': 'XYZ', }])
+    export_plan = CompanyExportPlanFactory.create(
+        target_markets=[
+            {
+                'country': 'XYZ',
+            }
+        ]
+    )
     export_plan.save()
 
     assert export_plan.target_markets[0].get('corruption_perceptions_index') is None
@@ -52,21 +78,34 @@ def test_export_plan_target_markets_create_no_bad_country(
 
 @pytest.mark.django_db
 def test_signal_target_markets_update(
-        mock_ease_of_business_index, mock_cpi, mock_last_year_data, mock_world_economic_outlook,
-        mock_cia_factbook, cpi_data, last_year_data, ease_of_business_data, world_economic_outlook_data,
-        cia_factbook_data,
+    mock_ease_of_business_index,
+    mock_cpi,
+    mock_last_year_data,
+    mock_world_economic_outlook,
+    mock_cia_factbook,
+    cpi_data,
+    last_year_data,
+    ease_of_business_data,
+    world_economic_outlook_data,
+    cia_factbook_data,
 ):
 
-    export_plan = CompanyExportPlanFactory.create(target_markets=[{'country': 'Australia', }])
+    export_plan = CompanyExportPlanFactory.create(
+        target_markets=[
+            {
+                'country': 'Australia',
+            }
+        ]
+    )
     export_plan.save()
 
     assert mock_ease_of_business_index.call_args == mock.call('AUS')
     assert mock_cpi.call_args == mock.call('AUS')
     assert mock_last_year_data.call_args == mock.call(commodity_code='101.2002.123', country='Australia')
     assert mock_world_economic_outlook.call_args == mock.call('AUS')
-    assert mock_cia_factbook.call_args == mock.call(country_name='Australia', data_keys=[
-            'languages', 'government', 'transportation', 'people'
-        ])
+    assert mock_cia_factbook.call_args == mock.call(
+        country_name='Australia', data_keys=['languages', 'government', 'transportation', 'people']
+    )
 
     assert mock_ease_of_business_index.call_count == 1
     assert mock_cpi.call_count == 1
@@ -94,8 +133,14 @@ def test_signal_target_markets_update(
 
 @pytest.mark.django_db
 def test_export_plan_target_markets_create_commodity_code(
-        mock_ease_of_business_index, mock_cpi, mock_last_year_data,
-        cpi_data, last_year_data, ease_of_business_data, world_economic_outlook_data, cia_factbook_data
+    mock_ease_of_business_index,
+    mock_cpi,
+    mock_last_year_data,
+    cpi_data,
+    last_year_data,
+    ease_of_business_data,
+    world_economic_outlook_data,
+    cia_factbook_data,
 ):
     export_plan = CompanyExportPlanFactory.create(export_commodity_codes=[])
     export_plan.save()

--- a/exportplan/tests/test_views.py
+++ b/exportplan/tests/test_views.py
@@ -1,14 +1,14 @@
-import pytest
-
-from datetime import date
-from django.urls import reverse
 import http
-from conf import settings
+from datetime import date
 
-from exportplan.tests import factories
-from company.tests.factories import CompanyFactory
-from exportplan.models import CompanyExportPlan
+import pytest
 from directory_constants import choices
+from django.urls import reverse
+
+from company.tests.factories import CompanyFactory
+from conf import settings
+from exportplan.models import CompanyExportPlan
+from exportplan.tests import factories
 
 
 @pytest.fixture
@@ -23,9 +23,15 @@ def export_plan_data(company):
         'export_commodity_codes': [{'commodity_name': 'gin', 'commodity_code': '101.2002.123'}],
         'export_countries': [{'country_name': 'China', 'country_iso2_code': 'CN'}],
         'ui_options': {'target_ages': ['25-34', '35-44']},
-        'company_objectives': [{'description': 'export 5k cases of wine'}, ],
-        'export_plan_actions': [{'is_reminders_on': True, 'action_type': 'TARGET_MARKETS', }]
-
+        'company_objectives': [
+            {'description': 'export 5k cases of wine'},
+        ],
+        'export_plan_actions': [
+            {
+                'is_reminders_on': True,
+                'action_type': 'TARGET_MARKETS',
+            }
+        ],
     }
 
 
@@ -41,9 +47,7 @@ def export_plan():
 
 @pytest.mark.django_db
 def test_export_plan_create(export_plan_data, authed_client, authed_supplier):
-    response = authed_client.post(
-        reverse('export-plan-list-create'), export_plan_data, format='json'
-    )
+    response = authed_client.post(reverse('export-plan-list-create'), export_plan_data, format='json')
     assert response.status_code == http.client.CREATED
     created_export_plan = response.json()
 
@@ -54,15 +58,23 @@ def test_export_plan_create(export_plan_data, authed_client, authed_supplier):
     assert created_export_plan['ui_options'] == export_plan_data['ui_options']
     assert created_export_plan['export_plan_actions'] == [
         {
-            'companyexportplan': export_plan_db.pk, 'owner': None, 'due_date': None,
-            'is_reminders_on': True, 'action_type': 'TARGET_MARKETS',
+            'companyexportplan': export_plan_db.pk,
+            'owner': None,
+            'due_date': None,
+            'is_reminders_on': True,
+            'action_type': 'TARGET_MARKETS',
         }
     ]
 
     assert created_export_plan['company_objectives'] == [
         {
-            'companyexportplan': export_plan_db.pk, 'description': 'export 5k cases of wine',
-            'owner': None, 'start_date': None, 'end_date': None,  'planned_reviews': '', 'pk': 1,
+            'companyexportplan': export_plan_db.pk,
+            'description': 'export 5k cases of wine',
+            'owner': None,
+            'start_date': None,
+            'end_date': None,
+            'planned_reviews': '',
+            'pk': 1,
         }
     ]
     assert created_export_plan['sso_id'] == authed_supplier.sso_id
@@ -72,7 +84,7 @@ def test_export_plan_create(export_plan_data, authed_client, authed_supplier):
 def test_export_plan_list(authed_client, authed_supplier):
     factories.CompanyExportPlanFactory.create(sso_id=authed_supplier.sso_id)
     factories.CompanyExportPlanFactory.create(sso_id=authed_supplier.sso_id)
-    factories.CompanyExportPlanFactory.create(sso_id=authed_supplier.sso_id+1)
+    factories.CompanyExportPlanFactory.create(sso_id=authed_supplier.sso_id + 1)
 
     response = authed_client.get(reverse('export-plan-list-create'))
 
@@ -111,7 +123,8 @@ def test_export_plan_retrieve(authed_client, authed_supplier, export_plan):
         'export_plan_actions': [
             {
                 'companyexportplan': export_plan.id,
-                'owner': None, 'due_date': None,
+                'owner': None,
+                'due_date': None,
                 'is_reminders_on': False,
                 'action_type': 'TARGET_MARKETS',
             }
@@ -125,7 +138,6 @@ def test_export_plan_retrieve(authed_client, authed_supplier, export_plan):
                 'start_date': None,
                 'end_date': None,
                 'pk': export_plan.company_objectives.all()[0].pk,
-
             }
         ],
         'route_to_markets': [
@@ -135,7 +147,6 @@ def test_export_plan_retrieve(authed_client, authed_supplier, export_plan):
                 'promote': export_plan.route_to_markets.all()[0].promote,
                 'market_promotional_channel': export_plan.route_to_markets.all()[0].market_promotional_channel,
                 'pk': export_plan.route_to_markets.all()[0].pk,
-
             }
         ],
         'target_market_documents': [
@@ -144,10 +155,9 @@ def test_export_plan_retrieve(authed_client, authed_supplier, export_plan):
                 'document_name': export_plan.target_market_documents.all()[0].document_name,
                 'note': export_plan.target_market_documents.all()[0].note,
                 'pk': export_plan.target_market_documents.all()[0].pk,
-
             }
         ],
-        'pk': export_plan.pk
+        'pk': export_plan.pk,
     }
     assert response.status_code == 200
     assert response.json() == data
@@ -183,7 +193,14 @@ def test_export_plan_target_markets_update_historical_disabled(authed_client, au
     authed_supplier.save()
     url = reverse('export-plan-detail-update', kwargs={'pk': export_plan.pk})
 
-    data = {'target_markets': export_plan.target_markets + [{'country': 'Australia', }]}
+    data = {
+        'target_markets': export_plan.target_markets
+        + [
+            {
+                'country': 'Australia',
+            }
+        ]
+    }
 
     response = authed_client.patch(url, data, format='json')
     export_plan.refresh_from_db()
@@ -193,10 +210,12 @@ def test_export_plan_target_markets_update_historical_disabled(authed_client, au
         'country': 'Mexico',
         'last_year_data': {'import_value': {'year': 2019, 'trade_value': 100}},
         'easeofdoingbusiness': {'total': 1, 'year_2019': 20, 'country_code': 'AUS', 'country_name': 'Australia'},
-        'corruption_perceptions_index':
-            {
-                'rank': 21, 'country_code': 'AUS', 'country_name': 'Australia', 'cpi_score_2019': 24
-             },
+        'corruption_perceptions_index': {
+            'rank': 21,
+            'country_code': 'AUS',
+            'country_name': 'Australia',
+            'cpi_score_2019': 24,
+        },
         'timezone': 'America/Mexico_City',
         'utz_offset': '-0500',
         'world_economic_outlook_data': [{'year_2019': 20, 'country_code': 'AUS', 'country_name': 'Australia'}],
@@ -234,12 +253,16 @@ def test_export_plan_target_markets_update_historical_enabled(authed_client, aut
         'country': 'Mexico',
         'last_year_data': {'import_value': {'year': 2019, 'trade_value': 100}},
         'easeofdoingbusiness': {'total': 1, 'year_2019': 20, 'country_code': 'AUS', 'country_name': 'Australia'},
-        'corruption_perceptions_index':
-            {
-                'rank': 21, 'country_code': 'AUS', 'country_name': 'Australia', 'cpi_score_2019': 24
-             },
-        'historical_import_data': {'historical_trade_value_all': {'2016': 350, '2017': 350, '2018': 350},
-                                   'historical_trade_value_partner': {'2016': 50, '2017': 100, '2018': 200}},
+        'corruption_perceptions_index': {
+            'rank': 21,
+            'country_code': 'AUS',
+            'country_name': 'Australia',
+            'cpi_score_2019': 24,
+        },
+        'historical_import_data': {
+            'historical_trade_value_all': {'2016': 350, '2017': 350, '2018': 350},
+            'historical_trade_value_partner': {'2016': 50, '2017': 100, '2018': 200},
+        },
         'timezone': 'America/Mexico_City',
         'utz_offset': '-0500',
         'world_economic_outlook_data': [{'year_2019': 20, 'country_code': 'AUS', 'country_name': 'Australia'}],
@@ -263,7 +286,7 @@ def test_export_plan_new_actions(authed_client, authed_supplier, export_plan):
 
     actions = [
         {'is_reminders_on': True, 'due_date': '2020-01-01'},
-        {'is_reminders_on': False, 'due_date': '2020-01-02'}
+        {'is_reminders_on': False, 'due_date': '2020-01-02'},
     ]
     url = reverse('export-plan-detail-update', kwargs={'pk': export_plan.pk})
     data = {'export_plan_actions': actions}
@@ -324,10 +347,10 @@ def test_export_plan_objectives_create(authed_client, authed_supplier, export_pl
     url = reverse('export-plan-objectives-list-create')
 
     data = {
-            'companyexportplan': export_plan.id,
-            'description': 'newly created',
-            'planned_reviews': 'None planned',
-        }
+        'companyexportplan': export_plan.id,
+        'description': 'newly created',
+        'planned_reviews': 'None planned',
+    }
 
     response = authed_client.post(url, data)
 
@@ -401,10 +424,10 @@ def test_route_to_market_create(authed_client, authed_supplier, export_plan):
     url = reverse('export-plan-route-to-markets-list-create')
 
     data = {
-            'companyexportplan': export_plan.id,
-            'route': choices.MARKET_ROUTE_CHOICES[0][0],
-            'promote': choices.PRODUCT_PROMOTIONAL_CHOICES[0][0],
-            'market_promotional_channel': 'facebook',
+        'companyexportplan': export_plan.id,
+        'route': choices.MARKET_ROUTE_CHOICES[0][0],
+        'promote': choices.PRODUCT_PROMOTIONAL_CHOICES[0][0],
+        'market_promotional_channel': 'facebook',
     }
 
     response = authed_client.post(url, data)
@@ -476,9 +499,9 @@ def test_target_market_doc_create(authed_client, authed_supplier, export_plan):
     url = reverse('export-plan-target-market-documents-list-create')
 
     data = {
-            'companyexportplan': export_plan.id,
-            'document_name': 'name update',
-            'note': 'new notes',
+        'companyexportplan': export_plan.id,
+        'document_name': 'name update',
+        'note': 'new notes',
     }
 
     response = authed_client.post(url, data)

--- a/exportplan/views.py
+++ b/exportplan/views.py
@@ -1,7 +1,7 @@
 from rest_framework import generics
-from core.permissions import IsAuthenticatedSSO
 
-from exportplan import serializers, models
+from core.permissions import IsAuthenticatedSSO
+from exportplan import models, serializers
 from exportplan.models import CompanyExportPlan
 
 

--- a/healthcheck/backends.py
+++ b/healthcheck/backends.py
@@ -4,7 +4,6 @@ from health_check.exceptions import ServiceUnavailable
 
 
 class ElasticSearchCheckBackend(BaseHealthCheckBackend):
-
     def check_status(self):
         connection = connections.get_connection()
         if not connection.ping():

--- a/makefile
+++ b/makefile
@@ -4,6 +4,16 @@ clean:
 	-find . -type f -name "*.pyc" -delete
 	-find . -type d -name "__pycache__" -delete
 
+# configuration for black and isort is in pyproject.toml
+autoformat:
+	isort $(PWD)
+	black $(PWD)
+
+checks:
+	isort $(PWD) --check
+	black $(PWD) --check --verbose
+	flake8 .
+
 pytest:
 	ENV_FILES='secrets-do-not-commit,test,dev' pytest $(ARGUMENTS)
 
@@ -33,8 +43,8 @@ worker:
 beat:
 	ENV_FILES='secrets-do-not-commit,dev' celery -A conf beat -l info -S django
 
-test: 
+test:
 	flake8 && make pytest
 
 
-.PHONY: clean pytest manage webserver requirements install_requirements css worker beat
+.PHONY: clean autoformat checks pytest manage webserver requirements install_requirements css worker beat

--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -12,9 +12,9 @@ class SupplierEmailNotificationAdmin(admin.ModelAdmin):
         'company_user__company_email',
         'company_user__name',
         'company_user__company__name',
-        'company_user__company__number'
+        'company_user__company__number',
     )
-    readonly_fields = ('date_sent', )
+    readonly_fields = ('date_sent',)
     list_display = ('company_user', 'company_name', 'category', 'date_sent')
     list_filter = ('category',)
     date_hierarchy = 'date_sent'
@@ -31,14 +31,10 @@ class SupplierEmailNotificationAdmin(admin.ModelAdmin):
         """
 
         return generate_csv_response(
-            queryset=queryset,
-            filename=self.csv_filename,
-            excluded_fields=self.csv_excluded_fields
+            queryset=queryset, filename=self.csv_filename, excluded_fields=self.csv_excluded_fields
         )
 
-    download_csv.short_description = (
-        "Download CSV report for selected notifications"
-    )
+    download_csv.short_description = "Download CSV report for selected notifications"
 
     def company_name(self, obj):
         return obj.company_user.company.name if obj.company_user.company else None
@@ -47,7 +43,7 @@ class SupplierEmailNotificationAdmin(admin.ModelAdmin):
 @admin.register(models.AnonymousEmailNotification)
 class AnonymousEmailNotificationAdmin(admin.ModelAdmin):
     search_fields = ('email',)
-    readonly_fields = ('date_sent', )
+    readonly_fields = ('date_sent',)
     list_display = ('email', 'category', 'date_sent')
     list_filter = ('category',)
     date_hierarchy = 'date_sent'
@@ -64,11 +60,7 @@ class AnonymousEmailNotificationAdmin(admin.ModelAdmin):
         """
 
         return generate_csv_response(
-            queryset=queryset,
-            filename=self.csv_filename,
-            excluded_fields=self.csv_excluded_fields
+            queryset=queryset, filename=self.csv_filename, excluded_fields=self.csv_excluded_fields
         )
 
-    download_csv.short_description = (
-        "Download CSV report for selected notifications"
-    )
+    download_csv.short_description = "Download CSV report for selected notifications"

--- a/notifications/constants.py
+++ b/notifications/constants.py
@@ -7,12 +7,9 @@ SUPPLIER_NOTIFICATION_CATEGORIES = (
     (NO_CASE_STUDIES, 'Case studies not created'),
     (HASNT_LOGGED_IN, 'Not logged in after first 30 days'),
     (VERIFICATION_CODE_NOT_GIVEN, 'Verification code not supplied'),
-    (VERIFICATION_CODE_2ND_EMAIL,
-        'Verification code not supplied - 2nd email'),
+    (VERIFICATION_CODE_2ND_EMAIL, 'Verification code not supplied - 2nd email'),
 )
 
 
 NEW_COMPANIES_IN_SECTOR = 'new_companies_in_sector'
-BUYER_NOTIFICATION_CATEGORIES = (
-    (NEW_COMPANIES_IN_SECTOR, 'New companies in sector'),
-)
+BUYER_NOTIFICATION_CATEGORIES = ((NEW_COMPANIES_IN_SECTOR, 'New companies in sector'),)

--- a/notifications/email.py
+++ b/notifications/email.py
@@ -25,7 +25,7 @@ class NotificationBase(abc.ABC):
             'full_name': self.recipient.name,
             'zendesk_url': self.zendesk_url,
             'unsubscribe_url': self.unsubscribe_url,
-            **kwargs
+            **kwargs,
         }
 
     def get_bodies(self):
@@ -50,10 +50,7 @@ class SupplierNotificationBase(NotificationBase):
 
     def send(self):
         text_body, html_body = self.get_bodies()
-        models.SupplierEmailNotification.objects.create(
-            company_user=self.company_user,
-            category=self.category
-        )
+        models.SupplierEmailNotification.objects.create(company_user=self.company_user, category=self.category)
         core.tasks.send_email.delay(
             subject=self.subject,
             text_body=text_body,
@@ -71,22 +68,17 @@ class AnonymousSubscriberNotificationBase(NotificationBase):
 
     @property
     def recipient(self):
-        return Recipient(
-            name=self.subscriber['name'],
-            email=self.subscriber['email']
-        )
+        return Recipient(name=self.subscriber['name'], email=self.subscriber['email'])
 
     def send(self):
         text_body, html_body = self.get_bodies()
-        models.AnonymousEmailNotification.objects.create(
-            email=self.recipient.email, category=self.category
-        )
+        models.AnonymousEmailNotification.objects.create(email=self.recipient.email, category=self.category)
         core.tasks.send_email.delay(
             subject=self.subject,
             text_body=text_body,
             html_body=html_body,
             recipient_email=self.recipient.email,
-            from_email=self.from_email
+            from_email=self.from_email,
         )
 
 
@@ -109,7 +101,9 @@ class VerificationStillWaitingNotification(SupplierNotificationBase):
     unsubscribe_url = settings.FAB_NOTIFICATIONS_UNSUBSCRIBE_URL
 
     def get_context_data(self):
-        return super().get_context_data(verification_url=settings.VERIFICATION_CODE_URL,)
+        return super().get_context_data(
+            verification_url=settings.VERIFICATION_CODE_URL,
+        )
 
 
 class NewCompaniesInSectorNotification(AnonymousSubscriberNotificationBase):

--- a/notifications/fields.py
+++ b/notifications/fields.py
@@ -1,6 +1,5 @@
-from rest_framework import exceptions, fields
-
 from django.core.signing import BadSignature, Signer
+from rest_framework import exceptions, fields
 
 
 class SignedEmailField(fields.EmailField):

--- a/notifications/helpers.py
+++ b/notifications/helpers.py
@@ -2,13 +2,13 @@ import urllib
 from collections import defaultdict
 from datetime import datetime, timedelta
 
-from django.core.signing import Signer
 from django.conf import settings
+from django.core.signing import Signer
 
 from buyer.models import Buyer
 from company.models import Company, CompanyUser
-from notifications.models import AnonymousUnsubscribe, AnonymousEmailNotification
 from notifications import constants
+from notifications.models import AnonymousEmailNotification, AnonymousUnsubscribe
 
 
 def group_new_companies_by_industry():
@@ -58,12 +58,10 @@ def get_new_companies_anonymous_subscribers():
     unsubscribers = AnonymousUnsubscribe.objects.all()
     delta = timedelta(days=settings.NEW_COMPANIES_IN_SECTOR_FREQUENCY_DAYS)
     notifications_sent_recently = AnonymousEmailNotification.objects.filter(
-        category=constants.NEW_COMPANIES_IN_SECTOR,
-        date_sent__date__gte=datetime.utcnow() - delta
+        category=constants.NEW_COMPANIES_IN_SECTOR, date_sent__date__gte=datetime.utcnow() - delta
     )
-    exclude_emails = (
-        list(unsubscribers.values_list('email', flat=True)) +
-        list(notifications_sent_recently.values_list('email', flat=True))
+    exclude_emails = list(unsubscribers.values_list('email', flat=True)) + list(
+        notifications_sent_recently.values_list('email', flat=True)
     )
 
     subscribers = {}

--- a/notifications/management/commands/send_notifications.py
+++ b/notifications/management/commands/send_notifications.py
@@ -7,12 +7,7 @@ class Command(BaseCommand):
     help = 'Send various notifications to users'
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            '--type',
-            action='store',
-            dest='type',
-            help='Specifies the type of notifications to send'
-        )
+        parser.add_argument('--type', action='store', dest='type', help='Specifies the type of notifications to send')
 
     def run_daily(self):
         notifications.verification_code_not_given()
@@ -25,8 +20,7 @@ class Command(BaseCommand):
         if type_option is None:
             raise CommandError('--type option is required')
         elif type_option not in ['daily', 'weekly']:
-            raise CommandError(
-                "%s is not a valid notification type" % type_option)
+            raise CommandError("%s is not a valid notification type" % type_option)
 
         if type_option == 'daily':
             self.run_daily()

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -11,10 +11,14 @@ def verification_code_not_given():
 def verification_code_not_given_first_reminder():
     days_ago = settings.VERIFICATION_CODE_NOT_GIVEN_DAYS
     category = constants.VERIFICATION_CODE_NOT_GIVEN
-    company_users = helpers.get_unverified_suppliers(days_ago).filter(
-        company__is_uk_isd_company=False,
-    ).exclude(
-        supplieremailnotification__category=category,
+    company_users = (
+        helpers.get_unverified_suppliers(days_ago)
+        .filter(
+            company__is_uk_isd_company=False,
+        )
+        .exclude(
+            supplieremailnotification__category=category,
+        )
     )
     for company_user in company_users:
         notification = email.VerificationWaitingNotification(company_user)
@@ -24,10 +28,14 @@ def verification_code_not_given_first_reminder():
 def verification_code_not_given_seconds_reminder():
     days_ago = settings.VERIFICATION_CODE_NOT_GIVEN_DAYS_2ND_EMAIL
     category = constants.VERIFICATION_CODE_2ND_EMAIL
-    company_users = helpers.get_unverified_suppliers(days_ago).filter(
-        company__is_uk_isd_company=False,
-    ).exclude(
-        supplieremailnotification__category=category,
+    company_users = (
+        helpers.get_unverified_suppliers(days_ago)
+        .filter(
+            company__is_uk_isd_company=False,
+        )
+        .exclude(
+            supplieremailnotification__category=category,
+        )
     )
     for company_user in company_users:
         notification = email.VerificationStillWaitingNotification(company_user)
@@ -42,9 +50,7 @@ def new_companies_in_sector():
         for industry in subscriber['industries']:
             companies.update(companies_grouped_by_industry[industry])
         if companies:
-            notification = email.NewCompaniesInSectorNotification(
-                subscriber=subscriber, companies=companies
-            )
+            notification = email.NewCompaniesInSectorNotification(subscriber=subscriber, companies=companies)
             notification.send()
 
 

--- a/notifications/serializers.py
+++ b/notifications/serializers.py
@@ -8,6 +8,4 @@ class AnonymousUnsubscribeSerializer(serializers.ModelSerializer):
 
     class Meta(object):
         model = models.AnonymousUnsubscribe
-        fields = (
-            'email',
-        )
+        fields = ('email',)

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -5,7 +5,7 @@ from notifications import notifications
 
 
 def lock_acquired(lock_name):
-    """ Returns False if the lock was already set in the last 20 hours
+    """Returns False if the lock was already set in the last 20 hours
 
     Multiple celery beat schedulers are running at the same time, which
     results in duplicated scheduled tasks. Cache-lock mechanism is used to

--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -1,7 +1,6 @@
 from django import template
 from django.conf import settings
 
-
 register = template.Library()
 
 

--- a/notifications/tests/factories.py
+++ b/notifications/tests/factories.py
@@ -1,9 +1,8 @@
 import factory
 import factory.fuzzy
 
-from notifications import models, constants
 from company.tests.factories import CompanyUserFactory
-
+from notifications import constants, models
 
 SUPPLIER_CATEGORY_CHOICES = [i[0] for i in constants.SUPPLIER_NOTIFICATION_CATEGORIES]
 BUYER_CATEGORY_CHOICES = [i[0] for i in constants.BUYER_NOTIFICATION_CATEGORIES]

--- a/notifications/tests/helpers.py
+++ b/notifications/tests/helpers.py
@@ -5,4 +5,5 @@ def build_suppier_email_notification_factory(SupplierEmailNotification):
     class HistoricFactory(SupplierEmailNotificationFactory):
         class Meta:
             model = SupplierEmailNotification
+
     return HistoricFactory

--- a/notifications/tests/test_admin.py
+++ b/notifications/tests/test_admin.py
@@ -1,29 +1,19 @@
 from collections import OrderedDict
 from unittest import TestCase
 
+import pytest
+from django.contrib.auth.models import User
 from django.test import Client
 from django.urls import reverse
-from django.contrib.auth.models import User
 
-import pytest
-
-from notifications.models import (
-    SupplierEmailNotification,
-    AnonymousEmailNotification
-)
-from notifications.tests.factories import (
-    SupplierEmailNotificationFactory,
-    AnonymousEmailNotificationFactory
-)
+from notifications.models import AnonymousEmailNotification, SupplierEmailNotification
+from notifications.tests.factories import AnonymousEmailNotificationFactory, SupplierEmailNotificationFactory
 
 
 @pytest.mark.django_db
 class DownloadCSVTestCase(TestCase):
-
     def setUp(self):
-        superuser = User.objects.create_superuser(
-            username='admin', email='admin@example.com', password='test'
-        )
+        superuser = User.objects.create_superuser(username='admin', email='admin@example.com', password='test')
         self.client = Client()
         self.client.force_login(superuser)
 
@@ -32,20 +22,20 @@ class DownloadCSVTestCase(TestCase):
 
         data = {
             'action': 'download_csv',
-            '_selected_action': SupplierEmailNotification.objects.all().values_list('pk', flat=True)
+            '_selected_action': SupplierEmailNotification.objects.all().values_list('pk', flat=True),
         }
         response = self.client.post(
-            reverse('admin:notifications_supplieremailnotification_changelist'),
-            data,
-            follow=True
+            reverse('admin:notifications_supplieremailnotification_changelist'), data, follow=True
         )
 
-        expected_data = OrderedDict([
-            ('category', str(supplier_email_notification.category)),
-            ('company_user', str(supplier_email_notification.company_user.id)),
-            ('date_sent', str(supplier_email_notification.date_sent)),
-            ('id', str(supplier_email_notification.id)),
-        ])
+        expected_data = OrderedDict(
+            [
+                ('category', str(supplier_email_notification.category)),
+                ('company_user', str(supplier_email_notification.company_user.id)),
+                ('date_sent', str(supplier_email_notification.date_sent)),
+                ('id', str(supplier_email_notification.id)),
+            ]
+        )
         actual = str(response.content, 'utf-8').split('\r\n')
 
         assert actual[0] == ','.join(expected_data.keys())
@@ -54,135 +44,114 @@ class DownloadCSVTestCase(TestCase):
     def test_download_csv_supplier_email_notification_no_company(self):
         SupplierEmailNotificationFactory(company_user__company=None)
 
-        response = self.client.get(
-            reverse('admin:notifications_supplieremailnotification_changelist')
-        )
+        response = self.client.get(reverse('admin:notifications_supplieremailnotification_changelist'))
 
         assert response.status_code == 200
 
     def test_download_csv_multiple_supplier_email_notifications(self):
         supplier_email_notifications = SupplierEmailNotificationFactory.create_batch(3)
 
-        supplier_email_notification_one_expected_data = OrderedDict([
-            ('category', str(supplier_email_notifications[2].category)),
-            ('company_user', str(supplier_email_notifications[2].company_user.id)),
-            ('date_sent', str(supplier_email_notifications[2].date_sent)),
-            ('id', str(supplier_email_notifications[2].id)),
-        ])
-        supplier_email_notification_two_expected_data = OrderedDict([
-            ('category', str(supplier_email_notifications[1].category)),
-            ('company_user', str(supplier_email_notifications[1].company_user.id)),
-            ('date_sent', str(supplier_email_notifications[1].date_sent)),
-            ('id', str(supplier_email_notifications[1].id)),
-        ])
-        supplier_email_notification_three_expected_data = OrderedDict([
-            ('category', str(supplier_email_notifications[0].category)),
-            ('company_user', str(supplier_email_notifications[0].company_user.id)),
-            ('date_sent', str(supplier_email_notifications[0].date_sent)),
-            ('id', str(supplier_email_notifications[0].id)),
-        ])
+        supplier_email_notification_one_expected_data = OrderedDict(
+            [
+                ('category', str(supplier_email_notifications[2].category)),
+                ('company_user', str(supplier_email_notifications[2].company_user.id)),
+                ('date_sent', str(supplier_email_notifications[2].date_sent)),
+                ('id', str(supplier_email_notifications[2].id)),
+            ]
+        )
+        supplier_email_notification_two_expected_data = OrderedDict(
+            [
+                ('category', str(supplier_email_notifications[1].category)),
+                ('company_user', str(supplier_email_notifications[1].company_user.id)),
+                ('date_sent', str(supplier_email_notifications[1].date_sent)),
+                ('id', str(supplier_email_notifications[1].id)),
+            ]
+        )
+        supplier_email_notification_three_expected_data = OrderedDict(
+            [
+                ('category', str(supplier_email_notifications[0].category)),
+                ('company_user', str(supplier_email_notifications[0].company_user.id)),
+                ('date_sent', str(supplier_email_notifications[0].date_sent)),
+                ('id', str(supplier_email_notifications[0].id)),
+            ]
+        )
 
         data = {
             'action': 'download_csv',
-            '_selected_action': SupplierEmailNotification.objects.all(
-            ).values_list('pk', flat=True)
+            '_selected_action': SupplierEmailNotification.objects.all().values_list('pk', flat=True),
         }
         response = self.client.post(
-            reverse(
-                'admin:notifications_supplieremailnotification_changelist'
-            ),
-            data,
-            follow=True
+            reverse('admin:notifications_supplieremailnotification_changelist'), data, follow=True
         )
 
         actual = str(response.content, 'utf-8').split('\r\n')
-        assert actual[0] == ','.join(
-            supplier_email_notification_one_expected_data.keys()
-        )
-        assert actual[1] == ','.join(
-            supplier_email_notification_one_expected_data.values()
-        )
-        assert actual[2] == ','.join(
-            supplier_email_notification_two_expected_data.values()
-        )
-        assert actual[3] == ','.join(
-            supplier_email_notification_three_expected_data.values()
-        )
+        assert actual[0] == ','.join(supplier_email_notification_one_expected_data.keys())
+        assert actual[1] == ','.join(supplier_email_notification_one_expected_data.values())
+        assert actual[2] == ','.join(supplier_email_notification_two_expected_data.values())
+        assert actual[3] == ','.join(supplier_email_notification_three_expected_data.values())
 
     def test_download_csv_anonymous_email_notification(self):
         anonymous_email_notification = AnonymousEmailNotificationFactory()
 
         data = {
             'action': 'download_csv',
-            '_selected_action': AnonymousEmailNotification.objects.all(
-            ).values_list('pk', flat=True)
+            '_selected_action': AnonymousEmailNotification.objects.all().values_list('pk', flat=True),
         }
         response = self.client.post(
-            reverse(
-                'admin:notifications_anonymousemailnotification_changelist'
-            ),
-            data,
-            follow=True
+            reverse('admin:notifications_anonymousemailnotification_changelist'), data, follow=True
         )
 
-        expected_data = OrderedDict([
-            ('category', str(anonymous_email_notification.category)),
-            ('date_sent', str(anonymous_email_notification.date_sent)),
-            ('email', str(anonymous_email_notification.email)),
-            ('id', str(anonymous_email_notification.id)),
-        ])
+        expected_data = OrderedDict(
+            [
+                ('category', str(anonymous_email_notification.category)),
+                ('date_sent', str(anonymous_email_notification.date_sent)),
+                ('email', str(anonymous_email_notification.email)),
+                ('id', str(anonymous_email_notification.id)),
+            ]
+        )
         actual = str(response.content, 'utf-8').split('\r\n')
 
         assert actual[0] == ','.join(expected_data.keys())
         assert actual[1] == ','.join(expected_data.values())
 
     def test_download_csv_multiple_anonymous_email_notifications(self):
-        anonymous_email_notifications = (
-            AnonymousEmailNotificationFactory.create_batch(3)
-        )
+        anonymous_email_notifications = AnonymousEmailNotificationFactory.create_batch(3)
 
-        anonymous_email_notification_one_expected_data = OrderedDict([
-            ('category', str(anonymous_email_notifications[2].category)),
-            ('date_sent', str(anonymous_email_notifications[2].date_sent)),
-            ('email', str(anonymous_email_notifications[2].email)),
-            ('id', str(anonymous_email_notifications[2].id)),
-        ])
-        anonymous_email_notification_two_expected_data = OrderedDict([
-            ('category', str(anonymous_email_notifications[1].category)),
-            ('date_sent', str(anonymous_email_notifications[1].date_sent)),
-            ('email', str(anonymous_email_notifications[1].email)),
-            ('id', str(anonymous_email_notifications[1].id)),
-        ])
-        anonymous_email_notification_three_expected_data = OrderedDict([
-            ('category', str(anonymous_email_notifications[0].category)),
-            ('date_sent', str(anonymous_email_notifications[0].date_sent)),
-            ('email', str(anonymous_email_notifications[0].email)),
-            ('id', str(anonymous_email_notifications[0].id)),
-        ])
+        anonymous_email_notification_one_expected_data = OrderedDict(
+            [
+                ('category', str(anonymous_email_notifications[2].category)),
+                ('date_sent', str(anonymous_email_notifications[2].date_sent)),
+                ('email', str(anonymous_email_notifications[2].email)),
+                ('id', str(anonymous_email_notifications[2].id)),
+            ]
+        )
+        anonymous_email_notification_two_expected_data = OrderedDict(
+            [
+                ('category', str(anonymous_email_notifications[1].category)),
+                ('date_sent', str(anonymous_email_notifications[1].date_sent)),
+                ('email', str(anonymous_email_notifications[1].email)),
+                ('id', str(anonymous_email_notifications[1].id)),
+            ]
+        )
+        anonymous_email_notification_three_expected_data = OrderedDict(
+            [
+                ('category', str(anonymous_email_notifications[0].category)),
+                ('date_sent', str(anonymous_email_notifications[0].date_sent)),
+                ('email', str(anonymous_email_notifications[0].email)),
+                ('id', str(anonymous_email_notifications[0].id)),
+            ]
+        )
 
         data = {
             'action': 'download_csv',
-            '_selected_action': AnonymousEmailNotification.objects.all(
-            ).values_list('pk', flat=True)
+            '_selected_action': AnonymousEmailNotification.objects.all().values_list('pk', flat=True),
         }
         response = self.client.post(
-            reverse(
-                'admin:notifications_anonymousemailnotification_changelist'
-            ),
-            data,
-            follow=True
+            reverse('admin:notifications_anonymousemailnotification_changelist'), data, follow=True
         )
 
         actual = str(response.content, 'utf-8').split('\r\n')
-        assert actual[0] == ','.join(
-            anonymous_email_notification_one_expected_data.keys()
-        )
-        assert actual[1] == ','.join(
-            anonymous_email_notification_one_expected_data.values()
-        )
-        assert actual[2] == ','.join(
-            anonymous_email_notification_two_expected_data.values()
-        )
-        assert actual[3] == ','.join(
-            anonymous_email_notification_three_expected_data.values()
-        )
+        assert actual[0] == ','.join(anonymous_email_notification_one_expected_data.keys())
+        assert actual[1] == ','.join(anonymous_email_notification_one_expected_data.values())
+        assert actual[2] == ','.join(anonymous_email_notification_two_expected_data.values())
+        assert actual[3] == ','.join(anonymous_email_notification_three_expected_data.values())

--- a/notifications/tests/test_commands.py
+++ b/notifications/tests/test_commands.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import pytest
-
 from django.core.management import call_command
 from django.core.management.base import CommandError
 

--- a/notifications/tests/test_models.py
+++ b/notifications/tests/test_models.py
@@ -1,18 +1,13 @@
-from notifications.tests.factories import (
-    SupplierEmailNotificationFactory, AnonymousEmailNotificationFactory)
+from notifications.tests.factories import AnonymousEmailNotificationFactory, SupplierEmailNotificationFactory
 
 
 def test_supplieremailnotifications_str_method():
     instance = SupplierEmailNotificationFactory.build(
-        company_user__company_email='test@example.com',
-        category='no_case_studies'
+        company_user__company_email='test@example.com', category='no_case_studies'
     )
     assert str(instance) == 'test@example.com: no_case_studies'
 
 
 def test_anonymous_email_notification_str_method():
-    instance = AnonymousEmailNotificationFactory.build(
-        email='test@example.com',
-        category='new_companies_in_sector'
-    )
+    instance = AnonymousEmailNotificationFactory.build(email='test@example.com', category='new_companies_in_sector')
     assert str(instance) == 'test@example.com: new_companies_in_sector'

--- a/notifications/tests/test_notifications.py
+++ b/notifications/tests/test_notifications.py
@@ -1,18 +1,16 @@
-from datetime import timedelta, datetime
-from unittest.mock import patch, PropertyMock
+from datetime import datetime, timedelta
+from unittest.mock import PropertyMock, patch
 
 import pytest
-from freezegun import freeze_time
-
 from django.core import mail
 from django.utils import html, timezone
+from freezegun import freeze_time
 
 from buyer.tests.factories import BuyerFactory
 from company.tests.factories import CompanyFactory, CompanyUserFactory
 from notifications import email, notifications
 from notifications.models import SupplierEmailNotification
 from notifications.tests import factories
-
 
 LAST_LOGIN_API_METHOD = 'directory_sso_api_client.user.UserAPIClient.get_last_login'
 
@@ -22,19 +20,13 @@ LAST_LOGIN_API_METHOD = 'directory_sso_api_client.user.UserAPIClient.get_last_lo
 def test_doesnt_send_ver_code_email_when_user_has_input_ver_code(mock_task):
     eight_days_ago = timezone.now() - timedelta(days=8)
     sixteen_days_ago = timezone.now() - timedelta(days=16)
-    CompanyUserFactory(
-        company__verified_with_code=True,
-        company__date_verification_letter_sent=eight_days_ago)
-    CompanyUserFactory(
-        company__verified_with_code=True,
-        company__date_verification_letter_sent=sixteen_days_ago)
+    CompanyUserFactory(company__verified_with_code=True, company__date_verification_letter_sent=eight_days_ago)
+    CompanyUserFactory(company__verified_with_code=True, company__date_verification_letter_sent=sixteen_days_ago)
     company_user_with_reminder = CompanyUserFactory(
-        company__verified_with_code=True,
-        company__date_verification_letter_sent=sixteen_days_ago)
+        company__verified_with_code=True, company__date_verification_letter_sent=sixteen_days_ago
+    )
     factories.SupplierEmailNotificationFactory(
-        company_user=company_user_with_reminder,
-        category='verification_code_not_given',
-        date_sent=eight_days_ago
+        company_user=company_user_with_reminder, category='verification_code_not_given', date_sent=eight_days_ago
     )
     notifications.verification_code_not_given()
 
@@ -51,22 +43,17 @@ def test_sends_ver_code_email_when_not_input_for_8_days(mock_task, settings):
     seven_days_ago = timezone.now() - timedelta(days=7)
     eight_days_ago = timezone.now() - timedelta(days=8)
     nine_days_ago = timezone.now() - timedelta(days=9)
-    CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=seven_days_ago
-    )
+    CompanyUserFactory(company__verified_with_code=False, company__date_verification_letter_sent=seven_days_ago)
     company_user = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=eight_days_ago
+        company__verified_with_code=False, company__date_verification_letter_sent=eight_days_ago
     )
     company_user_with_reminder = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=nine_days_ago
+        company__verified_with_code=False, company__date_verification_letter_sent=nine_days_ago
     )
     factories.SupplierEmailNotificationFactory(
         company_user=company_user_with_reminder,
         category='verification_code_not_given',
-        date_sent=(timezone.now() - timedelta(days=1))
+        date_sent=(timezone.now() - timedelta(days=1)),
     )
     notifications.verification_code_not_given()
 
@@ -82,8 +69,10 @@ def test_sends_ver_code_email_when_not_input_for_8_days(mock_task, settings):
 
 @freeze_time()
 @pytest.mark.django_db
-@patch('notifications.email.VerificationWaitingNotification.zendesk_url',
-       PropertyMock(return_value='http://help.zendesk.com'))
+@patch(
+    'notifications.email.VerificationWaitingNotification.zendesk_url',
+    PropertyMock(return_value='http://help.zendesk.com'),
+)
 @patch('core.tasks.send_email')
 def test_ver_code_email_has_expected_vars_in_template(mock_task, settings):
     settings.VERIFICATION_CODE_URL = 'http://great.gov.uk/verrrrify'
@@ -91,7 +80,9 @@ def test_ver_code_email_has_expected_vars_in_template(mock_task, settings):
     eight_days_ago = timezone.now() - timedelta(days=8)
     company_user = CompanyUserFactory(
         company__date_verification_letter_sent=eight_days_ago,
-        company__verified_with_code=False, date_joined=eight_days_ago)
+        company__verified_with_code=False,
+        date_joined=eight_days_ago,
+    )
 
     notifications.verification_code_not_given()
 
@@ -115,33 +106,33 @@ def test_sends_ver_code_email_when_not_input_for_16_days(mock_task, settings):
     sixteen_days_ago = timezone.now() - timedelta(days=16)
     seventeen_days_ago = timezone.now() - timedelta(days=17)
     company_user_15 = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=fifteen_days_ago)
+        company__verified_with_code=False, company__date_verification_letter_sent=fifteen_days_ago
+    )
     company_user_16 = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=sixteen_days_ago)
+        company__verified_with_code=False, company__date_verification_letter_sent=sixteen_days_ago
+    )
     company_user_17 = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=seventeen_days_ago)
+        company__verified_with_code=False, company__date_verification_letter_sent=seventeen_days_ago
+    )
     factories.SupplierEmailNotificationFactory(
         company_user=company_user_15,
         category='verification_code_not_given',
-        date_sent=(timezone.now() - timedelta(days=7))
+        date_sent=(timezone.now() - timedelta(days=7)),
     )
     factories.SupplierEmailNotificationFactory(
         company_user=company_user_16,
         category='verification_code_not_given',
-        date_sent=(timezone.now() - timedelta(days=8))
+        date_sent=(timezone.now() - timedelta(days=8)),
     )
     factories.SupplierEmailNotificationFactory(
         company_user=company_user_17,
         category='verification_code_not_given',
-        date_sent=(timezone.now() - timedelta(days=9))
+        date_sent=(timezone.now() - timedelta(days=9)),
     )
     factories.SupplierEmailNotificationFactory(
         company_user=company_user_17,
         category='verification_code_2nd_email',
-        date_sent=(timezone.now() - timedelta(days=1))
+        date_sent=(timezone.now() - timedelta(days=1)),
     )
 
     notifications.verification_code_not_given()
@@ -158,15 +149,19 @@ def test_sends_ver_code_email_when_not_input_for_16_days(mock_task, settings):
 
 @freeze_time()
 @pytest.mark.django_db
-@patch('notifications.email.VerificationStillWaitingNotification.zendesk_url',
-       PropertyMock(return_value='http://help.zendesk.com'))
+@patch(
+    'notifications.email.VerificationStillWaitingNotification.zendesk_url',
+    PropertyMock(return_value='http://help.zendesk.com'),
+)
 @patch('core.tasks.send_email')
 def test_ver_code_email2_has_expected_vars_in_template(mock_task, settings):
     settings.VERIFICATION_CODE_URL = 'http://great.gov.uk/verrrrify'
     sixteen_days_ago = timezone.now() - timedelta(days=16)
     company_user = CompanyUserFactory(
         company__date_verification_letter_sent=sixteen_days_ago,
-        company__verified_with_code=False, date_joined=sixteen_days_ago)
+        company__verified_with_code=False,
+        date_joined=sixteen_days_ago,
+    )
 
     notifications.verification_code_not_given()
 
@@ -184,16 +179,14 @@ def test_ver_code_email2_has_expected_vars_in_template(mock_task, settings):
 @freeze_time('2016-12-16 19:11')
 @pytest.mark.django_db
 @patch('core.tasks.send_email')
-def test_sends_ver_code_email_when_8_days_passed_but_not_to_the_minute(
-        mock_task, settings
-):
+def test_sends_ver_code_email_when_8_days_passed_but_not_to_the_minute(mock_task, settings):
     company_user_2_verification_sent = datetime(2016, 12, 8, 23, 59, 59)
     company_user_1 = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=datetime(2016, 12, 8, 0, 0, 1))
+        company__verified_with_code=False, company__date_verification_letter_sent=datetime(2016, 12, 8, 0, 0, 1)
+    )
     company_user_2 = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=company_user_2_verification_sent)
+        company__verified_with_code=False, company__date_verification_letter_sent=company_user_2_verification_sent
+    )
 
     notifications.verification_code_not_given()
 
@@ -209,20 +202,16 @@ def test_sends_ver_code_email_when_8_days_passed_but_not_to_the_minute(
 def test_sends_ver_code_email_when_16_days_passed_but_not_to_the_minute(mock_task, settings):
     company_user_2_verification_sent = datetime(2016, 11, 30, 23, 59, 59)
     company_user_1 = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=datetime(2016, 11, 30, 0, 0, 1))
+        company__verified_with_code=False, company__date_verification_letter_sent=datetime(2016, 11, 30, 0, 0, 1)
+    )
     company_user_2 = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=company_user_2_verification_sent)
-    factories.SupplierEmailNotificationFactory(
-        company_user=company_user_1,
-        category='verification_code_not_given',
-        date_sent=datetime(2016, 11, 8, 23, 59, 59)
+        company__verified_with_code=False, company__date_verification_letter_sent=company_user_2_verification_sent
     )
     factories.SupplierEmailNotificationFactory(
-        company_user=company_user_2,
-        category='verification_code_not_given',
-        date_sent=datetime(2016, 11, 8, 23, 59, 59)
+        company_user=company_user_1, category='verification_code_not_given', date_sent=datetime(2016, 11, 8, 23, 59, 59)
+    )
+    factories.SupplierEmailNotificationFactory(
+        company_user=company_user_2, category='verification_code_not_given', date_sent=datetime(2016, 11, 8, 23, 59, 59)
     )
 
     notifications.verification_code_not_given()
@@ -242,18 +231,16 @@ def test_doesnt_send_ver_code_email_if_email_already_sent(mock_task):
     eight_days_ago = timezone.now() - timedelta(days=8)
     sixteen_days_ago = timezone.now() - timedelta(days=16)
     company_user_1 = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=eight_days_ago)
+        company__verified_with_code=False, company__date_verification_letter_sent=eight_days_ago
+    )
     company_user_2 = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=sixteen_days_ago)
+        company__verified_with_code=False, company__date_verification_letter_sent=sixteen_days_ago
+    )
+    factories.SupplierEmailNotificationFactory(company_user=company_user_1, category='verification_code_not_given')
+    factories.SupplierEmailNotificationFactory(company_user=company_user_2, category='verification_code_2nd_email')
     factories.SupplierEmailNotificationFactory(
-        company_user=company_user_1, category='verification_code_not_given')
-    factories.SupplierEmailNotificationFactory(
-        company_user=company_user_2, category='verification_code_2nd_email')
-    factories.SupplierEmailNotificationFactory(
-        company_user=company_user_2, category='verification_code_not_given',
-        date_sent=eight_days_ago)
+        company_user=company_user_2, category='verification_code_not_given', date_sent=eight_days_ago
+    )
 
     notifications.verification_code_not_given()
 
@@ -264,21 +251,15 @@ def test_doesnt_send_ver_code_email_if_email_already_sent(mock_task):
 
 @pytest.mark.django_db
 @patch('core.tasks.send_email')
-def test_ver_code_email_uses_settings_for_no_of_days_and_subject_for_email1(
-        mock_task, settings
-):
+def test_ver_code_email_uses_settings_for_no_of_days_and_subject_for_email1(mock_task, settings):
     expected_subject = email.VerificationWaitingNotification.subject
     settings.VERIFICATION_CODE_NOT_GIVEN_DAYS = 1
     settings.VERIFICATION_CODE_NOT_GIVEN_SUBJECT = 'bla bla'
     one_day_ago = timezone.now() - timedelta(days=1)
     eight_days_ago = timezone.now() - timedelta(days=8)
-    CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=eight_days_ago
-    )
+    CompanyUserFactory(company__verified_with_code=False, company__date_verification_letter_sent=eight_days_ago)
     company_user = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=one_day_ago
+        company__verified_with_code=False, company__date_verification_letter_sent=one_day_ago
     )
 
     notifications.verification_code_not_given()
@@ -296,18 +277,14 @@ def test_ver_code_email_uses_settings_for_no_of_days_and_subject_for_email2(mock
     settings.VERIFICATION_CODE_NOT_GIVEN_SUBJECT_2ND_EMAIL = 'bla bla'
     one_day_ago = timezone.now() - timedelta(days=1)
     sixteen_days_ago = timezone.now() - timedelta(days=16)
-    CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=sixteen_days_ago
-    )
+    CompanyUserFactory(company__verified_with_code=False, company__date_verification_letter_sent=sixteen_days_ago)
     company_user = CompanyUserFactory(
-        company__verified_with_code=False,
-        company__date_verification_letter_sent=one_day_ago
+        company__verified_with_code=False, company__date_verification_letter_sent=one_day_ago
     )
     factories.SupplierEmailNotificationFactory(
         company_user=company_user,
         category='verification_code_not_given',
-        date_sent=(timezone.now() - timedelta(days=8))
+        date_sent=(timezone.now() - timedelta(days=8)),
     )
     mail.outbox = []  # reset after emails sent by signals
 
@@ -326,24 +303,22 @@ def test_sends_ver_code_email_to_expected_users(mock_task):
     twelve_days_ago = timezone.now() - timedelta(days=12)
     sixteen_days_ago = timezone.now() - timedelta(days=16)
     CompanyUserFactory.create_batch(
-        3, company__verified_with_code=True,
-        company__date_verification_letter_sent=eight_days_ago)
-    company_users_8 = CompanyUserFactory.create_batch(
-        3, company__verified_with_code=False,
-        company__date_verification_letter_sent=eight_days_ago)
-    CompanyUserFactory.create_batch(
-        3, company__verified_with_code=False,
-        company__date_verification_letter_sent=twelve_days_ago)
-    company_users_16 = CompanyUserFactory.create_batch(
-        3, company__verified_with_code=False,
-        company__date_verification_letter_sent=sixteen_days_ago)
-    CompanyUserFactory.create_batch(
-        3, company__verified_with_code=True,
-        company__date_verification_letter_sent=sixteen_days_ago)
-    factories.SupplierEmailNotificationFactory(company_user=company_users_8[2], category='verification_code_not_given')
-    factories.SupplierEmailNotificationFactory(
-        company_user=company_users_16[2], category='verification_code_2nd_email'
+        3, company__verified_with_code=True, company__date_verification_letter_sent=eight_days_ago
     )
+    company_users_8 = CompanyUserFactory.create_batch(
+        3, company__verified_with_code=False, company__date_verification_letter_sent=eight_days_ago
+    )
+    CompanyUserFactory.create_batch(
+        3, company__verified_with_code=False, company__date_verification_letter_sent=twelve_days_ago
+    )
+    company_users_16 = CompanyUserFactory.create_batch(
+        3, company__verified_with_code=False, company__date_verification_letter_sent=sixteen_days_ago
+    )
+    CompanyUserFactory.create_batch(
+        3, company__verified_with_code=True, company__date_verification_letter_sent=sixteen_days_ago
+    )
+    factories.SupplierEmailNotificationFactory(company_user=company_users_8[2], category='verification_code_not_given')
+    factories.SupplierEmailNotificationFactory(company_user=company_users_16[2], category='verification_code_2nd_email')
     for company_user in company_users_16:
         factories.SupplierEmailNotificationFactory(
             company_user=company_user, category='verification_code_not_given', date_sent=eight_days_ago
@@ -376,36 +351,24 @@ def test_new_companies_in_sector(mock_task, settings):
     buyer_two = BuyerFactory.create(sector='AEROSPACE')
     buyer_three = BuyerFactory.create(sector='CONSTRUCTION')
     company_one = CompanyFactory(
-        sectors=['AEROSPACE'], date_published=days_ago_three,
+        sectors=['AEROSPACE'],
+        date_published=days_ago_three,
     )
     company_two = CompanyFactory(
-        sectors=['AEROSPACE'], date_published=days_ago_four,
+        sectors=['AEROSPACE'],
+        date_published=days_ago_four,
     )
     company_three = CompanyFactory(
-        sectors=['CONSTRUCTION'], date_published=days_ago_three,
+        sectors=['CONSTRUCTION'],
+        date_published=days_ago_three,
     )
 
     notifications.new_companies_in_sector()
     call_args_list = mock_task.delay.call_args_list
     assert len(call_args_list) == 3
-    email_one = list(
-        filter(
-            lambda x: x[1]['recipient_email'] == buyer_one.email,
-            call_args_list
-        )
-    )[0][1]
-    email_two = list(
-        filter(
-            lambda x: x[1]['recipient_email'] == buyer_two.email,
-            call_args_list
-        )
-    )[0][1]
-    email_three = list(
-        filter(
-            lambda x: x[1]['recipient_email'] == buyer_three.email,
-            call_args_list
-        )
-    )[0][1]
+    email_one = list(filter(lambda x: x[1]['recipient_email'] == buyer_one.email, call_args_list))[0][1]
+    email_two = list(filter(lambda x: x[1]['recipient_email'] == buyer_two.email, call_args_list))[0][1]
+    email_three = list(filter(lambda x: x[1]['recipient_email'] == buyer_three.email, call_args_list))[0][1]
 
     assert email_one['recipient_email'] == buyer_one.email
     assert email_one['subject'] == expected_subject
@@ -464,8 +427,7 @@ def test_new_companies_in_sector_exclude_company_users_without_companies(mock_ta
 @freeze_time()
 @pytest.mark.django_db
 @patch('core.tasks.send_email')
-def test_new_companies_in_sector_exclude_already_sent_recently(
-        mock_task, settings):
+def test_new_companies_in_sector_exclude_already_sent_recently(mock_task, settings):
     settings.NEW_COMPANIES_IN_SECTOR_FREQUENCY_DAYS = 3
     settings.NEW_COMPANIES_IN_SECTOR_SUBJECT = 'test subject'
 
@@ -486,8 +448,7 @@ def test_new_companies_in_sector_exclude_already_sent_recently(
 @freeze_time()
 @pytest.mark.django_db
 @patch('core.tasks.send_email')
-def test_new_companies_in_sector_include_already_sent_long_time_ago(
-        mock_task, settings):
+def test_new_companies_in_sector_include_already_sent_long_time_ago(mock_task, settings):
     settings.NEW_COMPANIES_IN_SECTOR_FREQUENCY_DAYS = 3
     settings.NEW_COMPANIES_IN_SECTOR_SUBJECT = 'test subject'
 
@@ -533,12 +494,8 @@ def test_new_companies_in_sector_single_email_per_buyer(mock_task, settings):
     buyer = BuyerFactory.create(sector='AEROSPACE', email='jim@example.com')
     BuyerFactory.create(sector='AIRPORTS', email='jim@example.com')
 
-    company_one = CompanyFactory(
-        sectors=['AEROSPACE'], date_published=days_ago_three
-    )
-    company_two = CompanyFactory(
-        sectors=['AIRPORTS'], date_published=days_ago_three
-    )
+    company_one = CompanyFactory(sectors=['AEROSPACE'], date_published=days_ago_three)
+    company_two = CompanyFactory(sectors=['AIRPORTS'], date_published=days_ago_three)
 
     notifications.new_companies_in_sector()
 
@@ -558,17 +515,12 @@ def test_new_companies_in_sector_company_multiple_sectors(mock_task, settings):
     BuyerFactory.create(sector='AEROSPACE', email='jim@example.com')
     BuyerFactory.create(sector='AIRPORTS', email='jim@example.com')
 
-    company_one = CompanyFactory(
-        sectors=['AEROSPACE', 'AIRPORTS'], date_published=days_ago_three
-    )
-    company_two = CompanyFactory(
-        sectors=['AIRPORTS'], date_published=days_ago_three
-    )
+    company_one = CompanyFactory(sectors=['AEROSPACE', 'AIRPORTS'], date_published=days_ago_three)
+    company_two = CompanyFactory(sectors=['AIRPORTS'], date_published=days_ago_three)
 
     notifications.new_companies_in_sector()
     unsubscribe_url = (
-        'http://supplier.trade.great:8005/unsubscribe?email='
-        'jim%40example.com%3A2Kkc4EAEos2htrZXeLj73CSVBWA'
+        'http://supplier.trade.great:8005/unsubscribe?email=jim%40example.com%3A2Kkc4EAEos2htrZXeLj73CSVBWA'
     )
 
     assert len(mock_task.delay.call_args_list) == 1
@@ -592,9 +544,7 @@ def test_company_user_unsubscribed(mock_task):
 @pytest.mark.django_db
 @patch('core.tasks.send_email')
 def test_anonymous_unsubscribed(mock_task):
-    notifications.anonymous_unsubscribed(
-        recipient_email='jim@example.com'
-    )
+    notifications.anonymous_unsubscribed(recipient_email='jim@example.com')
 
     assert len(mock_task.delay.call_args_list) == 1
     call_args = mock_task.delay.call_args[1]

--- a/notifications/tests/test_views.py
+++ b/notifications/tests/test_views.py
@@ -2,7 +2,6 @@ import http
 from unittest.mock import patch
 
 import pytest
-
 from django.core.signing import Signer
 from django.urls import reverse
 
@@ -41,13 +40,9 @@ def test_create_anonymous_unsubscribe_multiple_times(mock_task, client):
 
 @pytest.mark.django_db
 @patch('notifications.notifications.anonymous_unsubscribed')
-def test_create_anonymous_unsubscribe_email_confirmation(
-    mock_anonymous_unsubscribed, client
-):
+def test_create_anonymous_unsubscribe_email_confirmation(mock_anonymous_unsubscribed, client):
     url = reverse('anonymous-unsubscribe')
     email = 'test@example.com'
     client.post(url, {'email': Signer().sign(email)})
 
-    mock_anonymous_unsubscribed.assert_called_once_with(
-        recipient_email=email
-    )
+    mock_anonymous_unsubscribed.assert_called_once_with(recipient_email=email)

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -1,7 +1,6 @@
+from django.db.utils import IntegrityError
 from rest_framework.generics import CreateAPIView
 from rest_framework.response import Response
-
-from django.db.utils import IntegrityError
 
 from notifications import models, notifications, serializers
 
@@ -21,6 +20,4 @@ class AnonymousUnsubscribeCreateAPIView(CreateAPIView):
 
     def perform_create(self, serializer):
         instance = serializer.save()
-        notifications.anonymous_unsubscribed(
-            recipient_email=instance.email
-        )
+        notifications.anonymous_unsubscribed(recipient_email=instance.email)

--- a/personalisation/admin.py
+++ b/personalisation/admin.py
@@ -7,9 +7,7 @@ from personalisation import models
 
 @admin.register(models.UserLocation)
 class UserLocationAdmin(admin.ModelAdmin):
-    formfield_overrides = {
-        TextField: {'widget': forms.TextInput}
-    }
+    formfield_overrides = {TextField: {'widget': forms.TextInput}}
 
     search_fields = (
         'sso_id',

--- a/personalisation/management/commands/create_countries_of_interest.py
+++ b/personalisation/management/commands/create_countries_of_interest.py
@@ -1,17 +1,15 @@
+import tablib
 from django.core.management import BaseCommand
 from django.db import transaction
-
-import tablib
 from import_export import resources
+
 from personalisation.models import CountryOfInterest
 
 
 class Command(BaseCommand):
-
     @transaction.atomic
     def handle(self, *args, **options):
-        with open('personalisation/management/commands/countries_of_interest.csv', 'r',
-                  encoding='utf-8-sig') as f:
+        with open('personalisation/management/commands/countries_of_interest.csv', 'r', encoding='utf-8-sig') as f:
             data = tablib.import_set(f.read(), format='csv', headers=True)
 
             country_of_interest_resource = resources.modelresource_factory(model=CountryOfInterest)()

--- a/personalisation/management/commands/test_import_suggested_countries.py
+++ b/personalisation/management/commands/test_import_suggested_countries.py
@@ -1,14 +1,13 @@
 import pytest
-
 from django.core import management
 
 from dataservices import models
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('model_name, management_cmd, object_count', (
-    (models.SuggestedCountry, 'import_suggested_countries', 493),
-))
+@pytest.mark.parametrize(
+    'model_name, management_cmd, object_count', ((models.SuggestedCountry, 'import_suggested_countries', 493),)
+)
 def test_personalisation_import_data_sets(model_name, management_cmd, object_count):
     # importing countries before suggested countries as it has FK to countries
     management.call_command('import_countries')

--- a/personalisation/serializers.py
+++ b/personalisation/serializers.py
@@ -1,19 +1,18 @@
-import markdown2
 from functools import partial
 from urllib.parse import urljoin
-from bs4 import BeautifulSoup
 
+import markdown2
+from bs4 import BeautifulSoup
+from directory_constants import urls
 from django.utils.text import Truncator
 from rest_framework import serializers
 
-from directory_constants import urls
 from personalisation import models
 
 build_events_url = partial(urljoin, urls.domestic.EVENTS)
 
 
 class UserLocationSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.UserLocation
         fields = (
@@ -28,22 +27,16 @@ class UserLocationSerializer(serializers.ModelSerializer):
 
 
 class CountryOfInterestSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.CountryOfInterest
-        fields = (
-            'country',
-        )
+        fields = ('country',)
 
 
 def parse_search_results(content):
-
     def strip_html(result):
         content = result.get('content', '')
         html = markdown2.markdown(content)
-        result['content'] = ''.join(
-            BeautifulSoup(html, "html.parser").findAll(text=True)
-        ).rstrip()
+        result['content'] = ''.join(BeautifulSoup(html, "html.parser").findAll(text=True)).rstrip()
 
     def abridge_long_contents(result):
         if 'content' in result:

--- a/personalisation/tests/factories.py
+++ b/personalisation/tests/factories.py
@@ -1,6 +1,6 @@
-import factory
 import random
 
+import factory
 from directory_constants import choices
 
 from personalisation.models import CountryOfInterest

--- a/personalisation/tests/test_helpers.py
+++ b/personalisation/tests/test_helpers.py
@@ -16,7 +16,7 @@ def test_exporting_is_great_handles_auth(mock_get, settings):
     mock_get.assert_called_once_with(
         'http://b.co/export-opportunities/api/opportunities',
         params={'hashed_sso_id': 2, 'shared_secret': 123, 's': ''},
-        auth=helpers.exopps_client.auth
+        auth=helpers.exopps_client.auth,
     )
     assert helpers.exopps_client.auth.username == username
     assert helpers.exopps_client.auth.password == password

--- a/personalisation/tests/test_serializers.py
+++ b/personalisation/tests/test_serializers.py
@@ -8,127 +8,128 @@ def test_parse_search_results():
     content = {
         'took': 17,
         'timed_out': False,
-        '_shards': {
-            'total': 4,
-            'successful': 4,
-            'skipped': 0,
-            'failed': 0
-        },
+        '_shards': {'total': 4, 'successful': 4, 'skipped': 0, 'failed': 0},
         'hits': {
             'total': 100,
             'max_score': 0.2876821,
-            'hits': [{
-                '_index': 'objects__feed_id_first_feed__date_2019',
-                '_type': '_doc',
-                '_id': 'dit:exportOpportunities:Opportunity:2',
-                '_score': 0.2876821,
-                '_source': {
-                    'type': ['Document', 'dit:Opportunity'],
-                    'title': 'France - Data analysis services',
-                    'content':
-                    'The purpose of this contract is to analyze Python\
+            'hits': [
+                {
+                    '_index': 'objects__feed_id_first_feed__date_2019',
+                    '_type': '_doc',
+                    '_id': 'dit:exportOpportunities:Opportunity:2',
+                    '_score': 0.2876821,
+                    '_source': {
+                        'type': ['Document', 'dit:Opportunity'],
+                        'title': 'France - Data analysis services',
+                        'content': 'The purpose of this contract is to analyze Python\
  For Loops. A for loop is used for iterating over a sequence (that is\
   either a list, a tuple, a dictionary, a set, or a string). This is \
   less like the for keyword in other programming language, and works \
   more like an iterator method as found in other object-orientated \
   programming languages.',
-                    'url': 'www.great.gov.uk/opportunities/1'
-                }
-            }, {
-                '_index': 'objects__feed_id_first_feed__date_2019',
-                '_type': '_doc',
-                '_id': 'dit:exportOpportunities:Opportunity:2',
-                '_score': 0.18232156,
-                '_source': {
-                    'type': ['Document', 'dit:Opportunity'],
-                    'title': 'Germany - snow clearing',
-                    'content':
-                    'Winter services for the properties1) Former…',
-                    'url': 'www.great.gov.uk/opportunities/2'
-                }
-            }, {
-                '_index': 'objects__feed_id_first_feed__date_2019',
-                '_type': '_doc',
-                '_id': 'dit:exportOpportunities:Opportunity:3',
-                '_score': 0.18232156,
-                '_source': {
-                    'type': ['Document', 'dit:Article'],
-                    'title': 'Test Shortening Content',
-                    'content':
-                    "The UK and the EU have agreed a draft agreement\
+                        'url': 'www.great.gov.uk/opportunities/1',
+                    },
+                },
+                {
+                    '_index': 'objects__feed_id_first_feed__date_2019',
+                    '_type': '_doc',
+                    '_id': 'dit:exportOpportunities:Opportunity:2',
+                    '_score': 0.18232156,
+                    '_source': {
+                        'type': ['Document', 'dit:Opportunity'],
+                        'title': 'Germany - snow clearing',
+                        'content': 'Winter services for the properties1) Former…',
+                        'url': 'www.great.gov.uk/opportunities/2',
+                    },
+                },
+                {
+                    '_index': 'objects__feed_id_first_feed__date_2019',
+                    '_type': '_doc',
+                    '_id': 'dit:exportOpportunities:Opportunity:3',
+                    '_score': 0.18232156,
+                    '_source': {
+                        'type': ['Document', 'dit:Article'],
+                        'title': 'Test Shortening Content',
+                        'content': "The UK and the EU have agreed a draft agreement\
  on withdrawing from the EU. Read the [Prime Minister's statement](ht\
 tps://www.gov.k/government/speeches/pms-statement-on-brexit-14-novembe\
 r-2018) and the full",
-                    'url': 'www.great.gov.uk/opportunities/3'
-                }
-            }, {
-                '_index': 'objects__feed_id_first_feed__date_2019',
-                '_type': '_doc',
-                '_id': 'dit:exportOpportunities:Opportunity:4',
-                '_score': 0.18232156,
-                '_source': {
-                    'type': ['Document', 'dit:Article'],
-                    'title': 'Test No Content',
-                    'url': 'www.great.gov.uk/opportunities/4'
-                }
-            }, {
-                '_index': 'objects__feed_id_first_feed__date_2019',
-                '_type': '_doc',
-                '_id': 'dit:exportOpportunities:Opportunity:5',
-                '_score': 0.18232156,
-                '_source': {
-                    'type': ['Document', 'dit:Article'],
-                    'title': 'Test No URL',
-                    'content': 'Here is the content'
-                }
-            }, {
-                '_index': 'objects__feed_id_first_feed__date_2019',
-                '_type': '_doc',
-                '_id': 'dit:exportOpportunities:Event:1',
-                '_score': 0.18232156,
-                '_source': {
-                    'type': ['Document', 'dit:aventri:Event'],
-                    'title': 'Test Event URL Parsing',
-                    'content': 'Great event',
-                    'url': 'https://eu.eventscloud.com\
-/ehome/index.php?eventid=200188836&'
-                }
-            }]
-        }
+                        'url': 'www.great.gov.uk/opportunities/3',
+                    },
+                },
+                {
+                    '_index': 'objects__feed_id_first_feed__date_2019',
+                    '_type': '_doc',
+                    '_id': 'dit:exportOpportunities:Opportunity:4',
+                    '_score': 0.18232156,
+                    '_source': {
+                        'type': ['Document', 'dit:Article'],
+                        'title': 'Test No Content',
+                        'url': 'www.great.gov.uk/opportunities/4',
+                    },
+                },
+                {
+                    '_index': 'objects__feed_id_first_feed__date_2019',
+                    '_type': '_doc',
+                    '_id': 'dit:exportOpportunities:Opportunity:5',
+                    '_score': 0.18232156,
+                    '_source': {
+                        'type': ['Document', 'dit:Article'],
+                        'title': 'Test No URL',
+                        'content': 'Here is the content',
+                    },
+                },
+                {
+                    '_index': 'objects__feed_id_first_feed__date_2019',
+                    '_type': '_doc',
+                    '_id': 'dit:exportOpportunities:Event:1',
+                    '_score': 0.18232156,
+                    '_source': {
+                        'type': ['Document', 'dit:aventri:Event'],
+                        'title': 'Test Event URL Parsing',
+                        'content': 'Great event',
+                        'url': 'https://eu.eventscloud.com\
+/ehome/index.php?eventid=200188836&',
+                    },
+                },
+            ],
+        },
     }
 
-    assert serializers.parse_search_results(content) == [{
-        'type': 'Export opportunity',
-        'title': 'France - Data analysis services',
-        'content': 'The purpose of this contract is to analyze Python\
+    assert serializers.parse_search_results(content) == [
+        {
+            'type': 'Export opportunity',
+            'title': 'France - Data analysis services',
+            'content': 'The purpose of this contract is to analyze Python\
  For Loops. A for loop is used for iterating over a sequence (that is\
   either a list, a tuple, a dictionary, a…',
-        'url': 'www.great.gov.uk/opportunities/1'
-    }, {
-        'type': 'Export opportunity',
-        'title': 'Germany - snow clearing',
-        'content': 'Winter services for the properties1) Former…',
-        'url': 'www.great.gov.uk/opportunities/2'
-    }, {
-        'type': 'Article',
-        'title': 'Test Shortening Content',
-        'content': 'The UK and the EU have agreed a draft agreement\
+            'url': 'www.great.gov.uk/opportunities/1',
+        },
+        {
+            'type': 'Export opportunity',
+            'title': 'Germany - snow clearing',
+            'content': 'Winter services for the properties1) Former…',
+            'url': 'www.great.gov.uk/opportunities/2',
+        },
+        {
+            'type': 'Article',
+            'title': 'Test Shortening Content',
+            'content': 'The UK and the EU have agreed a draft agreement\
  on withdrawing from the EU. Read the Prime Minister\'s statement and\
  the full',
-        'url': 'www.great.gov.uk/opportunities/3'
-    }, {
-        'type': 'Article',
-        'title': 'Test No Content',
-        'url': 'www.great.gov.uk/opportunities/4',
-        'content': ''
-    }, {
-        'type': 'Article',
-        'title': 'Test No URL',
-        'content': 'Here is the content',
-    }, {
-        'type': 'Event',
-        'title': 'Test Event URL Parsing',
-        'content': 'Great event',
-        'url': 'https://www.events.great.gov.uk/\
-ehome/index.php?eventid=200188836&'
-    }]
+            'url': 'www.great.gov.uk/opportunities/3',
+        },
+        {'type': 'Article', 'title': 'Test No Content', 'url': 'www.great.gov.uk/opportunities/4', 'content': ''},
+        {
+            'type': 'Article',
+            'title': 'Test No URL',
+            'content': 'Here is the content',
+        },
+        {
+            'type': 'Event',
+            'title': 'Test Event URL Parsing',
+            'content': 'Great event',
+            'url': 'https://www.events.great.gov.uk/\
+ehome/index.php?eventid=200188836&',
+        },
+    ]

--- a/personalisation/tests/test_views.py
+++ b/personalisation/tests/test_views.py
@@ -1,15 +1,14 @@
-import requests
-import pytest
 import http
-
+from decimal import Decimal
 from unittest.mock import patch
 
+import pytest
+import requests
 from django.urls import reverse
-from decimal import Decimal
 
+from core.tests.helpers import create_response
 from personalisation import models
 from personalisation.tests import factories
-from core.tests.helpers import create_response
 
 
 @pytest.fixture
@@ -66,10 +65,7 @@ def test_events_api(mock_search_with_activitystream, authed_client, settings):
         "currency": "Sterling",
         "enddate": "2020-03-18",
         "foldername": "1920 Events",
-        "geocoordinates": {
-            "lat": "49.83",
-            "lon": "3.44"
-        },
+        "geocoordinates": {"lat": "49.83", "lon": "3.44"},
         "id": "dit:aventri:Event:200198344",
         "language": "eng",
         "location": {
@@ -83,64 +79,55 @@ def test_events_api(mock_search_with_activitystream, authed_client, settings):
             "name": "RAI Amsterdam",
             "phone": "",
             "postcode": "1078 GZ",
-            "state": ""
+            "state": "",
         },
         "name": "Independent Hotel Show",
         "price": "null",
         "price_type": "null",
         "published": "2020-03-05T12:39:18.438792",
         "startdate": "2020-03-17",
-        "timezone":
-        "[GMT] Greenwich Mean Time: Dublin, Edinburgh, Lisbon, London",
+        "timezone": "[GMT] Greenwich Mean Time: Dublin, Edinburgh, Lisbon, London",
         "type": ["Event", "dit:aventri:Event"],
-        "url": "https://eu.eventscloud.com/200198344"
+        "url": "https://eu.eventscloud.com/200198344",
     }
 
-    mock_search_with_activitystream.return_value = create_response({
-        "took": 32,
-        "timed_out": "false",
-        "_shards": {
-            "total": 3,
-            "successful": 3,
-            "skipped": 0,
-            "failed": 0
-        },
-        "hits": {
-            "total": 1,
-            "max_score": "null",
-            "hits": [
-                {
-                    "_index":
-                    "objects__feed_id_aventri__date_2020-03-06__timestamp_1583508109__batch_id_hu6dz6lo__",
-                    "_type": "_doc",
-                    "_id": "dit:aventri:Event:200198344",
-                    "_score": "null",
-                    "_source": document,
-                    "sort": [313.0059910186728]
-                }
-            ]
+    mock_search_with_activitystream.return_value = create_response(
+        {
+            "took": 32,
+            "timed_out": "false",
+            "_shards": {"total": 3, "successful": 3, "skipped": 0, "failed": 0},
+            "hits": {
+                "total": 1,
+                "max_score": "null",
+                "hits": [
+                    {
+                        "_index": (
+                            "objects__feed_id_aventri__date_2020-03-06__timestamp_1583508109__batch_id_hu6dz6lo__"
+                        ),
+                        "_type": "_doc",
+                        "_id": "dit:aventri:Event:200198344",
+                        "_score": "null",
+                        "_source": document,
+                        "sort": [313.0059910186728],
+                    }
+                ],
+            },
         }
-    })
+    )
 
     response = authed_client.get(reverse('personalisation-events'))
     assert response.status_code == 200
     assert response.data == {'results': [document]}
 
     """ What if there are no results? """
-    mock_search_with_activitystream.return_value = create_response({
-        'took': 17,
-        'timed_out': False,
-        '_shards': {
-            'total': 4,
-            'successful': 4,
-            'skipped': 0,
-            'failed': 0
-        },
-        'hits': {
-            'total': 0,
-            'hits': []
+    mock_search_with_activitystream.return_value = create_response(
+        {
+            'took': 17,
+            'timed_out': False,
+            '_shards': {'total': 4, 'successful': 4, 'skipped': 0, 'failed': 0},
+            'hits': {'total': 0, 'hits': []},
         }
-    })
+    )
 
     response = authed_client.get(reverse('personalisation-events'))
     assert response.status_code == 200
@@ -164,25 +151,31 @@ def test_export_opportunities_api(authed_client, settings):
 
     with patch('personalisation.helpers.get_opportunities') as get_opportunities:
         mock_results = {
-            'relevant_opportunities': [{
-              'title': 'French sardines required',
-              'opportunity_url': 'www.example.com/export-opportunities/opportunities/french-sardines-required',
-              'description': 'Nam dolor nostrum distinctio.Et quod itaque.',
-              'submitted_on': '14 Jan 2020 15:26:45',
-              'expiration_date': 'Sat, 06 Jun 2020',
-            }]
+            'relevant_opportunities': [
+                {
+                    'title': 'French sardines required',
+                    'opportunity_url': 'www.example.com/export-opportunities/opportunities/french-sardines-required',
+                    'description': 'Nam dolor nostrum distinctio.Et quod itaque.',
+                    'submitted_on': '14 Jan 2020 15:26:45',
+                    'expiration_date': 'Sat, 06 Jun 2020',
+                }
+            ]
         }
         get_opportunities.return_value = {'status': 200, 'data': mock_results}
 
         response = authed_client.get(reverse('personalisation-export-opportunities'), data={'s': 'food-and-drink'})
         assert response.status_code == 200
-        assert response.data == {'results': [{
-            'title': 'French sardines required',
-            'opportunity_url': 'www.example.com/export-opportunities/opportunities/french-sardines-required',
-            'description': 'Nam dolor nostrum distinctio.Et quod itaque.',
-            'submitted_on': '14 Jan 2020 15:26:45',
-            'expiration_date': 'Sat, 06 Jun 2020',
-        }]}
+        assert response.data == {
+            'results': [
+                {
+                    'title': 'French sardines required',
+                    'opportunity_url': 'www.example.com/export-opportunities/opportunities/french-sardines-required',
+                    'description': 'Nam dolor nostrum distinctio.Et quod itaque.',
+                    'submitted_on': '14 Jan 2020 15:26:45',
+                    'expiration_date': 'Sat, 06 Jun 2020',
+                }
+            ]
+        }
 
     # Test failure to connect to ExOps
 
@@ -201,24 +194,21 @@ def test_export_opportunities_api(authed_client, settings):
 def test_recommended_countries_api(client):
     # Two with same country and sector
     country_of_interest = factories.CountryOfInterestFactory()
-    factories.CountryOfInterestFactory(
-        country=country_of_interest.country,
-        sector=country_of_interest.sector
-    )
+    factories.CountryOfInterestFactory(country=country_of_interest.country, sector=country_of_interest.sector)
     # Different country
     country_of_interest_different = factories.CountryOfInterestFactory(
-        sector=country_of_interest.sector,
-        country='other-country')
+        sector=country_of_interest.sector, country='other-country'
+    )
     # Different sector should be excluded from search
     factories.CountryOfInterestFactory(sector='grass-growing')
 
-    response = client.get(
-        reverse('personalisation-recommended-countries'),
-        data={'sector': country_of_interest.sector}
-    )
+    response = client.get(reverse('personalisation-recommended-countries'), data={'sector': country_of_interest.sector})
     assert response.status_code == 200
-    assert response.data == [{
-        'country': country_of_interest.country,
-    }, {
-        'country': country_of_interest_different.country,
-    }]
+    assert response.data == [
+        {
+            'country': country_of_interest.country,
+        },
+        {
+            'country': country_of_interest_different.country,
+        },
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,23 +6,29 @@ include = '\.pyi?$'
 exclude = '''
 (
   /(
-      \.git         # exclude a few common directories in the
-    | \.circleci          # root of the project
+      \.git
+    | \.circleci
     | \__pycache__
     | \.pytest_cache
     | \.venv
     | \.vscode
     | node_modules
     | venv
+    | migrations  # for this codebase, we'll exclude migrations from Black's reach
   )/
-  | manage.py       # also separately exclude a file in the root of the project
+  | manage.py
 )
 '''
 
 [tool.isort]
+skip = '.venv,venv,node_modules,migrations'
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 120
+
+[tool.flake8]
+exclude = '.venv,venv,node_modules,migrations'
+max-line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.black]
+line-length = 120
+skip-string-normalization = true
+target-version = ['py36']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.git         # exclude a few common directories in the
+    | \.circleci          # root of the project
+    | \__pycache__
+    | \.pytest_cache
+    | \.venv
+    | \.vscode
+    | node_modules
+    | venv
+  )/
+  | manage.py       # also separately exclude a file in the root of the project
+)
+'''
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 120

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,59 +4,59 @@
 #
 #    pip-compile requirements.in
 #
-airtable-python-wrapper==0.12.0
+airtable-python-wrapper==0.12.0  # via -r requirements.in
 amqp==2.5.2               # via kombu
 attrs==20.2.0             # via jsonschema
 beautifulsoup4==4.9.3     # via directory-components
 billiard==3.6.3.0         # via celery
-boto3==1.10.23
+boto3==1.10.23            # via -r requirements.in
 botocore==1.13.50         # via boto3, s3transfer
-celery[redis]==4.3.0
+celery[redis]==4.3.0      # via -r requirements.in
 certifi==2020.6.20        # via elasticsearch, requests, sentry-sdk
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==3.2
+cryptography==3.2         # via -r requirements.in, pyopenssl, requests
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
 directory-client-core==6.3.0  # via directory-forms-api-client, directory-sso-api-client
-directory-components==35.6.1
-directory-constants==20.17.0
-directory-forms-api-client==5.1.0
-directory-healthcheck==2.0.0
-directory-sso-api-client==6.5.3
-directory-validators==6.0.3
-dj-database-url==0.5.0
-django-admin-ip-restrictor==2.1.0
-django-celery-beat==1.5.0
-django-environ==0.4.5
-django-extensions==2.2.5
-django-field-history==0.7.0
-django-filter==2.2.0
+directory-components==35.6.1  # via -r requirements.in
+directory-constants==20.17.0  # via -r requirements.in, directory-components
+directory-forms-api-client==5.1.0  # via -r requirements.in
+directory-healthcheck==2.0.0  # via -r requirements.in
+directory-sso-api-client==6.5.3  # via -r requirements.in
+directory-validators==6.0.3  # via -r requirements.in
+dj-database-url==0.5.0    # via -r requirements.in
+django-admin-ip-restrictor==2.1.0  # via -r requirements.in
+django-celery-beat==1.5.0  # via -r requirements.in
+django-environ==0.4.5     # via -r requirements.in
+django-extensions==2.2.5  # via -r requirements.in
+django-field-history==0.7.0  # via -r requirements.in
+django-filter==2.2.0      # via -r requirements.in
 django-health-check==3.8.0  # via directory-healthcheck
-django-import-export==2.0.2
+django-import-export==2.0.2  # via -r requirements.in
 django-ipware==2.1.0      # via django-admin-ip-restrictor
-django-redis==4.10.0
-django-staff-sso-client==1.0.0
-django-storages==1.8.0
+django-redis==4.10.0      # via -r requirements.in
+django-staff-sso-client==1.0.0  # via -r requirements.in
+django-storages==1.8.0    # via -r requirements.in
 django-timezone-field==4.0  # via django-celery-beat
-django==2.2.13
-django_json_widget==1.0.1
-djangorestframework==3.10.3
+django==2.2.13            # via -r requirements.in, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-admin-ip-restrictor, django-filter, django-import-export, django-redis, django-staff-sso-client, django-storages, django-timezone-field, sigauth
+django_json_widget==1.0.1  # via -r requirements.in
+djangorestframework==3.10.3  # via -r requirements.in, sigauth
 docutils==0.15.2          # via botocore
-elasticsearch-dsl==7.3.0
+elasticsearch-dsl==7.3.0  # via -r requirements.in
 elasticsearch==7.9.1      # via elasticsearch-dsl
 et-xmlfile==1.0.1         # via openpyxl
-factory-boy==2.12.0
+factory-boy==2.12.0       # via -r requirements.in
 faker==4.14.0             # via factory-boy
 future==0.18.2            # via django-json-widget
 idna==2.8                 # via requests
 importlib-metadata==2.0.0  # via jsonschema, kombu
-iso3166==1.0.1
+iso3166==1.0.1            # via -r requirements.in
 jdcal==1.4.1              # via openpyxl
 jmespath==0.10.0          # via boto3, botocore
 jsonschema==3.2.0         # via directory-components
-kombu==4.6.6
-markdown2==2.3.9
+kombu==4.6.6              # via -r requirements.in, celery
+markdown2==2.3.9          # via -r requirements.in
 markuppy==1.14            # via tablib
 mohawk==0.3.4             # via sigauth
 monotonic==1.5            # via directory-client-core
@@ -65,9 +65,9 @@ oauthlib==3.1.0           # via requests-oauthlib
 odfpy==1.4.1              # via tablib
 olefile==0.46             # via directory-validators
 openpyxl==3.0.5           # via tablib
-pandas==1.0.1
+pandas==1.0.1             # via -r requirements.in
 pillow==8.0.1             # via directory-validators
-psycopg2-binary==2.8.4
+psycopg2-binary==2.8.4    # via -r requirements.in
 pycparser==2.20           # via cffi
 pyopenssl==19.1.0         # via requests
 pyrsistent==0.17.3        # via jsonschema
@@ -78,20 +78,23 @@ pyyaml==5.3.1             # via tablib
 raven==6.10.0             # via django-staff-sso-client
 redis==3.5.3              # via celery, django-redis
 requests-oauthlib==1.3.0  # via django-staff-sso-client
-requests[security]==2.22.0
+requests[security]==2.22.0  # via -r requirements.in, airtable-python-wrapper, directory-client-core, requests-oauthlib
 s3transfer==0.2.1         # via boto3
-sentry-sdk==0.13.4
-sigauth==4.1.1
+sentry-sdk==0.13.4        # via -r requirements.in
+sigauth==4.1.1            # via -r requirements.in, directory-client-core
 six==1.15.0               # via airtable-python-wrapper, cryptography, django-extensions, elasticsearch-dsl, jsonschema, mohawk, pyopenssl, python-dateutil, w3lib
 soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.4.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
 text-unidecode==1.3       # via faker
-urllib3==1.25.11
+urllib3==1.25.11          # via -r requirements.in, botocore, directory-validators, elasticsearch, requests, sentry-sdk
 vine==1.3.0               # via amqp, celery
 w3lib==1.22.0             # via directory-client-core
-waitress==1.4.3
-whitenoise==4.1.4
+waitress==1.4.3           # via -r requirements.in
+whitenoise==4.1.4         # via -r requirements.in
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 zipp==3.3.1               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -4,7 +4,13 @@ pytest==4.6.5
 pytest-cov==2.7.1
 pytest-django==3.5.1
 pytest-sugar==0.9.2
-flake8==3.7.8
 requests_mock==1.6.0
 freezegun==0.3.12
 codecov==2.1.7
+
+# Pinned because pre-commit features specific versions
+black==20.8b1
+blacken-docs==1.6.0
+isort==5.6.4
+flake8==3.8.4
+pre-commit-hooks==3.3.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,115 +4,132 @@
 #
 #    pip-compile requirements_test.in
 #
-airtable-python-wrapper==0.12.0
+airtable-python-wrapper==0.12.0  # via -r requirements.in
 amqp==2.5.2               # via kombu
+appdirs==1.4.4            # via black
 atomicwrites==1.4.0       # via pytest
 attrs==20.2.0             # via jsonschema, pytest
 beautifulsoup4==4.9.3     # via directory-components
 billiard==3.6.3.0         # via celery
-boto3==1.10.23
+black==20.8b1             # via -r requirements_test.in, blacken-docs
+blacken-docs==1.6.0       # via -r requirements_test.in
+boto3==1.10.23            # via -r requirements.in
 botocore==1.13.50         # via boto3, s3transfer
-celery[redis]==4.3.0
+celery[redis]==4.3.0      # via -r requirements.in
 certifi==2020.6.20        # via elasticsearch, requests, sentry-sdk
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
-codecov==2.1.7
+click==7.1.2              # via black
+codecov==2.1.7            # via -r requirements_test.in
 coverage==5.3             # via codecov, pytest-cov
-cryptography==3.2
+cryptography==3.2         # via -r requirements.in, pyopenssl, requests
+dataclasses==0.8          # via black
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
 directory-client-core==6.3.0  # via directory-forms-api-client, directory-sso-api-client
-directory-components==35.6.1
-directory-constants==20.17.0
-directory-forms-api-client==5.1.0
-directory-healthcheck==2.0.0
-directory-sso-api-client==6.5.3
-directory-validators==6.0.3
-dj-database-url==0.5.0
-django-admin-ip-restrictor==2.1.0
-django-celery-beat==1.5.0
-django-environ==0.4.5
-django-extensions==2.2.5
-django-field-history==0.7.0
-django-filter==2.2.0
+directory-components==35.6.1  # via -r requirements.in
+directory-constants==20.17.0  # via -r requirements.in, directory-components
+directory-forms-api-client==5.1.0  # via -r requirements.in
+directory-healthcheck==2.0.0  # via -r requirements.in
+directory-sso-api-client==6.5.3  # via -r requirements.in
+directory-validators==6.0.3  # via -r requirements.in
+dj-database-url==0.5.0    # via -r requirements.in
+django-admin-ip-restrictor==2.1.0  # via -r requirements.in
+django-celery-beat==1.5.0  # via -r requirements.in
+django-environ==0.4.5     # via -r requirements.in
+django-extensions==2.2.5  # via -r requirements.in
+django-field-history==0.7.0  # via -r requirements.in
+django-filter==2.2.0      # via -r requirements.in
 django-health-check==3.8.0  # via directory-healthcheck
-django-import-export==2.0.2
+django-import-export==2.0.2  # via -r requirements.in
 django-ipware==2.1.0      # via django-admin-ip-restrictor
-django-redis==4.10.0
-django-staff-sso-client==1.0.0
-django-storages==1.8.0
+django-redis==4.10.0      # via -r requirements.in
+django-staff-sso-client==1.0.0  # via -r requirements.in
+django-storages==1.8.0    # via -r requirements.in
 django-timezone-field==4.0  # via django-celery-beat
-django==2.2.13
-django_json_widget==1.0.1
-djangorestframework==3.10.3
+django==2.2.13            # via -r requirements.in, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-admin-ip-restrictor, django-filter, django-import-export, django-redis, django-staff-sso-client, django-storages, django-timezone-field, sigauth
+django_json_widget==1.0.1  # via -r requirements.in
+djangorestframework==3.10.3  # via -r requirements.in, sigauth
 docutils==0.15.2          # via botocore
-elasticsearch-dsl==7.3.0
+elasticsearch-dsl==7.3.0  # via -r requirements.in
 elasticsearch==7.9.1      # via elasticsearch-dsl
-entrypoints==0.3          # via flake8
 et-xmlfile==1.0.1         # via openpyxl
-factory-boy==2.12.0
+factory-boy==2.12.0       # via -r requirements.in
 faker==4.14.0             # via factory-boy
-flake8==3.7.8
-freezegun==0.3.12
+flake8==3.8.4             # via -r requirements_test.in
+freezegun==0.3.12         # via -r requirements_test.in
 future==0.18.2            # via django-json-widget
 idna==2.8                 # via requests
-importlib-metadata==2.0.0  # via jsonschema, kombu, pluggy, pytest
-iso3166==1.0.1
+importlib-metadata==2.0.0  # via flake8, jsonschema, kombu, pluggy, pytest
+iso3166==1.0.1            # via -r requirements.in
+isort==5.6.4              # via -r requirements_test.in
 jdcal==1.4.1              # via openpyxl
 jmespath==0.10.0          # via boto3, botocore
 jsonschema==3.2.0         # via directory-components
-kombu==4.6.6
-markdown2==2.3.9
+kombu==4.6.6              # via -r requirements.in, celery
+markdown2==2.3.9          # via -r requirements.in
 markuppy==1.14            # via tablib
 mccabe==0.6.1             # via flake8
 mohawk==0.3.4             # via sigauth
 monotonic==1.5            # via directory-client-core
 more-itertools==8.5.0     # via pytest
+mypy-extensions==0.4.3    # via black
 numpy==1.19.2             # via pandas
 oauthlib==3.1.0           # via requests-oauthlib
 odfpy==1.4.1              # via tablib
 olefile==0.46             # via directory-validators
 openpyxl==3.0.5           # via tablib
 packaging==20.4           # via pytest, pytest-sugar
-pandas==1.0.1
+pandas==1.0.1             # via -r requirements.in
+pathspec==0.8.1           # via black
 pillow==8.0.1             # via directory-validators
 pluggy==0.13.1            # via pytest
-psycopg2-binary==2.8.4
+pre-commit-hooks==3.3.0   # via -r requirements_test.in
+psycopg2-binary==2.8.4    # via -r requirements.in
 py==1.9.0                 # via pytest
-pycodestyle==2.5.0        # via flake8
+pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
-pyflakes==2.1.1           # via flake8
+pyflakes==2.2.0           # via flake8
 pyopenssl==19.1.0         # via requests
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest-sugar==0.9.2
-pytest==4.6.5
+pytest-cov==2.7.1         # via -r requirements_test.in
+pytest-django==3.5.1      # via -r requirements_test.in
+pytest-sugar==0.9.2       # via -r requirements_test.in
+pytest==4.6.5             # via -r requirements_test.in, pytest-cov, pytest-django, pytest-sugar
 python-crontab==2.5.1     # via django-celery-beat
 python-dateutil==2.8.1    # via botocore, elasticsearch-dsl, faker, freezegun, pandas, python-crontab
 pytz==2019.3              # via celery, directory-validators, django, django-timezone-field, pandas
 pyyaml==5.3.1             # via tablib
 raven==6.10.0             # via django-staff-sso-client
 redis==3.5.3              # via celery, django-redis
+regex==2020.11.13         # via black
 requests-oauthlib==1.3.0  # via django-staff-sso-client
-requests[security]==2.22.0
-requests_mock==1.6.0
+requests[security]==2.22.0  # via -r requirements.in, airtable-python-wrapper, codecov, directory-client-core, requests-mock, requests-oauthlib
+requests_mock==1.6.0      # via -r requirements_test.in
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
+ruamel.yaml==0.16.12      # via pre-commit-hooks
 s3transfer==0.2.1         # via boto3
-sentry-sdk==0.13.4
-sigauth==4.1.1
+sentry-sdk==0.13.4        # via -r requirements.in
+sigauth==4.1.1            # via -r requirements.in, directory-client-core
 six==1.15.0               # via airtable-python-wrapper, cryptography, django-extensions, elasticsearch-dsl, freezegun, jsonschema, mohawk, packaging, pyopenssl, pytest, python-dateutil, requests-mock, w3lib
 soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.4.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.3       # via faker
-urllib3==1.25.11
+toml==0.10.2              # via black, pre-commit-hooks
+typed-ast==1.4.1          # via black
+typing-extensions==3.7.4.3  # via black
+urllib3==1.25.11          # via -r requirements.in, botocore, directory-validators, elasticsearch, requests, sentry-sdk
 vine==1.3.0               # via amqp, celery
 w3lib==1.22.0             # via directory-client-core
-waitress==1.4.3
+waitress==1.4.3           # via -r requirements.in
 wcwidth==0.2.5            # via pytest
-whitenoise==4.1.4
+whitenoise==4.1.4         # via -r requirements.in
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 zipp==3.3.1               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/testapi/serializers.py
+++ b/testapi/serializers.py
@@ -1,19 +1,13 @@
 import random
 
-from rest_framework.serializers import (
-    Serializer,
-    CharField,
-    ListField,
-    ModelSerializer,
-)
-from directory_constants import choices, sectors, expertise
+from directory_constants import choices, expertise, sectors
+from rest_framework.serializers import CharField, ListField, ModelSerializer, Serializer
 
-from company.tests import factories
 from company.models import Company
+from company.tests import factories
 
 
 class CompanySerializer(ModelSerializer):
-
     class Meta:
         model = Company
         fields = (
@@ -29,17 +23,12 @@ class CompanySerializer(ModelSerializer):
 
 
 class ISDCompanySerializer(ModelSerializer):
-
     class Meta:
         model = Company
         fields = '__all__'
         extra_kwargs = {
-            'slug': {
-                'required': False
-            },
-            'name': {
-                'required': False
-            },
+            'slug': {'required': False},
+            'name': {'required': False},
             'is_uk_isd_company': {
                 'required': False,
                 'default': True,
@@ -51,35 +40,22 @@ class ISDCompanySerializer(ModelSerializer):
         return [
             choice[0]
             for choice in random.sample(
-                list_of_choice_tuples,
-                random.randint(
-                    0, max_items if max_items else len(list_of_choice_tuples)
-                )
+                list_of_choice_tuples, random.randint(0, max_items if max_items else len(list_of_choice_tuples))
             )
         ]
 
     @staticmethod
     def slice_list(list_of_strings, max_items=None):
-        return random.sample(
-            list_of_strings,
-            random.randint(0, max_items if max_items else len(list_of_strings))
-        )
+        return random.sample(list_of_strings, random.randint(0, max_items if max_items else len(list_of_strings)))
 
     def create(self, validated_data):
         number = f'AT{random.randint(0, 999999):06}'
-        countries = self.slice_choices(
-            choices.COUNTRY_CHOICES, max_items=15)
-        languages = self.slice_choices(
-            choices.EXPERTISE_LANGUAGES, max_items=15)
-        regions = self.slice_choices(
-            choices.EXPERTISE_REGION_CHOICES, max_items=5)
+        countries = self.slice_choices(choices.COUNTRY_CHOICES, max_items=15)
+        languages = self.slice_choices(choices.EXPERTISE_LANGUAGES, max_items=15)
+        regions = self.slice_choices(choices.EXPERTISE_REGION_CHOICES, max_items=5)
         industries = random.sample(
-            [
-                item
-                for item in dir(sectors)
-                if not item.startswith('__') and item != sectors.CONFLATED
-            ],
-            random.randint(0, 10)
+            [item for item in dir(sectors) if not item.startswith('__') and item != sectors.CONFLATED],
+            random.randint(0, 10),
         )
         wolf_company = factories.CompanyFactory(
             number=number,
@@ -97,13 +73,11 @@ class ISDCompanySerializer(ModelSerializer):
             expertise_products_services={
                 'other': ['Regulatory', 'Finance', 'IT'],
                 'Finance': self.slice_list(expertise.FINANCIAL),
-                'Management Consulting':
-                    self.slice_list(expertise.MANAGEMENT_CONSULTING),
+                'Management Consulting': self.slice_list(expertise.MANAGEMENT_CONSULTING),
                 'Human Resources': self.slice_list(expertise.HUMAN_RESOURCES),
                 'Legal': self.slice_list(expertise.LEGAL),
                 'Publicity': self.slice_list(expertise.PUBLICITY),
-                'Business Support':
-                    self.slice_list(expertise.BUSINESS_SUPPORT),
+                'Business Support': self.slice_list(expertise.BUSINESS_SUPPORT),
             },
             website=f'https://automated.tests.{number}.com',
             email_address='',

--- a/testapi/tests/test_views.py
+++ b/testapi/tests/test_views.py
@@ -57,12 +57,10 @@ def test_get_buyer_by_email_not_found(authed_client):
         'post',
         'put',
         'trace',
-    ]
+    ],
 )
 @pytest.mark.django_db
-def test_get_buyer_by_email_does_not_accept_all_http_methods(
-        authed_client, client, method
-):
+def test_get_buyer_by_email_does_not_accept_all_http_methods(authed_client, client, method):
     url = reverse('buyer_by_email', kwargs={'email': 'some@email.com'})
     methods = {
         'head': client.head,
@@ -143,11 +141,9 @@ def test_get_company_by_name_with_disabled_test_api(client, settings):
 
 
 @pytest.mark.django_db
-def test_get_existing_company_by_ch_id_with_disabled_test_api(
-        authed_client, authed_supplier, settings):
+def test_get_existing_company_by_ch_id_with_disabled_test_api(authed_client, authed_supplier, settings):
     settings.FEATURE_TEST_API_ENABLED = False
-    url = reverse(
-        'company_by_ch_id_or_name', kwargs={'ch_id_or_name': authed_supplier.company.number})
+    url = reverse('company_by_ch_id_or_name', kwargs={'ch_id_or_name': authed_supplier.company.number})
     response = authed_client.get(url)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -162,11 +158,10 @@ def test_get_company_by_non_existing_ch_id(client):
 @pytest.mark.django_db
 def test_patch_existing_company_by_name_to_verify_identity(authed_client, authed_supplier):
     url = reverse(
-        'company_by_ch_id_or_name', kwargs={'ch_id_or_name': authed_supplier.company.number},
+        'company_by_ch_id_or_name',
+        kwargs={'ch_id_or_name': authed_supplier.company.number},
     )
-    data = {
-        'verified_with_identity_check': True
-    }
+    data = {'verified_with_identity_check': True}
     response = authed_client.patch(url, data=data)
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -178,7 +173,8 @@ def test_patch_existing_company_by_name_to_verify_identity(authed_client, authed
 @pytest.mark.django_db
 def test_patch_existing_company_with_no_data(authed_client, authed_supplier):
     url = reverse(
-        'company_by_ch_id_or_name', kwargs={'ch_id_or_name': authed_supplier.company.number},
+        'company_by_ch_id_or_name',
+        kwargs={'ch_id_or_name': authed_supplier.company.number},
     )
     data = {}
     response = authed_client.patch(url, data=data)
@@ -188,13 +184,10 @@ def test_patch_existing_company_with_no_data(authed_client, authed_supplier):
 @pytest.mark.django_db
 def test_patch_existing_company_by_name_to_verify_with_code(authed_client, authed_supplier):
     url = reverse(
-        'company_by_ch_id_or_name', kwargs={
-            'ch_id_or_name': authed_supplier.company.number
-        },
+        'company_by_ch_id_or_name',
+        kwargs={'ch_id_or_name': authed_supplier.company.number},
     )
-    data = {
-        'verified_with_code': True
-    }
+    data = {'verified_with_code': True}
     response = authed_client.patch(url, data=data)
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -206,8 +199,7 @@ def test_patch_existing_company_by_name_to_verify_with_code(authed_client, authe
 @pytest.mark.django_db
 def test_delete_existing_company_by_ch_id(authed_client, authed_supplier):
     number = authed_supplier.company.number
-    url = reverse(
-        'company_by_ch_id_or_name', kwargs={'ch_id_or_name': number})
+    url = reverse('company_by_ch_id_or_name', kwargs={'ch_id_or_name': number})
     response = authed_client.delete(url)
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert Company.objects.filter(number=number).exists() is False
@@ -216,8 +208,7 @@ def test_delete_existing_company_by_ch_id(authed_client, authed_supplier):
 @pytest.mark.django_db
 def test_delete_existing_company_by_name(authed_client, authed_supplier):
     name = authed_supplier.company.name
-    url = reverse(
-        'company_by_ch_id_or_name', kwargs={'ch_id_or_name': name})
+    url = reverse('company_by_ch_id_or_name', kwargs={'ch_id_or_name': name})
     response = authed_client.delete(url)
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert Company.objects.filter(name=name).exists() is False
@@ -225,28 +216,23 @@ def test_delete_existing_company_by_name(authed_client, authed_supplier):
 
 @pytest.mark.django_db
 def test_delete_non_existing_company_by_ch_id_or_name(authed_client):
-    url = reverse(
-        'company_by_ch_id_or_name', kwargs={'ch_id_or_name': 'invalid'})
+    url = reverse('company_by_ch_id_or_name', kwargs={'ch_id_or_name': 'invalid'})
     response = authed_client.delete(url)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.django_db
-def test_delete_existing_company_by_ch_id_with_disabled_testapi(
-        authed_client, authed_supplier, settings):
+def test_delete_existing_company_by_ch_id_with_disabled_testapi(authed_client, authed_supplier, settings):
     settings.FEATURE_TEST_API_ENABLED = False
-    url = reverse(
-        'company_by_ch_id_or_name', kwargs={'ch_id_or_name': authed_supplier.company.number})
+    url = reverse('company_by_ch_id_or_name', kwargs={'ch_id_or_name': authed_supplier.company.number})
     response = authed_client.delete(url)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.django_db
-def test_delete_existing_company_by_name_with_disabled_testapi(
-        authed_client, authed_supplier, settings):
+def test_delete_existing_company_by_name_with_disabled_testapi(authed_client, authed_supplier, settings):
     settings.FEATURE_TEST_API_ENABLED = False
-    url = reverse(
-        'company_by_ch_id_or_name', kwargs={'ch_id_or_name': authed_supplier.company.name})
+    url = reverse('company_by_ch_id_or_name', kwargs={'ch_id_or_name': authed_supplier.company.name})
     response = authed_client.delete(url)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -279,23 +265,21 @@ def test_get_unpublished_companies_without_optional_parameters(authed_client):
         (-1, -1, status.HTTP_200_OK),
         (None, 0, status.HTTP_200_OK),
         (1, None, status.HTTP_200_OK),
-    ])
+    ],
+)
 @pytest.mark.django_db
 def test_get_published_companies_use_optional_parameters(
-        authed_client, limit, minimal_number_of_sectors, expected_status_code):
+    authed_client, limit, minimal_number_of_sectors, expected_status_code
+):
     url = reverse('published_companies')
-    params = {
-        'limit': limit,
-        'minimal_number_of_sectors': minimal_number_of_sectors
-    }
+    params = {'limit': limit, 'minimal_number_of_sectors': minimal_number_of_sectors}
     response = authed_client.get(url, params=params)
     assert response.status_code == expected_status_code
     assert response.json() == []
 
 
 @pytest.mark.django_db
-def test_get_published_companies_with_disabled_test_api(
-        authed_client, settings):
+def test_get_published_companies_with_disabled_test_api(authed_client, settings):
     settings.FEATURE_TEST_API_ENABLED = False
     url = reverse('published_companies')
     response = authed_client.get(url)
@@ -303,8 +287,7 @@ def test_get_published_companies_with_disabled_test_api(
 
 
 @pytest.mark.django_db
-def test_get_published_companies_with_disabled_test_api_and_unsigned_client(
-        client, settings):
+def test_get_published_companies_with_disabled_test_api_and_unsigned_client(client, settings):
     settings.FEATURE_TEST_API_ENABLED = False
     url = reverse('published_companies')
     response = client.get(url)
@@ -322,15 +305,14 @@ def test_get_published_companies_with_disabled_test_api_and_unsigned_client(
         (-1, -1, status.HTTP_200_OK),
         (None, 0, status.HTTP_200_OK),
         (1, None, status.HTTP_200_OK),
-    ])
+    ],
+)
 @pytest.mark.django_db
 def test_get_unpublished_companies_use_optional_parameters(
-        authed_client, limit, minimal_number_of_sectors, expected_status_code):
+    authed_client, limit, minimal_number_of_sectors, expected_status_code
+):
     url = reverse('unpublished_companies')
-    params = {
-        'limit': limit,
-        'minimal_number_of_sectors': minimal_number_of_sectors
-    }
+    params = {'limit': limit, 'minimal_number_of_sectors': minimal_number_of_sectors}
     response = authed_client.get(url, params=params)
     assert response.status_code == expected_status_code
     # authed_client fixture creates 1 unpublished company
@@ -338,8 +320,7 @@ def test_get_unpublished_companies_use_optional_parameters(
 
 
 @pytest.mark.django_db
-def test_get_unpublished_companies_with_disabled_test_api(
-        authed_client, settings):
+def test_get_unpublished_companies_with_disabled_test_api(authed_client, settings):
     settings.FEATURE_TEST_API_ENABLED = False
     url = reverse('unpublished_companies')
     response = authed_client.get(url)
@@ -347,8 +328,7 @@ def test_get_unpublished_companies_with_disabled_test_api(
 
 
 @pytest.mark.django_db
-def test_get_unpublished_companies_with_disabled_test_api_and_unsigned_client(
-        client, settings):
+def test_get_unpublished_companies_with_disabled_test_api_and_unsigned_client(client, settings):
     settings.FEATURE_TEST_API_ENABLED = False
     url = reverse('unpublished_companies')
     response = client.get(url)
@@ -356,8 +336,7 @@ def test_get_unpublished_companies_with_disabled_test_api_and_unsigned_client(
 
 
 @pytest.mark.django_db
-def test_get_published_companies_check_response_contents(
-        authed_client, authed_supplier):
+def test_get_published_companies_check_response_contents(authed_client, authed_supplier):
     name = 'Test Company'
     number = '12345678'
     email = 'test@user.com'
@@ -376,15 +355,21 @@ def test_get_published_companies_check_response_contents(
     expected_number_of_results = 1
     expected_number_of_keys = 15
     company = CompanyFactory(
-        name=name, number=number, email_address=email, sectors=sectors,
-        employees=employees, website=website, keywords=keywords,
-        facebook_url=facebook_url, linkedin_url=linkedin_url,
-        twitter_url=twitter_url, summary=summary, description=description,
+        name=name,
+        number=number,
+        email_address=email,
+        sectors=sectors,
+        employees=employees,
+        website=website,
+        keywords=keywords,
+        facebook_url=facebook_url,
+        linkedin_url=linkedin_url,
+        twitter_url=twitter_url,
+        summary=summary,
+        description=description,
         is_uk_isd_company=is_uk_isd_company,
         is_published_find_a_supplier=is_published_find_a_supplier,
-        is_published_investment_support_directory=(
-            is_published_investment_support_directory
-        ),
+        is_published_investment_support_directory=is_published_investment_support_directory,
     )
     authed_supplier.company = company
     authed_supplier.save()
@@ -420,21 +405,16 @@ def test_get_published_companies_check_response_contents(
         (None, 2, 2),
         (1, 0, 1),
         (0, 8, 0),
-    ])
+    ],
+)
 @pytest.mark.django_db
 def test_get_published_companies_use_optional_filters(
-        authed_client, limit, minimal_number_of_sectors,
-        expected_number_of_results):
+    authed_client, limit, minimal_number_of_sectors, expected_number_of_results
+):
     sectors_1 = ['AEROSPACE', 'AUTOMOTIVE', 'DEFENCE']
     sectors_2 = ['AEROSPACE', 'AUTOMOTIVE']
-    company_1 = CompanyFactory(
-        is_published_investment_support_directory=True,
-        sectors=sectors_1
-    )
-    company_2 = CompanyFactory(
-        is_published_investment_support_directory=True,
-        sectors=sectors_2
-    )
+    company_1 = CompanyFactory(is_published_investment_support_directory=True, sectors=sectors_1)
+    company_2 = CompanyFactory(is_published_investment_support_directory=True, sectors=sectors_2)
     supplier_1 = CompanyUserFactory.create(sso_id=777)
     supplier_2 = CompanyUserFactory.create(sso_id=888)
     supplier_1.company = company_1
@@ -446,8 +426,7 @@ def test_get_published_companies_use_optional_filters(
     if limit is not None:
         params.update({'limit': limit})
     if minimal_number_of_sectors is not None:
-        params.update(
-            {'minimal_number_of_sectors': minimal_number_of_sectors})
+        params.update({'minimal_number_of_sectors': minimal_number_of_sectors})
     response = authed_client.get(url, data=params)
     assert len(response.json()) == expected_number_of_results
 
@@ -526,8 +505,7 @@ def test_create_test_isd_company(authed_client):
 
 
 @pytest.mark.django_db
-def test_create_test_isd_company_with_disabled_test_api(
-        authed_client, settings):
+def test_create_test_isd_company_with_disabled_test_api(authed_client, settings):
     settings.FEATURE_TEST_API_ENABLED = False
     url = reverse('create_test_isd_company')
     response = authed_client.get(url)
@@ -535,8 +513,7 @@ def test_create_test_isd_company_with_disabled_test_api(
 
 
 @pytest.mark.django_db
-def test_create_test_isd_company_with_disabled_test_api_and_unsigned_client(
-        client, settings):
+def test_create_test_isd_company_with_disabled_test_api_and_unsigned_client(client, settings):
     settings.FEATURE_TEST_API_ENABLED = False
     url = reverse('create_test_isd_company')
     response = client.get(url)
@@ -556,9 +533,7 @@ def test_create_test_isd_company_with_optional_parameter(authed_client):
 
 
 @pytest.mark.django_db
-def test_create_test_isd_company_unexpected_parameters_are_ignored(
-        authed_client
-):
+def test_create_test_isd_company_unexpected_parameters_are_ignored(authed_client):
     url = reverse('create_test_isd_company')
     data = {
         'an_unexpected_parameter': 'unexpected value',
@@ -569,10 +544,7 @@ def test_create_test_isd_company_unexpected_parameters_are_ignored(
 
 @pytest.mark.django_db
 def test_delete_test_companies(client):
-    CompanyFactory.create_batch(
-        3,
-        email_address=Sequence(lambda n: f'test+{n}@directory.uktrade.digital')
-    )
+    CompanyFactory.create_batch(3, email_address=Sequence(lambda n: f'test+{n}@directory.uktrade.digital'))
     response = client.delete(reverse('delete_test_companies'))
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -586,19 +558,14 @@ def test_delete_test_companies_returns_404_when_no_test_companies(client):
 @pytest.mark.django_db
 def test_delete_test_companies_returns_404_with_disabled_testapi(client, settings):
     settings.FEATURE_TEST_API_ENABLED = False
-    CompanyFactory.create(
-        email_address=Sequence(lambda n: f'test+{n}@directory.uktrade.digital')
-    )
+    CompanyFactory.create(email_address=Sequence(lambda n: f'test+{n}@directory.uktrade.digital'))
     response = client.delete(reverse('delete_test_companies'))
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.django_db
 def test_delete_test_buyers(authed_client):
-    BuyerFactory.create_batch(
-        3,
-        email=Sequence(lambda n: f'test+{n}@directory.uktrade.digital')
-    )
+    BuyerFactory.create_batch(3, email=Sequence(lambda n: f'test+{n}@directory.uktrade.digital'))
     response = authed_client.delete(reverse('delete_test_buyers'))
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert Buyer.objects.count() == 0
@@ -613,9 +580,7 @@ def test_delete_test_buyers_returns_404_when_no_test_buyers(authed_client):
 @pytest.mark.django_db
 def test_delete_test_buyers_returns_404_with_disabled_testapi(authed_client, settings):
     settings.FEATURE_TEST_API_ENABLED = False
-    BuyerFactory.create(
-        email=Sequence(lambda n: f'test+{n}@directory.uktrade.digital')
-    )
+    BuyerFactory.create(email=Sequence(lambda n: f'test+{n}@directory.uktrade.digital'))
     response = authed_client.delete(reverse('delete_test_buyers'))
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert Buyer.objects.count() == 1
@@ -630,7 +595,7 @@ def test_delete_test_buyers_returns_404_with_disabled_testapi(authed_client, set
         'post',
         'put',
         'trace',
-    ]
+    ],
 )
 @pytest.mark.django_db
 def test_delete_test_buyers_does_not_accept_all_http_methods(authed_client, client, method):

--- a/testapi/utils.py
+++ b/testapi/utils.py
@@ -1,9 +1,7 @@
-
 def get_published_companies_query_params(request):
     params = request.query_params
     limit = int(params.get('limit', 100))
-    minimal_number_of_sectors = int(params.get(
-        'minimal_number_of_sectors', 0))
+    minimal_number_of_sectors = int(params.get('minimal_number_of_sectors', 0))
     return limit, minimal_number_of_sectors
 
 
@@ -22,10 +20,8 @@ def prepare_company_data(company):
         'summary': company.summary,
         'description': company.description,
         'is_uk_isd_company': company.is_uk_isd_company,
-        'is_published_investment_support_directory':
-            company.is_published_investment_support_directory,
-        'is_published_find_a_supplier':
-            company.is_published_find_a_supplier,
+        'is_published_investment_support_directory': company.is_published_investment_support_directory,
+        'is_published_find_a_supplier': company.is_published_find_a_supplier,
     }
 
 
@@ -35,9 +31,7 @@ def has_enough_sectors(company, minimal_number_of_sectors):
 
 def get_matching_companies(queryset, limit, minimal_number_of_sectors):
     result = []
-    companies = [
-        company for company in queryset.all()
-        if has_enough_sectors(company, minimal_number_of_sectors)]
+    companies = [company for company in queryset.all() if has_enough_sectors(company, minimal_number_of_sectors)]
     for company in companies[:limit]:
         data = prepare_company_data(company)
         result.append(data)

--- a/testapi/views.py
+++ b/testapi/views.py
@@ -17,15 +17,8 @@ from buyer.models import Buyer
 from buyer.serializers import BuyerSerializer
 from company.models import Company
 from core.authentication import Oauth2AuthenticationSSO
-from testapi.serializers import (
-    CompanySerializer,
-    ISDCompanySerializer,
-    PublishedCompaniesSerializer,
-)
-from testapi.utils import (
-    get_matching_companies,
-    get_published_companies_query_params,
-)
+from testapi.serializers import CompanySerializer, ISDCompanySerializer, PublishedCompaniesSerializer
+from testapi.utils import get_matching_companies, get_published_companies_query_params
 
 
 class TestAPIView(GenericAPIView):
@@ -77,16 +70,11 @@ class CompanyTestAPIView(TestAPIView, RetrieveAPIView, DestroyAPIView, UpdateAPI
             'is_verification_letter_sent': company.is_verification_letter_sent,
             'is_uk_isd_company': company.is_uk_isd_company,
             'invitation_key': signer.sign(company.number),
-            'is_published_investment_support_directory':
-                company.is_published_investment_support_directory,
-            'is_published_find_a_supplier':
-                company.is_published_find_a_supplier,
-            'is_identity_check_message_sent':
-                company.is_identity_check_message_sent,
-            'verified_with_identity_check':
-                company.verified_with_identity_check,
-            'verified_with_code':
-                company.verified_with_code,
+            'is_published_investment_support_directory': company.is_published_investment_support_directory,
+            'is_published_find_a_supplier': company.is_published_find_a_supplier,
+            'is_identity_check_message_sent': company.is_identity_check_message_sent,
+            'verified_with_identity_check': company.verified_with_identity_check,
+            'verified_with_code': company.verified_with_code,
         }
         return Response(response_data)
 
@@ -107,34 +95,28 @@ class CompanyTestAPIView(TestAPIView, RetrieveAPIView, DestroyAPIView, UpdateAPI
 class PublishedCompaniesTestAPIView(TestAPIView, RetrieveAPIView):
     serializer_class = PublishedCompaniesSerializer
     queryset = Company.objects.filter(
-        Q(is_published_investment_support_directory=True) |
-        Q(is_published_find_a_supplier=True)
+        Q(is_published_investment_support_directory=True) | Q(is_published_find_a_supplier=True)
     )
     lookup_field = 'is_published'
     http_method_names = 'get'
 
     def get(self, request, *args, **kwargs):
-        limit, minimal_number_of_sectors = \
-            get_published_companies_query_params(request)
-        response_data = get_matching_companies(
-            self.queryset, limit, minimal_number_of_sectors)
+        limit, minimal_number_of_sectors = get_published_companies_query_params(request)
+        response_data = get_matching_companies(self.queryset, limit, minimal_number_of_sectors)
         return Response(response_data)
 
 
 class UnpublishedCompaniesTestAPIView(TestAPIView, RetrieveAPIView):
     serializer_class = PublishedCompaniesSerializer
     queryset = Company.objects.filter(
-        Q(is_published_investment_support_directory=False) |
-        Q(is_published_find_a_supplier=False)
+        Q(is_published_investment_support_directory=False) | Q(is_published_find_a_supplier=False)
     )
     lookup_field = 'is_published'
     http_method_names = 'get'
 
     def get(self, request, *args, **kwargs):
-        limit, minimal_number_of_sectors = \
-            get_published_companies_query_params(request)
-        response_data = get_matching_companies(
-            self.queryset, limit, minimal_number_of_sectors)
+        limit, minimal_number_of_sectors = get_published_companies_query_params(request)
+        response_data = get_matching_companies(self.queryset, limit, minimal_number_of_sectors)
         return Response(response_data)
 
 

--- a/usermanagement/management/commands/createsuperuserwithpsswd.py
+++ b/usermanagement/management/commands/createsuperuserwithpsswd.py
@@ -1,15 +1,14 @@
-from django.db import DEFAULT_DB_ALIAS
 from django.contrib.auth.management.commands import createsuperuser
+from django.db import DEFAULT_DB_ALIAS
 
 
 class Command(createsuperuser.Command):
-
     def add_arguments(self, parser):
         parser.add_argument(
             '--{}'.format(self.UserModel.USERNAME_FIELD),
             dest=self.UserModel.USERNAME_FIELD,
             default=None,
-            help='Specifies the login for the superuser.'
+            help='Specifies the login for the superuser.',
         )
         parser.add_argument(
             '--password',
@@ -21,10 +20,7 @@ class Command(createsuperuser.Command):
 
         for field in self.UserModel.REQUIRED_FIELDS:
             parser.add_argument(
-                '--{}'.format(field),
-                dest=field,
-                default=None,
-                help='Specifies the {} for the superuser.'.format(field)
+                '--{}'.format(field), dest=field, default=None, help='Specifies the {} for the superuser.'.format(field)
             )
 
     def handle(self, *args, **options):
@@ -39,5 +35,4 @@ class Command(createsuperuser.Command):
         user_data[self.UserModel.USERNAME_FIELD] = username
         user_data['password'] = password
 
-        self.UserModel._default_manager.db_manager(
-            DEFAULT_DB_ALIAS).create_superuser(**user_data)
+        self.UserModel._default_manager.db_manager(DEFAULT_DB_ALIAS).create_superuser(**user_data)

--- a/usermanagement/management/commands/grant_staff_status.py
+++ b/usermanagement/management/commands/grant_staff_status.py
@@ -1,6 +1,5 @@
-from django.core.management import BaseCommand
-
 from django.contrib.auth.models import User
+from django.core.management import BaseCommand
 
 
 class Command(BaseCommand):
@@ -17,10 +16,6 @@ class Command(BaseCommand):
             user = User.objects.get(username=username)
             user.is_staff = True
             user.save()
-            self.stdout.write(
-                self.style.SUCCESS('Successfully granted staff status user "%s"' % user.username)
-            )
+            self.stdout.write(self.style.SUCCESS('Successfully granted staff status user "%s"' % user.username))
         except User.DoesNotExist:
-            self.stdout.write(
-                self.style.WARNING('No user found with username "%s"' % username)
-            )
+            self.stdout.write(self.style.WARNING('No user found with username "%s"' % username))

--- a/usermanagement/tests/test_createsuperuserwithpsswd.py
+++ b/usermanagement/tests/test_createsuperuserwithpsswd.py
@@ -1,17 +1,11 @@
-from django.core.management import call_command
-from django.contrib.auth.models import User
-
 import pytest
+from django.contrib.auth.models import User
+from django.core.management import call_command
 
 
 @pytest.mark.django_db
 def test_createsuperuserwithpsswd():
-    call_command(
-        "createsuperuserwithpsswd",
-        "--username=test",
-        "--email=test@example.com",
-        "--password=test"
-    )
+    call_command("createsuperuserwithpsswd", "--username=test", "--email=test@example.com", "--password=test")
 
     last_user = User.objects.last()
     assert last_user.username == "test"

--- a/usermanagement/tests/test_grant_staff_status.py
+++ b/usermanagement/tests/test_grant_staff_status.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.contrib.auth.models import User
 from django.core.management import call_command
 


### PR DESCRIPTION
This massive changeset is the result of applying black and isort to the codebase.

I have visually scanned every changed file, in case it's too much for eyes-on CR here. Tests are passing

* add Black and related deps to test requirements and rebuild requirements
* add minimal Black config in pyproject.toml which will be used by default
* config for isort so that it doesn't conflict with Black
* add makefile commands to use black in check or write mode (`make checks` or `make autoformat`)
* update CI config to run `black --check` in CI, too
* add .pre-commit-config.yaml for pre-commit (see pre-commit.com)
* reformat the entire codebase (done as six separate commits to make review easier)

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
 - [X] (if updating requirements) Requirements have been compiled.
 