### PR TITLE
Greatuk 101 automate IMF data

### DIFF
--- a/dataservices/management/commands/import_market_guides_data.py
+++ b/dataservices/management/commands/import_market_guides_data.py
@@ -56,7 +56,6 @@ class Command(BaseCommand):
                     self.stderr.write(self.style.ERROR(e))
                     send_ingest_error_notify_email(table_view_names['view_name'], e)
             else:
-                print("test")
                 self.stdout.write(self.style.NOTICE(f'{table_view_names["view_name"]} does not need updating'))
 
         self.stdout.write(self.style.SUCCESS('Finished Market Guides import!'))

--- a/dataservices/management/commands/import_market_guides_data.py
+++ b/dataservices/management/commands/import_market_guides_data.py
@@ -24,6 +24,10 @@ class Command(BaseCommand):
             'table_name': 'trade__uk_services_nsa',
             'view_name': 'TopFiveServicesExportsByCountryView',
         },
+        'import_world_economic_outlook_data': {
+            'table_name': 'world_economic_outlook__by_country',
+            'view_name': 'EconomicHighlightsView',
+        },
     }
 
     def add_arguments(self, parser):

--- a/dataservices/management/commands/import_market_guides_data.py
+++ b/dataservices/management/commands/import_market_guides_data.py
@@ -56,6 +56,7 @@ class Command(BaseCommand):
                     self.stderr.write(self.style.ERROR(e))
                     send_ingest_error_notify_email(table_view_names['view_name'], e)
             else:
+                print("test")
                 self.stdout.write(self.style.NOTICE(f'{table_view_names["view_name"]} does not need updating'))
 
         self.stdout.write(self.style.SUCCESS('Finished Market Guides import!'))

--- a/dataservices/management/commands/import_world_economic_outlook_data.py
+++ b/dataservices/management/commands/import_world_economic_outlook_data.py
@@ -1,7 +1,5 @@
 import pandas as pd
 import sqlalchemy as sa
-from django.conf import settings
-from django.core.management import BaseCommand
 
 from dataservices.models import Country, WorldEconomicOutlookByCountry
 

--- a/dataservices/management/commands/import_world_economic_outlook_data.py
+++ b/dataservices/management/commands/import_world_economic_outlook_data.py
@@ -5,11 +5,12 @@ from django.core.management import BaseCommand
 
 from dataservices.models import Country, WorldEconomicOutlookByCountry
 
+from .helpers import MarketGuidesDataIngestionCommand
 
-class Command(BaseCommand):
+
+class Command(MarketGuidesDataIngestionCommand):
     help = 'Import IMF world economic outlook data by country from Data Workspace'
 
-    engine = sa.create_engine(settings.DATA_WORKSPACE_DATASETS_URL, execution_options={'stream_results': True})
     sql = '''
         SELECT
             iso AS ons_iso_alpha_3_code,
@@ -38,7 +39,14 @@ class Command(BaseCommand):
             AND NULLIF(TRIM(x.value), '') IS NOT NULL;
     '''
 
-    def handle(self, *args, **options):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--write',
+            action='store_true',
+            help='Store dataset records',
+        )
+
+    def load_data(self):
         data = []
         chunks = pd.read_sql(sa.text(self.sql), self.engine, chunksize=10000)
 
@@ -64,7 +72,4 @@ class Command(BaseCommand):
                     )
                 )
 
-        WorldEconomicOutlookByCountry.objects.all().delete()
-        WorldEconomicOutlookByCountry.objects.bulk_create(data)
-
-        self.stdout.write(self.style.SUCCESS('All done, bye!'))
+        return data


### PR DESCRIPTION
This PR is to automate the import_world_economic_outlook_data management command and run it alongside the 3 x commands in the main pipeline.

To test locally you need to activate a tunnel to an env of your choice...Lets use staging

Note: you won't be able to test his if you use a docker set up
1) login to cf with:  cf login -sso
2) select > org: dit-staging
3) select > space: directory-staging
4) create tunnel: cf ssh directory-api-staging -T -L 12345:data-workspace-datasets-for-great-staging.apps.internal:5432
5) run management command from a new terminal: python manage.py import_world_economic_outlook_data
6) You should see 'Would create 26166 records' if it worked correctly

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-101
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers.
