### PR TITLE
Fix trade in services queryset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Enhancements
 ### Bugs fixed
 - GLS-428 - Handle missing markets from the IMF dataset
-
+- GLS-425 - Fix trade in services queryset
 ## [2.5.0](https://github.com/uktrade/directory-api/releases/tag/2.5.0)
 [Full Changelog](https://github.com/uktrade/directory-api/compare/2.4.2...2.5.0)
 ### Enhancements

--- a/dataservices/managers.py
+++ b/dataservices/managers.py
@@ -65,9 +65,9 @@ class UKTtradeInServicesDataManager(models.Manager):
             period_type = 'quarter'
             period_list = []
             for quarter in [1, 2, 3, 4][current_quarter:]:
-                period_list.append(f'{period_type}/{current_year}-Q{quarter}')
-            for quarter in [1, 2, 3, 4][:current_quarter]:
                 period_list.append(f'{period_type}/{current_year - 1}-Q{quarter}')
+            for quarter in [1, 2, 3, 4][:current_quarter]:
+                period_list.append(f'{period_type}/{current_year}-Q{quarter}')
         else:
             period_type = 'year'
             period_list = [f'{period_type}/{current_year}']

--- a/dataservices/tests/test_managers.py
+++ b/dataservices/tests/test_managers.py
@@ -78,32 +78,14 @@ def test_uk_top_services_yearly_totals(countries, trade_in_services_records):
 
 @pytest.mark.django_db
 def test_uk_top_services_quarterly_totals(countries, trade_in_services_records):
-    records = [
-        {'code': '0', 'name': 'none value', 'exports': None, 'imports': None},
-        {'code': '1', 'name': 'first', 'exports': 6, 'imports': 1},
-        {'code': '2', 'name': 'second', 'exports': 5, 'imports': 1},
-        {'code': '3', 'name': 'third', 'exports': 4, 'imports': 1},
-        {'code': '4', 'name': 'fourth', 'exports': 3, 'imports': 1},
-        {'code': '5', 'name': 'fifth', 'exports': 2, 'imports': 1},
-        {'code': '6', 'name': 'last', 'exports': 1, 'imports': 1},
-    ]
+    top_services_exports_cn = models.UKTradeInServicesByCountry.objects.top_services_exports().filter(
+        country__iso2='CN'
+    )
 
-    for iso2 in ['DE', 'FR', 'CN']:
-        for record in records:
-            models.UKTradeInServicesByCountry.objects.create(
-                country=countries[iso2],
-                period='quarter/2022-Q1',
-                period_type='quarter',
-                service_code=record['code'],
-                service_name=record['name'],
-                imports=record['imports'],
-                exports=record['exports'],
-            )
+    labels = ['first', 'second', 'third', 'fourth', 'fifth', 'last']
 
-    top_services_exports = models.UKTradeInServicesByCountry.objects.top_services_exports()
-
-    assert top_services_exports[0]['label'] == 'first'
-    assert top_services_exports[0]['total_value'] == 6
+    for idx, service in enumerate(top_services_exports_cn):
+        assert service['label'] == labels[idx]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fix the trade in services queryset by changing the algorithm to resolve the last four quarters from a given time period.

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
