### PR TITLE
EYB-170 change vertical to primary lookup

### DIFF
--- a/dataservices/filters.py
+++ b/dataservices/filters.py
@@ -63,13 +63,13 @@ class BusinessClusterInformationByDBTSectorFilter(django_filters.rest_framework.
 
 
 class EYBSalaryFilter(django_filters.rest_framework.FilterSet):
-    geo_description = django_filters.CharFilter(field_name='geo_description', lookup_expr='iexact', required=True)
-    vertical = django_filters.CharFilter(field_name='vertical', lookup_expr='iexact')
+    vertical = django_filters.CharFilter(field_name='vertical', lookup_expr='iexact', required=True)
     professional_level = django_filters.CharFilter(field_name='professional_level', lookup_expr='iexact')
+    geo_description = django_filters.CharFilter(field_name='geo_description', lookup_expr='iexact')
 
     class Meta:
         model = models.EYBSalaryData
-        fields = ['geo_description', 'vertical', 'professional_level']
+        fields = ['vertical', 'professional_level', 'geo_description']
 
 
 class EYBCommercialRentDataFilter(django_filters.rest_framework.FilterSet):

--- a/dataservices/management/commands/import_comtrade_data.py
+++ b/dataservices/management/commands/import_comtrade_data.py
@@ -1,7 +1,7 @@
 import csv
+
 import pandas as pd
 import sqlalchemy as sa
-
 from django.conf import settings
 from django.db import connection
 

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -704,8 +704,8 @@ def test_dataservices_eyb_salary_data_api(client, eyb_salary_data, url, expected
 @pytest.mark.parametrize(
     "url",
     [
-        (f"{reverse('dataservices-eyb-salary-data')}?geo_description=abcd"),
-        (f"{reverse('dataservices-eyb-salary-data')}?geo_description=London&vertical=abcd"),
+        (f"{reverse('dataservices-eyb-salary-data')}?vertical=abcd"),
+        (f"{reverse('dataservices-eyb-salary-data')}?vertical=abcd&geo_description=London"),
     ],
 )
 @pytest.mark.django_db
@@ -722,8 +722,8 @@ def test_dataservices_eyb_salary_data_api_no_data(client, url):
 @pytest.mark.parametrize(
     "url",
     [
-        (f"{reverse('dataservices-eyb-salary-data')}?vertical=abcd"),
-        (f"{reverse('dataservices-eyb-salary-data')}?vertical=Consumer+and+Retail&professional_level=Entry-level"),
+        (f"{reverse('dataservices-eyb-salary-data')}?geo_description=London"),
+        (f"{reverse('dataservices-eyb-salary-data')}?geo_description=London&professional_level=Entry-level"),
     ],
 )
 @pytest.mark.django_db

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -913,15 +913,8 @@ class BusinessClusterInformationByDBTSectorView(generics.ListAPIView):
             status_codes=[200],
         ),
     ],
-    description='Median salary data by region and optionally, vertical and profession level',
+    description='Median salary data by vertical and optionally, professional level and geographic region',
     parameters=[
-        OpenApiParameter(
-            name='geo_description',
-            description='Geographic Region',
-            required=True,
-            type=str,
-            examples=[OpenApiExample('East Midlands', value='East Midlands')],
-        ),
         OpenApiParameter(
             name='vertical',
             description='Industry',
@@ -932,9 +925,16 @@ class BusinessClusterInformationByDBTSectorView(generics.ListAPIView):
         OpenApiParameter(
             name='professional_level',
             description='Professional level',
-            required=False,
+            required=True,
             type=str,
             examples=[OpenApiExample('Middle/Senior Management', value='Middle/Senior Management')],
+        ),
+        OpenApiParameter(
+            name='geo_description',
+            description='Geographic Region',
+            required=False,
+            type=str,
+            examples=[OpenApiExample('East Midlands', value='East Midlands')],
         ),
     ],
 )


### PR DESCRIPTION
This PR amends the GET Salary data endpoint so that the primary lookup is performed on the vertical (sector) attribute rather than the geographic description. This is to accommodate error messaging on the front-end whereby we first check if salary data exists for a given vertical and geographic region, if data does not exist we then make another request without the geographic region to check if there is salary data available for the sector in any location.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/EYB-170
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
