### PR TITLE
Dataservices' highlights figures fine tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - GLS-232 - Ingest ONS data for UK total trade from Data Workspace
 - GLS-233 - Ingest ONS data for UK trade in goods from Data Workspace
 - GLS-234 - Ingest ONS data for UK trade in services from Data Workspace
+- GLS-246 - Use World Total records for percentage calculations on highlights
+- GLS-247 - Use correct ranking algorithm for highligths
 
 ### Bugs fixed
 

--- a/dataservices/filters.py
+++ b/dataservices/filters.py
@@ -26,3 +26,11 @@ class UKMarketTrendsFilter(django_filters.rest_framework.FilterSet):
     class Meta:
         model = models.UKTotalTradeByCountry
         fields = ['iso2', 'from_year']
+
+
+class UKTradeHighlightsFilter(django_filters.rest_framework.FilterSet):
+    iso2 = django_filters.CharFilter(field_name='country__iso2', lookup_expr='iexact', required=True)
+
+    class Meta:
+        model = models.UKTotalTradeByCountry
+        fields = ['iso2']

--- a/dataservices/management/commands/import_uk_total_trade_data.py
+++ b/dataservices/management/commands/import_uk_total_trade_data.py
@@ -30,7 +30,11 @@ class Command(BaseCommand):
                 try:
                     country = Country.objects.get(iso2=row.ons_iso_alpha_2_code)
                 except Country.DoesNotExist:
-                    continue
+                    # We need to store rows for 'World Total' (iso2 'W1')
+                    if row.ons_iso_alpha_2_code == 'W1':
+                        country = None
+                    else:
+                        continue
 
                 year, quarter = row.period.split('-Q')
                 value = None if row.value < 0 else row.value

--- a/dataservices/managers.py
+++ b/dataservices/managers.py
@@ -24,7 +24,7 @@ class PeriodDataMixin:
 
 class UKTotalTradeDataManager(PeriodDataMixin, CTEManager):
     def market_trends(self):
-        qs = self
+        qs = self.exclude(country__isnull=True)
         year, quarter = self.get_current_period().values()
 
         if quarter and quarter != 4:

--- a/dataservices/managers.py
+++ b/dataservices/managers.py
@@ -1,10 +1,11 @@
 from django.db import models
 from django.db.models import ExpressionWrapper, F, FloatField, Q, Sum
 from django.db.models.expressions import Window
-from django.db.models.functions import RowNumber
+from django.db.models.functions import Rank
+from django_cte import CTEManager, With
 
 
-class BaseDataManager(models.manager.Manager):
+class PeriodDataMixin:
     def _last_four_quarters(self):
         year, quarter = self.get_current_period().values()
 
@@ -21,7 +22,7 @@ class BaseDataManager(models.manager.Manager):
         }
 
 
-class UKTotalTradeDataManager(BaseDataManager):
+class UKTotalTradeDataManager(PeriodDataMixin, CTEManager):
     def market_trends(self):
         qs = self
         year, quarter = self.get_current_period().values()
@@ -33,21 +34,26 @@ class UKTotalTradeDataManager(BaseDataManager):
 
     def highlights(self):
         last_four_quarters = self._last_four_quarters()
-        total = last_four_quarters.aggregate(total=Sum('exports'))['total']
+        total = last_four_quarters.filter(country__isnull=True).aggregate(total=Sum('exports'))['total']
 
         if total and total != 0:
-            return last_four_quarters.values('country__iso2').annotate(
-                total_uk_exports=Sum('exports'),
-                trading_position=Window(expression=RowNumber(), order_by=F('total_uk_exports').desc()),
-                percentage_of_uk_trade=ExpressionWrapper(
-                    F('total_uk_exports') * 100.0 / total, output_field=FloatField()
-                ),
+            cte = With(
+                last_four_quarters.exclude(country__isnull=True)
+                .values('country')
+                .annotate(
+                    total_uk_exports=Sum('exports'),
+                    trading_position=Window(expression=Rank(), order_by=F('total_uk_exports').desc()),
+                    percentage_of_uk_trade=ExpressionWrapper(
+                        F('total_uk_exports') * 100.0 / total, output_field=FloatField()
+                    ),
+                )
             )
+            return cte.queryset().with_cte(cte)
 
         return self.none()
 
 
-class UKTtradeInServicesDataManager(BaseDataManager):
+class UKTtradeInServicesDataManager(PeriodDataMixin, models.Manager):
     def top_services_exports(self):
         last_four_quarters = self._last_four_quarters()
 
@@ -59,7 +65,7 @@ class UKTtradeInServicesDataManager(BaseDataManager):
         )
 
 
-class UKTtradeInGoodsDataManager(BaseDataManager):
+class UKTtradeInGoodsDataManager(PeriodDataMixin, models.Manager):
     def top_goods_exports(self):
         last_four_quarters = self._last_four_quarters()
 

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -208,25 +208,31 @@ class UKMarketTrendsSerializer(serializers.ModelSerializer):
     imports = serializers.SerializerMethodField()
     exports = serializers.SerializerMethodField()
 
-    class Meta:
-        model = models.UKTotalTradeByCountry
-        exclude = ['id', 'country', 'quarter']
-
     def get_imports(self, obj):
         return millions_to_currency_unit(obj['imports'])
 
     def get_exports(self, obj):
         return millions_to_currency_unit(obj['exports'])
 
+    class Meta:
+        model = models.UKTotalTradeByCountry
+        exclude = ['id', 'country', 'quarter']
+
 
 class UKTradeHighlightsSerializer(serializers.Serializer):
-    def to_representation(self, obj):
-        total_uk_exports = millions_to_currency_unit(obj['total_uk_exports'])
-        trading_position = obj['trading_position']
-        percentage_of_uk_trade = obj['percentage_of_uk_trade']
+    total_uk_exports = serializers.SerializerMethodField()
+    trading_position = serializers.SerializerMethodField()
+    percentage_of_uk_trade = serializers.SerializerMethodField()
 
-        return {
-            'total_uk_exports': total_uk_exports,
-            'trading_position': trading_position,
-            'percentage_of_uk_trade': percentage_of_uk_trade,
-        }
+    def get_total_uk_exports(self, obj):
+        return millions_to_currency_unit(obj['total_uk_exports'])
+
+    def get_trading_position(self, obj):
+        return obj['trading_position']
+
+    def get_percentage_of_uk_trade(self, obj):
+        return obj['percentage_of_uk_trade']
+
+    class Meta:
+        model = models.UKTotalTradeByCountry
+        fields = ['total_uk_exports', 'trading_position', 'percentage_of_uk_trade']

--- a/dataservices/tests/conftest.py
+++ b/dataservices/tests/conftest.py
@@ -122,11 +122,11 @@ def trade_barrier_data():
 
 @pytest.fixture()
 def total_trade_records(countries):
-    for idx, iso2 in enumerate(['DE', 'FR', 'CN']):
+    for idx, iso2 in enumerate(['', 'DE', 'FR', 'CN']):
         for year in [2020, 2021]:
             for quarter in [1, 2, 3, 4]:
                 models.UKTotalTradeByCountry.objects.create(
-                    country=countries[iso2], year=year, quarter=quarter, imports=idx, exports=idx
+                    country=countries.get(iso2, None), year=year, quarter=quarter, imports=idx + 1, exports=idx + 1
                 )
 
 

--- a/dataservices/tests/test_managers.py
+++ b/dataservices/tests/test_managers.py
@@ -6,16 +6,18 @@ from dataservices.tests.factories import UKTotalTradeByCountryFactory
 
 @pytest.mark.django_db
 def test_uk_total_trade_manager_current_period_full_year(total_trade_records):
-    assert UKTotalTradeByCountry.objects.count() == 24
+    assert UKTotalTradeByCountry.objects.count() == 32
     assert UKTotalTradeByCountry.objects.get_current_period() == {'year': 2021, 'quarter': 4}
 
 
 @pytest.mark.django_db
 def test_uk_total_trade_manager_current_period_partial_year(countries, total_trade_records):
-    for idx, iso2 in enumerate(['DE', 'FR', 'CN']):
-        UKTotalTradeByCountryFactory.create(country=countries[iso2], year=2022, quarter=1, imports=idx, exports=idx)
+    for idx, iso2 in enumerate(['', 'DE', 'FR', 'CN']):
+        UKTotalTradeByCountryFactory.create(
+            country=countries.get(iso2, None), year=2022, quarter=1, imports=idx, exports=idx
+        )
 
-    assert UKTotalTradeByCountry.objects.count() == 27
+    assert UKTotalTradeByCountry.objects.count() == 36
     assert UKTotalTradeByCountry.objects.get_current_period() == {'year': 2022, 'quarter': 1}
 
 
@@ -43,7 +45,7 @@ def test_uk_total_trade_manager_highlights(total_trade_records):
     assert len(highlights_queryset) == 3
     for record in highlights_queryset:
         assert list(record.keys()) == [
-            'country__iso2',
+            'country',
             'total_uk_exports',
             'trading_position',
             'percentage_of_uk_trade',

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -498,10 +498,11 @@ def test_dataservices_market_trends_api_filter_by_year(client):
 
 @pytest.mark.django_db
 def test_dataservices_trade_highlights_api(client):
-    country = factories.CountryFactory(iso2='XY')
-    for year in [2020, 2021]:
-        for quarter in [1, 2, 3, 4]:
-            factories.UKTotalTradeByCountryFactory.create(country=country, year=year, quarter=quarter, exports=1)
+    countries = [factories.CountryFactory(iso2='XY'), None]
+    for country in countries:
+        for year in [2020, 2021]:
+            for quarter in [1, 2, 3, 4]:
+                factories.UKTotalTradeByCountryFactory.create(country=country, year=year, quarter=quarter, exports=1)
 
     response = client.get(reverse('dataservices-trade-highlights'), data={'iso2': 'XY'})
 

--- a/requirements.in
+++ b/requirements.in
@@ -44,3 +44,4 @@ xhtml2pdf==0.2.6
 pyjwt==2.4.0
 pandas==1.4.2
 sqlalchemy==1.4.36
+django-cte==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,6 +104,8 @@ django-celery-beat==2.2.1
     # via -r requirements.in
 django-cleanup==5.2.0
     # via -r requirements.in
+django-cte==1.2.0
+    # via -r requirements.in
 django-environ==0.4.5
     # via -r requirements.in
 django-extensions==2.2.5
@@ -118,7 +120,7 @@ django-import-export==2.0.2
     # via -r requirements.in
 django-ipware==2.1.0
     # via django-admin-ip-restrictor
-django_json_widget==1.0.1
+django-json-widget==1.0.1
     # via -r requirements.in
 django-redis==4.10.0
     # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -123,6 +123,8 @@ django-celery-beat==2.2.1
     # via -r requirements.in
 django-cleanup==5.2.0
     # via -r requirements.in
+django-cte==1.2.0
+    # via -r requirements.in
 django-environ==0.4.5
     # via -r requirements.in
 django-extensions==2.2.5
@@ -137,7 +139,7 @@ django-import-export==2.0.2
     # via -r requirements.in
 django-ipware==2.1.0
     # via django-admin-ip-restrictor
-django_json_widget==1.0.1
+django-json-widget==1.0.1
     # via -r requirements.in
 django-redis==4.10.0
     # via -r requirements.in
@@ -325,14 +327,14 @@ requests[security]==2.25.1
     #   notifications-python-client
     #   requests-mock
     #   requests-oauthlib
-requests_mock==1.6.0
+requests-mock==1.6.0
     # via -r requirements_test.in
 requests-oauthlib==1.3.0
     # via django-staff-sso-client
-ruamel.yaml==0.17.21
+ruamel-yaml==0.17.21
     # via pre-commit-hooks
-ruamel.yaml.clib==0.2.6
-    # via ruamel.yaml
+ruamel-yaml-clib==0.2.6
+    # via ruamel-yaml
 s3transfer==0.4.2
     # via boto3
 sentry-sdk==0.13.4


### PR DESCRIPTION
This changeset brings in the use of 'World Total' figures in the UK Total Trade data set to calculate the percentages yielded by the 'trade highlights' endpoint of dataservices.

The ranking algorithm used in the aforementioned endpoint has been also changed to include gaps.

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
 - [X] (if updating requirements) Requirements have been compiled.
