### PR TITLE
Return dataset source data as metadata in the response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
 ## Pre release
+
 ### Enhancements
+- GLS-458 - Return dataset source data as metadata in the response
+
 ### Bugs fixed
 - GLS-428 - Handle missing markets from the IMF dataset
 - GLS-425 - Fix trade in services queryset
+
 ## [2.5.0](https://github.com/uktrade/directory-api/releases/tag/2.5.0)
 [Full Changelog](https://github.com/uktrade/directory-api/compare/2.4.2...2.5.0)
 ### Enhancements

--- a/dataservices/management/commands/tests/test_import_data.py
+++ b/dataservices/management/commands/tests/test_import_data.py
@@ -369,11 +369,11 @@ def test_import_world_economic_outlook_data(read_sql_mock, world_economic_outloo
 @pytest.mark.django_db
 @mock.patch('pandas.read_sql')
 @override_settings(DATA_WORKSPACE_DATASETS_URL='postgresql://')
-def test_import_metadata_last_release_data(read_sql_mock, metadata_last_release_raw_data):
+def test_import_metadata_source_data(read_sql_mock, metadata_last_release_raw_data):
     read_sql_mock.return_value = pd.DataFrame(metadata_last_release_raw_data)
 
     assert len(models.Metadata.objects.all()) == 0
 
-    management.call_command('import_metadata_last_release_data')
+    management.call_command('import_metadata_source_data')
 
     assert len(models.Metadata.objects.all()) == 4

--- a/dataservices/models.py
+++ b/dataservices/models.py
@@ -300,6 +300,12 @@ class PopulationData(models.Model):
 
 
 class UKTradeInGoodsByCountry(models.Model):
+    METADATA_SOURCE_ORGANISATION = 'ONS'
+    METADATA_SOURCE_LABEL = 'Trade in goods: country-by-commodity exports'
+    METADATA_SOURCE_URL = (
+        'https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets/uktradecountrybycommodityexports'
+    )
+
     country = models.ForeignKey(
         'dataservices.Country', verbose_name=_('Countries'), on_delete=models.SET_NULL, null=True
     )
@@ -317,6 +323,13 @@ class UKTradeInGoodsByCountry(models.Model):
 
 
 class UKTradeInServicesByCountry(models.Model):
+    METADATA_SOURCE_ORGANISATION = 'ONS'
+    METADATA_SOURCE_LABEL = 'UK trade in services: service type by partner country, non-seasonally adjusted'
+    METADATA_SOURCE_URL = (
+        'https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/datasets/'
+        'uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted'
+    )
+
     country = models.ForeignKey(
         'dataservices.Country', verbose_name=_('Countries'), on_delete=models.SET_NULL, null=True
     )
@@ -334,6 +347,13 @@ class UKTradeInServicesByCountry(models.Model):
 
 
 class UKTotalTradeByCountry(models.Model):
+    METADATA_SOURCE_ORGANISATION = 'ONS'
+    METADATA_SOURCE_LABEL = 'UK total trade: all countries, seasonally adjusted'
+    METADATA_SOURCE_URL = (
+        'https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets/'
+        'uktotaltradeallcountriesseasonallyadjusted'
+    )
+
     country = models.ForeignKey(
         'dataservices.Country', verbose_name=_('Countries'), on_delete=models.SET_NULL, null=True
     )
@@ -350,6 +370,10 @@ class UKTotalTradeByCountry(models.Model):
 
 
 class WorldEconomicOutlookByCountry(models.Model):
+    METADATA_SOURCE_ORGANISATION = 'IMF'
+    METADATA_SOURCE_LABEL = 'World Economic Outlook Database'
+    METADATA_SOURCE_URL = 'https://www.imf.org/en/Publications/WEO/weo-database/2022/April'
+
     country = models.ForeignKey(
         'dataservices.Country', verbose_name=_('Countries'), on_delete=models.SET_NULL, null=True
     )

--- a/dataservices/renderers.py
+++ b/dataservices/renderers.py
@@ -1,0 +1,21 @@
+from rest_framework.renderers import JSONRenderer
+
+
+class CustomDataMetadataJSONRenderer(JSONRenderer):
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        view = renderer_context.get('view')
+        metadata = view.get_serializer().get_metadata()
+        response_data = {}
+
+        if isinstance(data, list):
+            data = data[: view.limit]
+
+        if metadata:
+            response_data['metadata'] = metadata
+
+        if renderer_context["response"].status_code == 200:
+            response_data['data'] = data
+        else:
+            response_data = data
+
+        return super().render(response_data, accepted_media_type, renderer_context)

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -174,7 +174,12 @@ class PopulationDataSerializer(serializers.ModelSerializer):
         }
 
 
-class UKTopFiveGoodsExportsSerializer(serializers.ModelSerializer):
+class BaseDataMetadataSerializer(serializers.Serializer):
+    def get_metadata(self):
+        return self.context.get('metadata', {}) | self.context.get('view').kwargs.get('extra_metadata', {})
+
+
+class UKTopFiveGoodsExportsSerializer(BaseDataMetadataSerializer):
     label = serializers.SerializerMethodField()
     value = serializers.SerializerMethodField()
 
@@ -184,12 +189,8 @@ class UKTopFiveGoodsExportsSerializer(serializers.ModelSerializer):
     def get_value(self, obj):
         return millions_to_currency_unit(obj['total_value'])
 
-    class Meta:
-        model = models.UKTradeInGoodsByCountry
-        fields = ['label', 'value']
 
-
-class UKTopFiveServicesExportSerializer(serializers.ModelSerializer):
+class UKTopFiveServicesExportSerializer(BaseDataMetadataSerializer):
     label = serializers.SerializerMethodField()
     value = serializers.SerializerMethodField()
 
@@ -199,14 +200,14 @@ class UKTopFiveServicesExportSerializer(serializers.ModelSerializer):
     def get_value(self, obj):
         return millions_to_currency_unit(obj['total_value'])
 
-    class Meta:
-        model = models.UKTradeInServicesByCountry
-        fields = ['label', 'value']
 
-
-class UKMarketTrendsSerializer(serializers.ModelSerializer):
+class UKMarketTrendsSerializer(BaseDataMetadataSerializer):
+    year = serializers.SerializerMethodField()
     imports = serializers.SerializerMethodField()
     exports = serializers.SerializerMethodField()
+
+    def get_year(self, obj):
+        return obj['year']
 
     def get_imports(self, obj):
         return millions_to_currency_unit(obj['imports'])
@@ -214,12 +215,8 @@ class UKMarketTrendsSerializer(serializers.ModelSerializer):
     def get_exports(self, obj):
         return millions_to_currency_unit(obj['exports'])
 
-    class Meta:
-        model = models.UKTotalTradeByCountry
-        exclude = ['id', 'country', 'ons_iso_alpha_2_code', 'quarter']
 
-
-class UKTradeHighlightsSerializer(serializers.Serializer):
+class UKTradeHighlightsSerializer(BaseDataMetadataSerializer):
     total_uk_exports = serializers.SerializerMethodField()
     trading_position = serializers.SerializerMethodField()
     percentage_of_uk_trade = serializers.SerializerMethodField()
@@ -233,12 +230,8 @@ class UKTradeHighlightsSerializer(serializers.Serializer):
     def get_percentage_of_uk_trade(self, obj):
         return obj['percentage_of_uk_trade']
 
-    class Meta:
-        model = models.UKTotalTradeByCountry
-        fields = ['total_uk_exports', 'trading_position', 'percentage_of_uk_trade']
 
-
-class EconomicHighlightsSerializer(serializers.Serializer):
+class EconomicHighlightsSerializer(BaseDataMetadataSerializer):
     class Meta:
         model = models.WorldEconomicOutlookByCountry
 

--- a/dataservices/tests/conftest.py
+++ b/dataservices/tests/conftest.py
@@ -202,12 +202,20 @@ def world_economic_outlook_records(countries):
 
 
 @pytest.fixture()
-def metadata_last_release_records():
+def metadata_source_records():
     data = {
-        'TopFiveGoodsExportsByCountryView': '30 June 2020',
-        'TopFiveServicesExportsByCountryView': '30 June 2021',
-        'UKMarketTrendsView': '30 June 2022',
-        'UKTradeHighlightsView': '30 June 2022',
+        'TopFiveGoodsExportsByCountryView': {
+            'source': {'organisation': 'ONS', 'label': 'goods exports', 'last_release': '30 June 2020'}
+        },
+        'TopFiveServicesExportsByCountryView': {
+            'source': {'organisation': 'ONS', 'label': 'services exports', 'last_release': '30 June 2021'}
+        },
+        'UKMarketTrendsView': {
+            'source': {'organisation': 'ONS', 'label': 'total exports', 'last_release': '30 June 2022'}
+        },
+        'UKTradeHighlightsView': {
+            'source': {'organisation': 'ONS', 'label': 'total exports', 'last_release': '30 June 2022'}
+        },
     }
-    for view_name, last_release in data.items():
-        models.Metadata.objects.create(view_name=view_name, data={'last_release': last_release})
+    for view_name, metadata in data.items():
+        models.Metadata.objects.create(view_name=view_name, data=metadata)

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -377,11 +377,7 @@ def test_trading_trade_barrier_with_sectors(mock_api_client, client):
 
 
 @pytest.mark.django_db
-def test_dataservices_top_five_goods_by_country_api(client, trade_in_goods_records, metadata_last_release_records):
-    metadata = models.Metadata.objects.get(view_name='TopFiveGoodsExportsByCountryView')
-    metadata.data = metadata.data | {'label': 'ONS UK trade'}
-    metadata.save()
-
+def test_dataservices_top_five_goods_by_country_api(client, trade_in_goods_records, metadata_source_records):
     response = client.get(reverse('dataservices-top-five-goods-by-country'), data={'iso2': 'DE'})
 
     assert response.status_code == 200
@@ -390,8 +386,7 @@ def test_dataservices_top_five_goods_by_country_api(client, trade_in_goods_recor
 
     assert api_data['metadata'] == {
         'country': {'iso2': 'DE', 'name': 'Germany'},
-        'label': 'ONS UK trade',
-        'last_release': mock.ANY,
+        'source': {'organisation': 'ONS', 'label': 'goods exports', 'last_release': mock.ANY},
         'reference_period': {'period': mock.ANY, 'resolution': 'quarter', 'year': mock.ANY},
     }
     assert len(api_data['data']) == 5
@@ -406,13 +401,7 @@ def test_dataservices_top_five_goods_by_country_api_for_no_iso2(client, trade_in
 
 
 @pytest.mark.django_db
-def test_dataservices_trade_in_services_by_country_api(
-    client, trade_in_services_records, metadata_last_release_records
-):
-    metadata = models.Metadata.objects.get(view_name='TopFiveServicesExportsByCountryView')
-    metadata.data = metadata.data | {'label': 'ONS UK trade'}
-    metadata.save()
-
+def test_dataservices_trade_in_services_by_country_api(client, trade_in_services_records, metadata_source_records):
     response = client.get(reverse('dataservices-top-five-services-by-country'), data={'iso2': 'DE'})
 
     assert response.status_code == 200
@@ -421,8 +410,7 @@ def test_dataservices_trade_in_services_by_country_api(
 
     assert api_data['metadata'] == {
         'country': {'iso2': 'DE', 'name': 'Germany'},
-        'label': 'ONS UK trade',
-        'last_release': mock.ANY,
+        'source': {'organisation': 'ONS', 'label': 'services exports', 'last_release': mock.ANY},
         'reference_period': {'period': mock.ANY, 'resolution': 'quarter', 'year': mock.ANY},
     }
     assert len(api_data['data']) == 5
@@ -437,17 +425,8 @@ def test_dataservices_trade_in_services_by_country_api_for_no_iso(client, trade_
 
 
 @pytest.mark.django_db
-def test_dataservices_market_trends_api(client, metadata_last_release_records):
+def test_dataservices_market_trends_api(client, metadata_source_records):
     country = factories.CountryFactory(iso2='XY')
-    metadata = models.Metadata.objects.get(view_name='UKMarketTrendsView')
-    metadata.data = metadata.data | {
-        'label': 'ONS UK total trade: all countries',
-        'notes': [
-            'Total trade is the sum of all exports and imports over the same time period.',
-            'Data includes goods and services combined.',
-        ],
-    }
-    metadata.save()
 
     for year in [2020, 2021]:
         for quarter in [1, 2, 3, 4]:
@@ -463,12 +442,7 @@ def test_dataservices_market_trends_api(client, metadata_last_release_records):
 
     assert api_data['metadata'] == {
         'country': {'iso2': 'XY', 'name': mock.ANY},
-        'label': 'ONS UK total trade: all countries',
-        'last_release': mock.ANY,
-        'notes': [
-            'Total trade is the sum of all exports and imports over the same time period.',
-            'Data includes goods and services combined.',
-        ],
+        'source': {'organisation': 'ONS', 'label': 'total exports', 'last_release': mock.ANY},
     }
     assert len(api_data['data']) == 2
 
@@ -512,15 +486,7 @@ def test_dataservices_market_trends_api_filter_by_year(client):
 
 
 @pytest.mark.django_db
-def test_dataservices_trade_highlights_api(client, metadata_last_release_records):
-    metadata = models.Metadata.objects.get(view_name='UKTradeHighlightsView')
-    metadata.data = metadata.data | {
-        'label': 'ONS UK total trade: all countries',
-        'notes': [
-            'Data includes goods and services combined in the four quarters to the end of Q4 2021.',
-        ],
-    }
-    metadata.save()
+def test_dataservices_trade_highlights_api(client, metadata_source_records):
     countries = [factories.CountryFactory(iso2='XY'), None]
     for country in countries:
         for year in [2020, 2021]:
@@ -538,11 +504,7 @@ def test_dataservices_trade_highlights_api(client, metadata_last_release_records
 
     assert api_data['metadata'] == {
         'country': {'iso2': 'XY', 'name': mock.ANY},
-        'label': 'ONS UK total trade: all countries',
-        'last_release': mock.ANY,
-        'notes': [
-            'Data includes goods and services combined in the four quarters to the end of Q4 2021.',
-        ],
+        'source': {'organisation': 'ONS', 'label': 'total exports', 'last_release': mock.ANY},
         'reference_period': {'period': mock.ANY, 'resolution': 'quarter', 'year': mock.ANY},
     }
     assert len(api_data['data']) == 3

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -5,7 +5,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework import generics, status
 from rest_framework.response import Response
 
-from dataservices import filters, helpers, models, serializers
+from dataservices import filters, helpers, models, renderers, serializers
 from dataservices.core import client_api
 from dataservices.helpers import (
     deep_extend,
@@ -169,7 +169,6 @@ class TradeBarriersView(generics.GenericAPIView):
 
 
 class MetadataMixin:
-    METADATA_DATA_SOURCE_NOTES = None
     METADATA_DATA_RESOLUTION = 'quarter'
 
     limit = None
@@ -177,6 +176,9 @@ class MetadataMixin:
 
     def get_country(self):
         iso2 = self.request.query_params.get('iso2', '')
+        if not iso2:
+            return {}
+
         country = get_object_or_404(models.Country, iso2__iexact=iso2)
 
         return {'country': {'name': country.name, 'iso2': country.iso2}}
@@ -206,20 +208,11 @@ class MetadataMixin:
 
         return metadata.data | country | reference_period
 
-    def get(self, *args, **kwargs):
-        res = super().get(*args, **kwargs)
-        data = res.data
-        metadata = self.get_metadata()
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['metadata'] = self.get_metadata()
 
-        if isinstance(data, list):
-            data = data[: self.limit]
-
-        res.data = {
-            'metadata': metadata,
-            'data': data,
-        }
-
-        return res
+        return context
 
 
 class TopFiveGoodsExportsByCountryView(MetadataMixin, generics.ListAPIView):
@@ -227,6 +220,7 @@ class TopFiveGoodsExportsByCountryView(MetadataMixin, generics.ListAPIView):
     queryset = models.UKTradeInGoodsByCountry.objects
     serializer_class = serializers.UKTopFiveGoodsExportsSerializer
     filter_class = filters.UKTopFiveGoodsExportsFilter
+    renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
     limit = 5
     reference_period = True
 
@@ -239,6 +233,7 @@ class TopFiveServicesExportsByCountryView(MetadataMixin, generics.ListAPIView):
     queryset = models.UKTradeInServicesByCountry.objects
     serializer_class = serializers.UKTopFiveServicesExportSerializer
     filter_class = filters.UKTopFiveServicesExportsFilter
+    renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
     limit = 5
     reference_period = True
 
@@ -247,30 +242,22 @@ class TopFiveServicesExportsByCountryView(MetadataMixin, generics.ListAPIView):
 
 
 class UKMarketTrendsView(MetadataMixin, generics.ListAPIView):
-    METADATA_DATA_SOURCE_NOTES = [
-        'Total trade is the sum of all exports and imports over the same time period.',
-        'Data includes goods and services combined.',
-    ]
-
     permission_classes = []
     queryset = models.UKTotalTradeByCountry.objects
     serializer_class = serializers.UKMarketTrendsSerializer
     filter_class = filters.UKMarketTrendsFilter
+    renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
 
     def get_queryset(self):
         return self.queryset.market_trends()
 
 
 class UKTradeHighlightsView(MetadataMixin, generics.RetrieveAPIView):
-    # NOTE: this note could be dynamic, as it depends on the reference period
-    METADATA_DATA_SOURCE_NOTES = [
-        'Data includes goods and services combined in the four quarters to the end of Q4 2021.'
-    ]
-
     permission_classes = []
     queryset = models.UKTotalTradeByCountry.objects
     serializer_class = serializers.UKTradeHighlightsSerializer
     filter_class = filters.UKTradeHighlightsFilter
+    renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
     lookup_field = 'country__iso2'
     reference_period = True
 
@@ -288,6 +275,7 @@ class EconomicHighlightsView(MetadataMixin, generics.RetrieveAPIView):
     queryset = models.WorldEconomicOutlookByCountry.objects
     serializer_class = serializers.EconomicHighlightsSerializer
     filter_class = filters.EconomicHighlightsFilter
+    renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
     lookup_field = 'country__iso2'
 
     def get_uk_stats(self, gdp_year, economic_growth_year):
@@ -295,35 +283,19 @@ class EconomicHighlightsView(MetadataMixin, generics.RetrieveAPIView):
             country__iso2='GB'
         )
         serializer = self.get_serializer(queryset, many=True)
-        data = {}
-
-        for obj in serializer.data:
-            data.update(obj)
+        data = {k: v for element in serializer.data for k, v in element.items()}
 
         return {'uk_data': data}
-
-    def get(self, *args, **kwargs):
-        res = super().get(*args, **kwargs)
-        data = res.data['data']
-        metadata = res.data['metadata']
-        uk_data = {}
-
-        if data:
-            uk_data = self.get_uk_stats(
-                gdp_year=data['gdp_per_capita']['year'], economic_growth_year=data['economic_growth']['year']
-            )
-
-        res.data['metadata'] = metadata | uk_data
-
-        return res
 
     def retrieve(self, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer(queryset, many=True)
-        data = {}
+        data = {k: v for element in serializer.data for k, v in element.items()}
 
-        for obj in serializer.data:
-            data.update(obj)
+        if data:
+            self.kwargs['extra_metadata'] = self.get_uk_stats(
+                gdp_year=data['gdp_per_capita']['year'], economic_growth_year=data['economic_growth']['year']
+            )
 
         return Response(data)
 


### PR DESCRIPTION
This pull request brings custom renderer that returns a JSON response with `data` and `metadata` objects inside the root object.

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
