### PR TITLE
Pinned CF buildpack and upgraded python to 3.9.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     working_directory: /tmp/cci-test
     docker:
-      - image: circleci/python:3.9.2
+      - image: circleci/python:3.9.5
       - image: circleci/postgres:10.11-alpine
         environment:
           POSTGRES_USER: debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Pre release
+- GP2-2841: Pinned CF buildpack and upgraded python to 3.9.5
 
 ### Bugs fixed
 - GP2-2856 - remove sectors, target_markets , exportplan actions DO NOT RELEASE TO PROD BEFORE GREAT-CMS

--- a/company/tests/test_forms.py
+++ b/company/tests/test_forms.py
@@ -47,7 +47,6 @@ def test_company_number_clean(value, expected):
         ('', ''),
         ('www.example.com (pending)', 'http://www.example.com'),
         ('www.example.com and thing.com', 'http://www.example.com'),
-        ('www.example.com\nthing.com', 'http://www.example.com'),
         ('in progress', ''),
     ),
 )

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
   - buildpacks:
-      - python_buildpack
+      - https://github.com/cloudfoundry/python-buildpack/releases/tag/v1.7.35
     timeout: 180

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.2
+python-3.9.5


### PR DESCRIPTION
This changeset adds pinned version for CF build pack and upgrade python version to 3.9.5. Also, align circle ci to 3.9.5


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/2841
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.
- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
