### PR TITLE
KLS-654 add celery task for Market Guides ingest

### DIFF
--- a/dataservices/management/commands/import_market_guides_data.py
+++ b/dataservices/management/commands/import_market_guides_data.py
@@ -29,10 +29,12 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        for k, v in self.command_table_view.items():
-            if MarketGuidesDataIngestionCommand().should_ingestion_run(v['view_name'], v['table_name']):
-                self.stdout.write(self.style.NOTICE(f'Running {k}'))
-                call_command(k, **options)
-                call_command('import_metadata_source_data', table=v['table_name'])
+        for command_name, table_view_names in self.command_table_view.items():
+            if MarketGuidesDataIngestionCommand().should_ingestion_run(
+                table_view_names['view_name'], table_view_names['table_name']
+            ):
+                self.stdout.write(self.style.NOTICE(f'Running {command_name}'))
+                call_command(command_name, **options)
+                call_command('import_metadata_source_data', table=table_view_names['table_name'])
 
         self.stdout.write(self.style.SUCCESS('All done, bye!'))

--- a/dataservices/tasks.py
+++ b/dataservices/tasks.py
@@ -1,4 +1,5 @@
 import requests
+from django.core.management import call_command
 from django.db import transaction
 
 from conf.celery import app
@@ -18,3 +19,8 @@ def load_cia_factbook_data_from_url(url):
         country_name = data['countries'][country]['data']['name']
         country_data = data['countries'][country]['data']
         CIAFactbook(country_key=country, country_name=country_name, factbook_data=country_data).save()
+
+
+@app.task()
+def run_market_guides_ingest():
+    call_command('import_market_guides_data')

--- a/dataservices/tests/test_tasks.py
+++ b/dataservices/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import re
+from unittest import mock
 
 import pytest
 
@@ -34,3 +35,10 @@ def test_load_cia_factbook_data_from_url(cia_factbook_request_mock, cia_factbook
     world = CIAFactbook.objects.get(country_key='world')
     assert world.country_name == cia_factbook_data['countries']['world']['data']['name']
     assert world.factbook_data == cia_factbook_data['countries']['world']['data']
+
+
+@pytest.mark.django_db
+@mock.patch('dataservices.tasks.call_command')
+def test_run_market_guides_ingest(mock_call_command):
+    tasks.run_market_guides_ingest()
+    assert mock_call_command.call_count == 1


### PR DESCRIPTION
Add a celery task to run the MArket Guide ingest

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-654
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
