### PR TITLE
GP2-1347 Stop blowing up whe retrieving missing CPI or internet usage data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bugs fixed
 
+- GP2-1347 - Stop missing CPI or internet usage data from blowing up
 - GP2-1391 - US missing from cpi
 - GP2-1314 - ComTrade World import value fix
 

--- a/dataservices/helpers.py
+++ b/dataservices/helpers.py
@@ -368,25 +368,28 @@ def get_cia_factbook_data(country_name, data_keys=None):
 def get_internet_usage(country):
     try:
         internet_usage_obj = models.InternetUsage.objects.filter(country_name=country).latest()
-    except models.InternetUsage.DoesNotExist:
-        return {}
-    return {
-        'internet_usage': {
-            'value': '{:.2f}'.format(internet_usage_obj.value) if hasattr(internet_usage_obj, 'value') else None,
-            'year': internet_usage_obj.year if hasattr(internet_usage_obj, 'year') else None,
+        return {
+            'internet_usage': {
+                'value': '{:.2f}'.format(internet_usage_obj.value) if hasattr(internet_usage_obj, 'value') else None,
+                'year': internet_usage_obj.year if hasattr(internet_usage_obj, 'year') else None,
+            }
         }
-    }
+    finally:
+        return {}
 
 
 @TTLCache()
 def get_cpi_data(country):
     try:
         cpi_obj = models.ConsumerPriceIndex.objects.filter(country_name=country).latest()
-    except models.ConsumerPriceIndex.DoesNotExist:
+        return {
+            'cpi': {
+                'value': '{:.2f}'.format(cpi_obj.value) if hasattr(cpi_obj, 'value') else None,
+                'year': cpi_obj.year,
+            }
+        }
+    finally:
         return {}
-    return {
-        'cpi': {'value': '{:.2f}'.format(cpi_obj.value) if hasattr(cpi_obj, 'value') else None, 'year': cpi_obj.year}
-    }
 
 
 @TTLCache()

--- a/dataservices/helpers.py
+++ b/dataservices/helpers.py
@@ -374,7 +374,7 @@ def get_internet_usage(country):
                 'year': internet_usage_obj.year if hasattr(internet_usage_obj, 'year') else None,
             }
         }
-    finally:
+    except Exception:
         return {}
 
 
@@ -388,7 +388,7 @@ def get_cpi_data(country):
                 'year': cpi_obj.year,
             }
         }
-    finally:
+    except Exception:
         return {}
 
 


### PR DESCRIPTION
If a request is made to dataservices to get CPI which does not exist, the filter(...).latest() does not throw an exception, but just returns a None value. This then blow up on the formatting meaning the whole request (possibly for several countries) goes bank.
This PR takes the easy way out and wraps the whole thing in a try: with an exception catch all at the end. This is for safety - in other words - "I don't really care why it went wrong - just don't crash one me"

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.