### PR TITLE
Fix ViewSet attribute to invoke filtersets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pre release
 ### Bugs fixed
+- KLS-348 - View attributes renamed to match filtersets
+
 ### Enhancements
 - KLS-265 - Patch certify to 2022.12.17
 - KLS-339 - Make label and value fields on Choice model not unique

--- a/company/views.py
+++ b/company/views.py
@@ -131,7 +131,7 @@ class CompanyPublicProfileViewSet(viewsets.ModelViewSet):
     )
     permission_classes = []
     pagination_class = pagination.CompanyPublicProfile
-    filter_class = filters.CompanyPublicProfileFilter
+    filterset_class = filters.CompanyPublicProfileFilter
     lookup_url_kwarg = 'companies_house_number'
     lookup_field = 'number'
 

--- a/dataservices/management/commands/import_metadata_source_data.py
+++ b/dataservices/management/commands/import_metadata_source_data.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             if row.table_name in table_names_view_names.keys():
                 for view_name in table_names_view_names[row.table_name]:
                     view = getattr(views, view_name)
-                    model = view.filter_class.Meta.model
+                    model = view.filterset_class.Meta.model
                     instance, _created = Metadata.objects.get_or_create(view_name=view_name)
                     instance.data['source'] = {}
                     instance.data['source']['organisation'] = model.METADATA_SOURCE_ORGANISATION

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -219,7 +219,7 @@ class TopFiveGoodsExportsByCountryView(MetadataMixin, generics.ListAPIView):
     permission_classes = []
     queryset = models.UKTradeInGoodsByCountry.objects
     serializer_class = serializers.UKTopFiveGoodsExportsSerializer
-    filter_class = filters.UKTopFiveGoodsExportsFilter
+    filterset_class = filters.UKTopFiveGoodsExportsFilter
     renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
     limit = 5
     reference_period = True
@@ -232,7 +232,7 @@ class TopFiveServicesExportsByCountryView(MetadataMixin, generics.ListAPIView):
     permission_classes = []
     queryset = models.UKTradeInServicesByCountry.objects
     serializer_class = serializers.UKTopFiveServicesExportSerializer
-    filter_class = filters.UKTopFiveServicesExportsFilter
+    filterset_class = filters.UKTopFiveServicesExportsFilter
     renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
     limit = 5
     reference_period = True
@@ -245,7 +245,7 @@ class UKMarketTrendsView(MetadataMixin, generics.ListAPIView):
     permission_classes = []
     queryset = models.UKTotalTradeByCountry.objects
     serializer_class = serializers.UKMarketTrendsSerializer
-    filter_class = filters.UKMarketTrendsFilter
+    filterset_class = filters.UKMarketTrendsFilter
     renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
 
     def get_queryset(self):
@@ -256,7 +256,7 @@ class UKTradeHighlightsView(MetadataMixin, generics.RetrieveAPIView):
     permission_classes = []
     queryset = models.UKTotalTradeByCountry.objects
     serializer_class = serializers.UKTradeHighlightsSerializer
-    filter_class = filters.UKTradeHighlightsFilter
+    filterset_class = filters.UKTradeHighlightsFilter
     renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
     lookup_field = 'country__iso2'
     reference_period = True
@@ -274,7 +274,7 @@ class EconomicHighlightsView(MetadataMixin, generics.RetrieveAPIView):
     permission_classes = []
     queryset = models.WorldEconomicOutlookByCountry.objects
     serializer_class = serializers.EconomicHighlightsSerializer
-    filter_class = filters.EconomicHighlightsFilter
+    filterset_class = filters.EconomicHighlightsFilter
     renderer_classes = (renderers.CustomDataMetadataJSONRenderer,)
     lookup_field = 'country__iso2'
 


### PR DESCRIPTION
[django-filter](https://github.com/carltongibson/django-filter) renamed `ViewSet.filter_class` to `ViewSet.filterset_class` [some time ago](https://github.com/carltongibson/django-filter/pull/867). The deprecated attribute name remained valid until v22 but now results in filters not being applied.

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.

