### PR TITLE
GP2-1348 Economy and population - added raw values and rank_totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Implemented enhancements
 
+- GP2-1348 - Economy and population raw values and rank totals
 - GP2-1264 - Added currencies data
 - GP2-1267 - Added Rule of Law data
 - GP2-1258 - Society data

--- a/dataservices/helpers.py
+++ b/dataservices/helpers.py
@@ -429,13 +429,11 @@ def get_urban_rural_data(data_object, total_population, classification):
     }
 
 
-def get_serialized_instance_from_model(model_class, serializer_class, filter_args, include_total=False):
+def get_serialized_instance_from_model(model_class, serializer_class, filter_args):
     try:
         instance = model_class.objects.get(**filter_args)
         serializer = serializer_class(instance)
         result = serializer.data
-        if include_total:
-            result.update({'total': model_class.objects.count()})
         return result
     except model_class.DoesNotExist:
         return None

--- a/dataservices/helpers.py
+++ b/dataservices/helpers.py
@@ -432,9 +432,8 @@ def get_urban_rural_data(data_object, total_population, classification):
 def get_serialized_instance_from_model(model_class, serializer_class, filter_args):
     try:
         instance = model_class.objects.get(**filter_args)
-        serializer = serializer_class(instance)
-        result = serializer.data
-        return result
+        serializer = serializer_class(instance) 
+        return serializer.data
     except model_class.DoesNotExist:
         return None
 

--- a/dataservices/helpers.py
+++ b/dataservices/helpers.py
@@ -429,11 +429,14 @@ def get_urban_rural_data(data_object, total_population, classification):
     }
 
 
-def get_serialized_instance_from_model(model_class, serializer_class, filter_args):
+def get_serialized_instance_from_model(model_class, serializer_class, filter_args, include_total=False):
     try:
         instance = model_class.objects.get(**filter_args)
         serializer = serializer_class(instance)
-        return serializer.data
+        result = serializer.data
+        if include_total:
+            result.update({'total': model_class.objects.count()})
+        return result
     except model_class.DoesNotExist:
         return None
 

--- a/dataservices/helpers.py
+++ b/dataservices/helpers.py
@@ -432,7 +432,7 @@ def get_urban_rural_data(data_object, total_population, classification):
 def get_serialized_instance_from_model(model_class, serializer_class, filter_args):
     try:
         instance = model_class.objects.get(**filter_args)
-        serializer = serializer_class(instance) 
+        serializer = serializer_class(instance)
         return serializer.data
     except model_class.DoesNotExist:
         return None

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -6,6 +6,7 @@ from dataservices import models
 class EaseOfDoingBusinessSerializer(serializers.ModelSerializer):
     total = serializers.SerializerMethodField()
     country = serializers.SerializerMethodField()
+    year = serializers.SerializerMethodField()
 
     class Meta:
         model = models.EaseOfDoingBusiness
@@ -18,17 +19,30 @@ class EaseOfDoingBusinessSerializer(serializers.ModelSerializer):
         if obj.country:
             return obj.country.name
 
+    def get_year(self, obj):
+        # The year is implicit and should be updated when new data are imported
+        return '2019'
+
 
 class CorruptionPerceptionsIndexSerializer(serializers.ModelSerializer):
     country = serializers.SerializerMethodField()
+    total = serializers.SerializerMethodField()
+    year = serializers.SerializerMethodField()
 
     class Meta:
         model = models.CorruptionPerceptionsIndex
         exclude = ['created', 'id', 'modified']
 
+    def get_total(self, obj):
+        return models.CorruptionPerceptionsIndex.objects.all().count()
+
     def get_country(self, obj):
         if obj.country:
             return obj.country.name
+
+    def get_year(self, obj):
+        # The year is implicit and should be updated when new data are imported
+        return '2019'
 
 
 class WorldEconomicOutlookSerializer(serializers.ModelSerializer):

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -7,6 +7,7 @@ class EaseOfDoingBusinessSerializer(serializers.ModelSerializer):
     total = serializers.SerializerMethodField()
     country = serializers.SerializerMethodField()
     year = serializers.SerializerMethodField()
+    rank = serializers.SerializerMethodField()
 
     class Meta:
         model = models.EaseOfDoingBusiness
@@ -22,6 +23,9 @@ class EaseOfDoingBusinessSerializer(serializers.ModelSerializer):
     def get_year(self, obj):
         # The year is implicit and should be updated when new data are imported
         return '2019'
+
+    def get_rank(self, obj):
+        return obj.year_2019
 
 
 class CorruptionPerceptionsIndexSerializer(serializers.ModelSerializer):

--- a/dataservices/tests/test_helpers.py
+++ b/dataservices/tests/test_helpers.py
@@ -238,6 +238,8 @@ def test_get_corruption_perceptions_index():
         'cpi_score_2019': 24,
         'rank': 21,
         'country': 'Australia',
+        'total': 1,
+        'year': '2019',
     }
 
 

--- a/dataservices/tests/test_helpers.py
+++ b/dataservices/tests/test_helpers.py
@@ -211,6 +211,8 @@ def test_get_ease_of_business_index():
         'country_code': 'AUS',
         'year_2019': 20,
         'country': 'Australia',
+        'year': '2019',
+        'rank': 20,
     }
 
 

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -519,6 +519,18 @@ def test_income_data_api(api_client):
     assert 'income' in json_response['country_data']
     assert 'Canada' == json_response['country_data']['income']['country_name']
     assert '37653.281' == json_response['country_data']['income']['value']
+    # Retrieve India too as it has cpi data mocked
+    url = reverse('dataservices-country-data', kwargs={'country': 'India'})
+    json_response = api_client.get(url).json()
+    assert 'income' in json_response['country_data']
+    assert 'India' == json_response['country_data']['income']['country_name']
+    assert '1735.329' == json_response['country_data']['income']['value']
+    assert 5 == json_response['country_data']['ease_of_doing_bussiness']['year_2019']
+    assert 2 == json_response['country_data']['ease_of_doing_bussiness']['total']
+    assert '2019' == json_response['country_data']['ease_of_doing_bussiness']['year']
+    assert 9 == json_response['country_data']['corruption_perceptions_index']['rank']
+    assert 2 == json_response['country_data']['corruption_perceptions_index']['total']
+    assert '2019' == json_response['country_data']['corruption_perceptions_index']['year']
 
 
 @pytest.mark.django_db

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -442,6 +442,7 @@ def test_population_data_by_country(api_client, internet_usage_data):
             'urban_population_total': 56970,
             'urban_population_percentage_formatted': '83.53% (56.97 million)',
             'total_population': '68.20 million',
+            'total_population_raw': 68204000,
             'cpi': {'value': '150.56', 'year': 2019},
         }
     ]
@@ -464,16 +465,19 @@ def test_population_data_by_country_multiple_countries(api_client, internet_usag
             'urban_population_total': 56970,
             'urban_population_percentage_formatted': '83.53% (56.97 million)',
             'total_population': '68.20 million',
+            'total_population_raw': 68204000,
             'cpi': {'value': '150.56', 'year': 2019},
         },
         {
             'country': 'Germany',
-            'internet_usage': {'value': '91.97', 'year': 2020},
+            'internet_usage': {'value': '89.74', 'year': 2018},
             'rural_population_total': 18546,
             'rural_population_percentage_formatted': '22.10% (18.55 million)',
             'urban_population_total': 64044,
             'urban_population_percentage_formatted': '76.33% (64.04 million)',
             'total_population': '83.90 million',
+            'total_population_raw': 83902000,
+            'cpi': {'value': '112.86', 'year': 2019}
         },
     ]
 

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -470,7 +470,7 @@ def test_population_data_by_country_multiple_countries(api_client, internet_usag
         },
         {
             'country': 'Germany',
-            'internet_usage': {'value': '89.74', 'year': 2018},
+            'internet_usage': {'value': '91.97', 'year': 2020},
             'rural_population_total': 18546,
             'rural_population_percentage_formatted': '22.10% (18.55 million)',
             'urban_population_total': 64044,

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -481,7 +481,6 @@ def test_population_data_by_country_multiple_countries(api_client, internet_usag
             'urban_population_percentage_formatted': '76.33% (64.04 million)',
             'total_population': '83.90 million',
             'total_population_raw': 83902000,
-            'cpi': {'value': '112.86', 'year': 2019},
         },
     ]
 

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -477,7 +477,6 @@ def test_population_data_by_country_multiple_countries(api_client, internet_usag
             'urban_population_percentage_formatted': '76.33% (64.04 million)',
             'total_population': '83.90 million',
             'total_population_raw': 83902000,
-            'cpi': {'value': '112.86', 'year': 2019},
         },
     ]
 

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -477,7 +477,7 @@ def test_population_data_by_country_multiple_countries(api_client, internet_usag
             'urban_population_percentage_formatted': '76.33% (64.04 million)',
             'total_population': '83.90 million',
             'total_population_raw': 83902000,
-            'cpi': {'value': '112.86', 'year': 2019}
+            'cpi': {'value': '112.86', 'year': 2019},
         },
     ]
 

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -90,6 +90,8 @@ def test_get_easeofdoingbusiness(api_client):
         'year_2019': 10,
         'total': 2,
         'country': None,
+        'year': '2019',
+        'rank': 10,
     }
 
 
@@ -114,6 +116,8 @@ def test_get_corruptionperceptionsindex(api_client):
         'cpi_score_2019': 10,
         'rank': 3,
         'country': None,
+        'total': 2,
+        'year': '2019',
     }
 
 
@@ -477,6 +481,7 @@ def test_population_data_by_country_multiple_countries(api_client, internet_usag
             'urban_population_percentage_formatted': '76.33% (64.04 million)',
             'total_population': '83.90 million',
             'total_population_raw': 83902000,
+            'cpi': {'value': '112.86', 'year': 2019},
         },
     ]
 

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -119,7 +119,6 @@ class RetrieveCountryDataView(generics.GenericAPIView):
     permission_classes = []
 
     def get(self, *args, **kwargs):
-
         country = self.map_dit_to_weo_country_data(self.kwargs['country'])
         filter_args = {'country_name': country}
 
@@ -131,10 +130,10 @@ class RetrieveCountryDataView(generics.GenericAPIView):
             ),
             'internet_usage': get_serialized_instance_from_model(InternetUsage, InternetUsageSerializer, filter_args),
             'corruption_perceptions_index': get_serialized_instance_from_model(
-                CorruptionPerceptionsIndex, CorruptionPerceptionsIndexSerializer, filter_args, include_total=True
+                CorruptionPerceptionsIndex, CorruptionPerceptionsIndexSerializer, filter_args
             ),
             'ease_of_doing_bussiness': get_serialized_instance_from_model(
-                EaseOfDoingBusiness, EaseOfDoingBusinessSerializer, filter_args, include_total=True
+                EaseOfDoingBusiness, EaseOfDoingBusinessSerializer, filter_args
             ),
             'gdp_per_capita': get_serialized_instance_from_model(GDPPerCapita, GDPPerCapitalSerializer, filter_args),
             'total_population': millify(total_population.get('total_population', 0) * 1000),

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -235,9 +235,10 @@ class RetrievePopulationDataViewByCountry(generics.GenericAPIView):
             country_population = helpers.PopulationData()
             country_data = {'country': country}
             total_population = country_population.get_population_total_data(country=country)
+            total_population_raw = total_population.get('total_population', 0) * 1000
             population_data = {
-                'total_population': millify(total_population.get('total_population', 0) * 1000),
-                'total_population_raw': total_population.get('total_population', 0) * 1000,
+                'total_population': millify(total_population_raw),
+                'total_population_raw': total_population_raw,
             }
 
             # urban population

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -125,17 +125,16 @@ class RetrieveCountryDataView(generics.GenericAPIView):
 
         country_population = helpers.PopulationData()
         total_population = country_population.get_population_total_data(country=self.kwargs['country'])
-
         country_data = {
             'consumer_price_index': get_serialized_instance_from_model(
                 ConsumerPriceIndex, ConsumerPriceIndexSerializer, filter_args
             ),
             'internet_usage': get_serialized_instance_from_model(InternetUsage, InternetUsageSerializer, filter_args),
             'corruption_perceptions_index': get_serialized_instance_from_model(
-                CorruptionPerceptionsIndex, CorruptionPerceptionsIndexSerializer, filter_args
+                CorruptionPerceptionsIndex, CorruptionPerceptionsIndexSerializer, filter_args, include_total=True
             ),
             'ease_of_doing_bussiness': get_serialized_instance_from_model(
-                EaseOfDoingBusiness, EaseOfDoingBusinessSerializer, filter_args
+                EaseOfDoingBusiness, EaseOfDoingBusinessSerializer, filter_args, include_total=True
             ),
             'gdp_per_capita': get_serialized_instance_from_model(GDPPerCapita, GDPPerCapitalSerializer, filter_args),
             'total_population': millify(total_population.get('total_population', 0) * 1000),
@@ -237,7 +236,10 @@ class RetrievePopulationDataViewByCountry(generics.GenericAPIView):
             country_population = helpers.PopulationData()
             country_data = {'country': country}
             total_population = country_population.get_population_total_data(country=country)
-            population_data = {'total_population': millify(total_population.get('total_population', 0) * 1000)}
+            population_data = {
+                'total_population': millify(total_population.get('total_population', 0) * 1000),
+                'total_population_raw': total_population.get('total_population', 0) * 1000
+            }
 
             # urban population
             urban_population_data = country_population.get_population_urban_rural_data(

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -238,7 +238,7 @@ class RetrievePopulationDataViewByCountry(generics.GenericAPIView):
             total_population = country_population.get_population_total_data(country=country)
             population_data = {
                 'total_population': millify(total_population.get('total_population', 0) * 1000),
-                'total_population_raw': total_population.get('total_population', 0) * 1000
+                'total_population_raw': total_population.get('total_population', 0) * 1000,
             }
 
             # urban population


### PR DESCRIPTION
This PR just adds some fields to api responses.
A raw, unformatted population field so that we can format correctly in the UI layer.
Totals for corruption perception and ease of business, Also hardcoded years for these and a 'rank' field that duplicates the 'year_2019' field.
This means that great-cms can be made independent of new data being loaded in directory-api.
Existing fields are unchanged so maintaining backward compatibility. 

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.

