### PR TITLE
GP2-3071 Improve make secrets script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 #### Configuration
 
-Secrets such as API keys and environment specific configurations are placed in `conf/env/secrets-do-not-commit` - a file that is not added to version control. To create a template secrets file with dummy values run `make init_secrets`.
+Secrets such as API keys and environment specific configurations are placed in `conf/env/secrets-do-not-commit` - a file that is not added to version control. To create a template secrets file with dummy values run `make secrets`.
 
 ### Commands
 
@@ -45,7 +45,7 @@ Secrets such as API keys and environment specific configurations are placed in `
 | make requirements             | Compile the requirements file                    |
 | make install_requirements     | Installed the compile requirements file          |
 | make css                      | Compile scss to css                              |
-| make init_secrets             | Create your secret env var file                  |
+| make secrets                  | Create your secret env var file                  |
 | make worker                   | Run the celery worker                            |
 | make beat                     | Run the celery beat scheduler                    |
 | make checks                   | Run isort, black and flake8 in check-only mode   |

--- a/makefile
+++ b/makefile
@@ -34,10 +34,10 @@ css:
 	./node_modules/.bin/gulp sass
 
 secrets:
-	@if [ ! -f ./config/env/secrets-do-not-commit ]; \
-		then sed -e 's/#DO NOT ADD SECRETS TO THIS FILE//g' config/env/secrets-template > config/env/secrets-do-not-commit \
-			&& echo "Created config/env/secrets-do-not-commit"; \
-		else echo "config/env/secrets-do-not-commit already exists. Delete first to recreate it."; \
+	@if [ ! -f ./conf/env/secrets-do-not-commit ]; \
+		then sed -e 's/#DO NOT ADD SECRETS TO THIS FILE//g' conf/env/secrets-template > conf/env/secrets-do-not-commit \
+			&& echo "Created conf/env/secrets-do-not-commit"; \
+		else echo "conf/env/secrets-do-not-commit already exists. Delete it first to recreate it."; \
 	fi
 
 worker:

--- a/makefile
+++ b/makefile
@@ -33,9 +33,12 @@ install_requirements:
 css:
 	./node_modules/.bin/gulp sass
 
-init_secrets:
-	cp conf/env/secrets-template conf/env/secrets-do-not-commit
-	sed -i -e 's/#DO NOT ADD SECRETS TO THIS FILE//g' conf/env/secrets-do-not-commit
+secrets:
+	@if [ ! -f ./config/env/secrets-do-not-commit ]; \
+		then sed -e 's/#DO NOT ADD SECRETS TO THIS FILE//g' config/env/secrets-template > config/env/secrets-do-not-commit \
+			&& echo "Created config/env/secrets-do-not-commit"; \
+		else echo "config/env/secrets-do-not-commit already exists. Delete first to recreate it."; \
+	fi
 
 worker:
 	ENV_FILES='secrets-do-not-commit,dev' celery -A conf worker -l info


### PR DESCRIPTION
Changed `init_secrets` Make script to `secrets` for consistency with other directory repos.

Makefile secret script now uses sed directly to create the new file to avoid using -i option, which ensures compatibility with both Mac and Linux platforms (and prevents creating extra secrets-do-not-commit-e file on Mac).

The secrets file is only created if it does not exist, otherwise user is prompted to delete if they require a fresh one.

CONTEXT: This should make onboarding and fresh setup slightly easier and more consistent when using the Docker setup from https://github.com/uktrade/great-cms

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [ ] Changelog entry added.
 - [ ] ~~(if there are vulnerable requirements) Upgraded any vulnerable dependencies.~~
 - [ ] ~~(if updating requirements) Requirements have been compiled.~~
 - [ ] ~~(if adding env vars) Added any new environment variable to vault.~~
 - [ ] ~~(if adding feature flags) Cleaned up old flags~~
 - [ ] ~~(if hotfix) Has made PR into develop too~~
