### PR TITLE
Handle missing markets from the IMF dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre release
 ### Enhancements
 ### Bugs fixed
+- GLS-428 - Handle missing markets from the IMF dataset
 
 ## [2.5.0](https://github.com/uktrade/directory-api/releases/tag/2.5.0)
 [Full Changelog](https://github.com/uktrade/directory-api/compare/2.4.2...2.5.0)

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -590,3 +590,20 @@ def test_dataservices_economic_highlights_api_no_county_code(client):
     assert response.status_code == 400
 
     models.Country.objects.filter(iso2='XY').delete()
+
+
+@pytest.mark.django_db
+def test_dataservices_economic_highlights_api_no_data_found(client):
+    factories.CountryFactory(iso2='XY')
+    factories.WorldEconomicOutlookByCountryFactory()
+
+    response = client.get(reverse('dataservices-economic-highlights'), data={'iso2': 'XY'})
+
+    assert response.status_code == 200
+
+    api_data = json.loads(response.content)
+
+    assert api_data['metadata']
+    assert not api_data['data']
+
+    models.Country.objects.all().delete()

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -306,9 +306,12 @@ class EconomicHighlightsView(MetadataMixin, generics.RetrieveAPIView):
         res = super().get(*args, **kwargs)
         data = res.data['data']
         metadata = res.data['metadata']
-        uk_data = self.get_uk_stats(
-            gdp_year=data['gdp_per_capita']['year'], economic_growth_year=data['economic_growth']['year']
-        )
+        uk_data = {}
+
+        if data:
+            uk_data = self.get_uk_stats(
+                gdp_year=data['gdp_per_capita']['year'], economic_growth_year=data['economic_growth']['year']
+            )
 
         res.data['metadata'] = metadata | uk_data
 


### PR DESCRIPTION
CONTEXT: the [IMF's World Economic Outlook Database](https://www.imf.org/en/Publications/WEO/weo-database/2022/April) does not include certain countries that we show in the current market guides (e.g. Liechtenstein).

The API endpoint to yield economic stats is a filter (as opposed to a resource), therefore for an API request given a country ID that is missing in the dataset, a valid data object in the response body would be an empty object. It is for the client to handle this situation.

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
