### PR TITLE
Add a filter to the wipe command

### DIFF
--- a/dataservices/management/commands/import_comtrade_data.py
+++ b/dataservices/management/commands/import_comtrade_data.py
@@ -122,31 +122,30 @@ class Command(BaseDataWorkspaceIngestionCommand):
                 file_reader = csv.DictReader(f)
                 for row in file_reader:
                     read = read + 1
-                    if row.get('Is Leaf Code') == '1':
-                        reporter_iso3 = row.get('Reporter ISO')
-                        partner_iso3 = row.get('Partner ISO')
-                        flow = row.get('Trade Flow')
-                        uk_or_world = None
-                        country_iso3 = None
-                        if reporter_iso3 == 'GBR' and flow == 'Export':
-                            uk_or_world = reporter_iso3
-                            country_iso3 = partner_iso3
-                        if partner_iso3 == 'WLD' and flow == 'Import':
-                            uk_or_world = partner_iso3
-                            country_iso3 = reporter_iso3
-                        if country_iso3 and uk_or_world:
-                            written = written + 1
-                            report = ComtradeReport(
-                                country_iso3=country_iso3,
-                                year=row.get('Year'),
-                                classification=row.get('Classification'),
-                                commodity_code=row.get('Commodity Code'),
-                                trade_value=float(row.get('Trade Value (US$)') or '0'),
-                                uk_or_world=uk_or_world,
-                            )
-                            report.save()
-                            if written % 100 == 0:
-                                print(f'{read} read, {written} written', end='\r', flush=True)
+                    reporter_iso3 = row.get('Reporter ISO')
+                    partner_iso3 = row.get('Partner ISO')
+                    flow = row.get('Trade Flow')
+                    uk_or_world = None
+                    country_iso3 = None
+                    if reporter_iso3 == 'GBR' and flow == 'Export':
+                        uk_or_world = reporter_iso3
+                        country_iso3 = partner_iso3
+                    if partner_iso3 == 'WLD' and flow == 'Import':
+                        uk_or_world = partner_iso3
+                        country_iso3 = reporter_iso3
+                    if country_iso3 and uk_or_world:
+                        written = written + 1
+                        report = ComtradeReport(
+                            country_iso3=country_iso3,
+                            year=row.get('Year'),
+                            classification=row.get('Classification'),
+                            commodity_code=row.get('Commodity Code'),
+                            trade_value=float(row.get('Trade Value (US$)') or '0'),
+                            uk_or_world=uk_or_world,
+                        )
+                        report.save()
+                        if written % 100 == 0:
+                            print(f'{read} read, {written} written', end='\r', flush=True)
                 self.stdout.write(self.style.SUCCESS(f'{read} read, {written} written'))
 
     def link_countries(self):
@@ -200,7 +199,7 @@ class Command(BaseDataWorkspaceIngestionCommand):
         filenames = options['filenames']
         period = options.get('period')
         if options['wipe']:
-            ComtradeReport.objects.all().delete()
+            ComtradeReport.objects.filter(year=period).delete()
         elif options['link_countries']:
             self.link_countries()
         elif options['unlink_countries']:

--- a/dataservices/management/commands/tests/test_import_data.py
+++ b/dataservices/management/commands/tests/test_import_data.py
@@ -134,7 +134,7 @@ def test_import_raw_comtrade():
     assert data.first().uk_or_world == 'WLD'
     assert data[1].uk_or_world == 'GBR'
 
-    management.call_command('import_comtrade_data', '--wipe')
+    management.call_command('import_comtrade_data', '--wipe', '--period=2019')
     assert len(models.ComtradeReport.objects.all()) == 0
 
 


### PR DESCRIPTION
Data load for comtrade was loaded only half way , we need a way to wipe the half baked data.

_Tick or delete as appropriate:_

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: sigauth, django-staff-sso-client, directory-validators, directory-constants, directory-sso-api-client, directory-healthcheck, directory-forms-api-client, directory-components

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
