### PR TITLE
Upgrade flake8 and black circle ci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           path: test-reports
   flake8:
     docker:
-      - image: circleci/python:3.6.6
+      - image: cimg/python:3.9.13
     steps:
       - checkout
       - setup_remote_docker:
@@ -75,7 +75,7 @@ jobs:
             flake8
   black:
     docker:
-      - image: circleci/python:3.6.6
+      - image: cimg/python:3.9.13
     steps:
       - checkout
       - setup_remote_docker:


### PR DESCRIPTION
This PR upgrades the circle ci images used for the flake8 and black formatting checks to use the new `cimg` images, which I missed in pr #1075 .

 - [x] Change has a jira ticket that has the correct status.
