### PR TITLE
Ioo 1125 bci api endpoint

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -569,6 +569,7 @@ SIGAUTH_URL_NAMES_WHITELIST = [
     'dataservices-trade-agreements',
     'dataservices-market-trends',
     'dataservices-trade-highlights',
+    'dataservices-business-cluster-information',
     'enrolment-preverified',
     'enrolment-claim-preverified',
     'offices-by-postcode',

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -305,6 +305,11 @@ urlpatterns = [
         dataservices.views.UKFreeTradeAgreementsView.as_view(),
         name='dataservices-trade-agreements',
     ),
+    re_path(
+        r'^dataservices/business-cluster-information/$',
+        dataservices.views.BusinessClusterInformationView.as_view(),
+        name='dataservices-business-cluster-information',
+    ),
     re_path(r'^testapi/buyer/(?P<email>.*)/$', testapi.views.BuyerTestAPIView.as_view(), name='buyer_by_email'),
     re_path(r'^testapi/test-buyers/$', testapi.views.BuyerTestAPIView.as_view(), name='delete_test_buyers'),
     re_path(

--- a/dataservices/filters.py
+++ b/dataservices/filters.py
@@ -42,3 +42,12 @@ class EconomicHighlightsFilter(django_filters.rest_framework.FilterSet):
     class Meta:
         model = models.WorldEconomicOutlookByCountry
         fields = ['iso2']
+
+class BusinessClusterInformationFilter(django_filters.rest_framework.FilterSet):
+    sic_code = django_filters.CharFilter(field_name='sic_code', lookup_expr='iexact', required=True)
+    geo_code = django_filters.CharFilter(field_name='geo_code', lookup_expr='iexact')
+
+    class Meta:
+        model = models.EYBBusinessClusterInformation
+        fields = ['sic_code', 'geo_code']
+

--- a/dataservices/filters.py
+++ b/dataservices/filters.py
@@ -43,6 +43,7 @@ class EconomicHighlightsFilter(django_filters.rest_framework.FilterSet):
         model = models.WorldEconomicOutlookByCountry
         fields = ['iso2']
 
+
 class BusinessClusterInformationFilter(django_filters.rest_framework.FilterSet):
     sic_code = django_filters.CharFilter(field_name='sic_code', lookup_expr='iexact', required=True)
     geo_code = django_filters.CharFilter(field_name='geo_code', lookup_expr='iexact')
@@ -50,4 +51,3 @@ class BusinessClusterInformationFilter(django_filters.rest_framework.FilterSet):
     class Meta:
         model = models.EYBBusinessClusterInformation
         fields = ['sic_code', 'geo_code']
-

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -250,11 +250,21 @@ class EconomicHighlightsSerializer(BaseDataMetadataSerializer):
 class UKFreeTradeAgreementSerializer(serializers.Serializer):
     def to_representation(self, instance):
         return instance.name
-    
+
+
 class BusinessClusterInformationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.EYBBusinessClusterInformation
-        fields = ['sic_code', 'sic_description', 'geo_code', 'geo_description', 'total_business_count', 'business_count_release_year', 'total_employee_count', 'employee_count_release_year', 'dbt_full_sector_name', 'dbt_sector_name']
-
-
+        fields = [
+            'sic_code',
+            'sic_description',
+            'geo_code',
+            'geo_description',
+            'total_business_count',
+            'business_count_release_year',
+            'total_employee_count',
+            'employee_count_release_year',
+            'dbt_full_sector_name',
+            'dbt_sector_name',
+        ]

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -250,3 +250,11 @@ class EconomicHighlightsSerializer(BaseDataMetadataSerializer):
 class UKFreeTradeAgreementSerializer(serializers.Serializer):
     def to_representation(self, instance):
         return instance.name
+    
+class BusinessClusterInformationSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.EYBBusinessClusterInformation
+        fields = ['sic_code', 'sic_description', 'geo_code', 'geo_description', 'total_business_count', 'business_count_release_year', 'total_employee_count', 'employee_count_release_year', 'dbt_full_sector_name', 'dbt_sector_name']
+
+

--- a/dataservices/tests/conftest.py
+++ b/dataservices/tests/conftest.py
@@ -247,3 +247,5 @@ def uk_trade_agreements_records(countries):
         models.UKFreeTradeAgreement.objects.create(country=countries[iso2], name=name)
     yield
     models.UKFreeTradeAgreement.objects.all().delete()
+
+    

--- a/dataservices/tests/conftest.py
+++ b/dataservices/tests/conftest.py
@@ -248,4 +248,73 @@ def uk_trade_agreements_records(countries):
     yield
     models.UKFreeTradeAgreement.objects.all().delete()
 
-    
+
+@pytest.fixture()
+def business_cluster_information_data():
+    records = [
+        {
+            'geo_description': 'England',
+            'geo_code': 'E92000001',
+            'sic_code': '95110',
+            'sic_description': 'Repair of computers and peripheral equipment',
+            'total_business_count': 4020,
+            'business_count_release_year': 2023,
+            'total_employee_count': 31000,
+            'employee_count_release_year': 2023,
+            'dbt_full_sector_name': 'Technology and smart cities : Hardware',
+            'dbt_sector_name': 'Technology and smart cities',
+        },
+        {
+            'geo_description': 'Northern Ireland',
+            'geo_code': 'N92000002',
+            'sic_code': '95110',
+            'sic_description': 'Repair of computers and peripheral equipment',
+            'total_business_count': 55,
+            'business_count_release_year': 2023,
+            'total_employee_count': None,
+            'employee_count_release_year': None,
+            'dbt_full_sector_name': 'Technology and smart cities : Hardware',
+            'dbt_sector_name': 'Technology and smart cities',
+        },
+        {
+            'geo_description': 'England',
+            'geo_code': 'E92000001',
+            'sic_code': '94990',
+            'sic_description': 'Activities of other membership organisations nec',
+            'total_business_count': 5700,
+            'business_count_release_year': 2023,
+            'total_employee_count': 99000,
+            'employee_count_release_year': 2023,
+            'dbt_full_sector_name': 'Financial and professional services',
+            'dbt_sector_name': 'Financial and professional services',
+        },
+        {
+            'geo_description': 'Yorkshire and The Humber',
+            'geo_code': 'E12000003',
+            'sic_code': 'L',
+            'sic_description': 'Real estate activities',
+            'total_business_count': 7625,
+            'business_count_release_year': 2022,
+            'total_employee_count': 33000,
+            'employee_count_release_year': 2021,
+            'dbt_full_sector_name': None,
+            'dbt_sector_name': None,
+        },
+        {
+            'geo_description': 'London',
+            'geo_code': 'E12000007',
+            'sic_code': '82',
+            'sic_description': 'Office administrative, office support and other business support activities',
+            'total_business_count': 26110,
+            'business_count_release_year': 2023,
+            'total_employee_count': 147000,
+            'employee_count_release_year': 2023,
+            'dbt_full_sector_name': None,
+            'dbt_sector_name': None,
+        },
+    ]
+
+    for record in records:
+        models.EYBBusinessClusterInformation.objects.create(**record)
+    yield
+    models.EYBBusinessClusterInformation.objects.all().delete()

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -747,3 +747,35 @@ class UKFreeTradeAgreementsView(generics.ListAPIView):
         res.data = {'data': res.data}
 
         return res
+    
+@extend_schema(
+    responses=OpenApiTypes.OBJECT,
+    examples=[
+        OpenApiExample(
+            'GET Request 200 Example',
+            value=[
+                { 
+                    'geo_description': 'England',
+                    'geo_code': 'E92000001',
+                    'sic_code': '95110',
+                    'sic_description': 'Repair of computers and peripheral equipment',
+                    'total_business_count': 4020,
+                    'business_count_release_year': 2023,
+                    'total_employee_count': 31000,
+                    'employee_count_release_year': 2023,
+                    'dbt_full_sector_name': 'Technology and smart cities : Hardware',
+                    'dbt_sector_name': 'Technology and smart cities'
+                }
+            ],
+            response_only=True,
+            status_codes=[200],
+        ),
+    ],
+    description='Business Cluster Information',
+    parameters=[OpenApiParameter(name='sic_code', description='SIC code', required=True, type=str), OpenApiParameter(name='geo_code', description='Geographic code', required=False, type=str)]
+)
+class BusinessClusterInformationView(generics.ListAPIView):
+    permission_classes = []
+    queryset = models.EYBBusinessClusterInformation.objects
+    serializer_class = serializers.BusinessClusterInformationSerializer
+    filterset_class = filters.BusinessClusterInformationFilter

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -747,14 +747,15 @@ class UKFreeTradeAgreementsView(generics.ListAPIView):
         res.data = {'data': res.data}
 
         return res
-    
+
+
 @extend_schema(
     responses=OpenApiTypes.OBJECT,
     examples=[
         OpenApiExample(
             'GET Request 200 Example',
             value=[
-                { 
+                {
                     'geo_description': 'England',
                     'geo_code': 'E92000001',
                     'sic_code': '95110',
@@ -764,7 +765,7 @@ class UKFreeTradeAgreementsView(generics.ListAPIView):
                     'total_employee_count': 31000,
                     'employee_count_release_year': 2023,
                     'dbt_full_sector_name': 'Technology and smart cities : Hardware',
-                    'dbt_sector_name': 'Technology and smart cities'
+                    'dbt_sector_name': 'Technology and smart cities',
                 }
             ],
             response_only=True,
@@ -772,7 +773,10 @@ class UKFreeTradeAgreementsView(generics.ListAPIView):
         ),
     ],
     description='Business Cluster Information',
-    parameters=[OpenApiParameter(name='sic_code', description='SIC code', required=True, type=str), OpenApiParameter(name='geo_code', description='Geographic code', required=False, type=str)]
+    parameters=[
+        OpenApiParameter(name='sic_code', description='SIC code', required=True, type=str),
+        OpenApiParameter(name='geo_code', description='Geographic code', required=False, type=str),
+    ],
 )
 class BusinessClusterInformationView(generics.ListAPIView):
     permission_classes = []


### PR DESCRIPTION
This changeset adds a GET API endpoint to expose Business Cluster Information. The endpoint can accept two parameters: 1) sic_code (required), 2) geo_code (optional). Where a geo_code is not supplied all regions for a given sic_code will be returned.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-1125
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- OpenAPI documentation
  1. Turn on feature flag - `FEATURE_OPENAPI_ENABLED=True`
  2. Navigate to http://localhost:8000/openapi/ui

- To test endpoint
  1. Hydrate database via the management command `make manage import_eyb_business_cluster_information`
  2. Visit http://localhost:8000/dataservices/business-cluster-information/?sic_code=95290

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
