### PR TITLE
IGUK-177 helper function to align statista and internal vertical names

### DIFF
--- a/dataservices/management/commands/helpers.py
+++ b/dataservices/management/commands/helpers.py
@@ -152,3 +152,17 @@ class MarketGuidesDataIngestionCommand(BaseDataWorkspaceIngestionCommand):
             return None
         else:
             return view_data.data['source']['last_release']
+
+
+def align_vertical_names(statista_vertical_name: str) -> str:
+    """
+    Some vertical names used by statista do not map to the internal vertical names used in IGUK
+    """
+    mapping = {
+        'Technology & Smart Cities': 'Technology and Smart Cities',
+        'Pharmaceuticals and Biotech': 'Pharmaceuticals and biotechnology',
+        'Manufacture of medical and dental instruments and supplies': 'Medical devices and equipment',
+        'Automovie': 'Automotive',
+    }
+
+    return mapping[statista_vertical_name] if statista_vertical_name in mapping.keys() else statista_vertical_name

--- a/dataservices/management/commands/import_eyb_salary_data.py
+++ b/dataservices/management/commands/import_eyb_salary_data.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 
 from dataservices.models import EYBSalaryData
 
-from .helpers import BaseDataWorkspaceIngestionCommand
+from .helpers import BaseDataWorkspaceIngestionCommand, align_vertical_names
 
 
 class Command(BaseDataWorkspaceIngestionCommand):
@@ -38,7 +38,7 @@ class Command(BaseDataWorkspaceIngestionCommand):
                 data.append(
                     EYBSalaryData(
                         geo_description=row.geo_description.strip(),
-                        vertical=row.vertical.strip(),
+                        vertical=align_vertical_names(row.vertical.strip()),
                         professional_level=row.professional_level.strip(),
                         occupation=row.occupation.strip(),
                         soc_code=row.code,

--- a/dataservices/tests/test_helpers.py
+++ b/dataservices/tests/test_helpers.py
@@ -236,3 +236,19 @@ def test_send_review_request_message(mock_notify, last_release, notification_sen
         },
     )
     assert mock_notify.call_count == result
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'statista_vertical_name, expected_vertical_name',
+    [
+        ('Technology & Smart Cities', 'Technology and Smart Cities'),
+        ('Pharmaceuticals and Biotech', 'Pharmaceuticals and biotechnology'),
+        ('Manufacture of medical and dental instruments and supplies', 'Medical devices and equipment'),
+        ('Automovie', 'Automotive'),
+        ('Food and Drink', 'Food and Drink'),
+        ('Space', 'Space'),
+    ],
+)
+def test_align_vertical_names(statista_vertical_name, expected_vertical_name):
+    assert dmch.align_vertical_names(statista_vertical_name) == expected_vertical_name


### PR DESCRIPTION
A small subset of the vertical (sector/industry) names used in the Statista dataset do not align with the vertical names used internally in IGUK. This PR introduces a small helper function to address this.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-177
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
Refer to https://github.com/uktrade/directory-api/pull/1264 for local testing.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
