### PR TITLE
GP2-1920_ref_countries_zero_padding

### DIFF
--- a/dataservices/management/commands/import_population_urbanrural.py
+++ b/dataservices/management/commands/import_population_urbanrural.py
@@ -16,11 +16,13 @@ class Command(BaseCommand):
         for urban_rural in ['urban', 'rural']:
             with open(f'dataservices/resources/{urban_rural}_population_annual.csv', 'r', encoding='utf-8-sig') as f:
                 file_reader = csv.DictReader(f)
+
                 for row in file_reader:
                     try:
-                        country = Country.objects.get(iso1=row['country_code'])
+                        country = Country.objects.get(iso1=row['country_code'].zfill(3))
                     except Country.DoesNotExist:
                         country = None
+                        self.stdout.write(f'No country match for {row["country_name"]}')
                     for year in self.import_years:
                         value = row.get(year)
                         if value:

--- a/dataservices/management/commands/import_target_age_groups.py
+++ b/dataservices/management/commands/import_target_age_groups.py
@@ -15,12 +15,16 @@ class Command(BaseCommand):
         for gender in genders:
             with open(f'dataservices/resources/world_population_medium_{gender}.csv', 'r', encoding='utf-8-sig') as f:
                 file_reader = csv.DictReader(f)
-
+                country = None
+                country_iso1 = None
                 for row in file_reader:
-                    try:
-                        country = Country.objects.get(iso1=row['country_code'])
-                    except Country.DoesNotExist:
-                        country = None
+                    if country_iso1 != (row['country_code']):
+                        country_iso1 = row['country_code']
+                        try:
+                            country = Country.objects.get(iso1=country_iso1.zfill(3))
+                        except Country.DoesNotExist:
+                            self.stdout.write(f'No country match for {row["country_name"]}')
+                            country = None
 
                     population_data.append(
                         PopulationData(

--- a/dataservices/management/commands/tests/test_import_data.py
+++ b/dataservices/management/commands/tests/test_import_data.py
@@ -115,11 +115,12 @@ def test_import_target_age_groups():
     management.call_command('import_countries')
     management.call_command('import_target_age_groups')
     data = models.PopulationData.objects.filter(country__iso1=276, year=2020)
-
     assert len(models.PopulationData.objects.all()) == 40986
     assert data.first().country.iso1 == '276'
     assert len(data) == 2
     assert data.first().age_100_plus == 4
+    data = models.PopulationData.objects.filter(country__iso2='BE', year=2020)
+    assert data.first().country.name == 'Belgium'
 
 
 @pytest.mark.django_db
@@ -136,6 +137,8 @@ def test_import_urban_rural_population():
     assert data[0].urban_rural == 'urban'
     assert data[1].value == 18610
     assert data[1].urban_rural == 'rural'
+    data = models.PopulationUrbanRural.objects.filter(country__iso3='BEL', year=2020)
+    assert data.first().country.name == 'Belgium'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR fixes an issue caused by an update to our reference country list from the data team.
The new version of the country list has the iso1 numeric code, zero padded to three digits. This means that it no longer joins to the numeric iso1 field in population data from the UN.
To fix, I've changed the two loaders for the population data to zero pad the field on country look-up.

 - [x] Change has a jira ticket that has the correct status.

