### PR TITLE
GP2-2266 Add spoof year to rule of law

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Pre release
 
-### Implemented enhancements
- GP2-2401-pdf-save
-GP2 2401 - pdf save
+### Bugs fixed
+- GP2-2266 Add spoof year to rule of law
 
+### Implemented enhancements
+- GP2-2401-pdf-save
 
 ## [1.10.1](https://github.com/uktrade/directory-api/releases/tag/1.10.1)
 

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -82,6 +82,7 @@ class RuleOfLawSerializer(serializers.ModelSerializer):
         # The year is implicit and should be updated when new data are imported
         return '2020'
 
+
 class SuggestedCountrySerializer(serializers.ModelSerializer):
     country_name = serializers.CharField(source='country__name')
     country_iso2 = serializers.CharField(source='country__iso2')

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -72,10 +72,15 @@ class IncomeSerializer(serializers.ModelSerializer):
 
 
 class RuleOfLawSerializer(serializers.ModelSerializer):
+    year = serializers.SerializerMethodField()
+
     class Meta:
         model = models.RuleOfLaw
         exclude = ['created', 'id', 'modified', 'country']
 
+    def get_year(self, obj):
+        # The year is implicit and should be updated when new data are imported
+        return '2020'
 
 class SuggestedCountrySerializer(serializers.ModelSerializer):
     country_name = serializers.CharField(source='country__name')

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -561,6 +561,7 @@ def test_society_data_by_country(api_client):
                 'iso2': 'UK',
                 'rank': 10,
                 'score': '76.000',
+                'year': '2020',
             },
         }
     ]


### PR DESCRIPTION
Adds a fixed year to the rule-of-law serializer so that a future update of data can be carried out without changing great-cms

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
 - [ ] (if hotfix) Has made PR into develop too
