### PR TITLE
IGUK-179 - return latest GVA bandings

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -35,7 +35,6 @@ class PingDomView(TemplateView):
 
     @method_decorator(never_cache)
     def get(self, *args, **kwargs):
-
         checked = {}
         for service in health_check_services:
             checked[service.name] = service().check()

--- a/dataservices/filters.py
+++ b/dataservices/filters.py
@@ -80,11 +80,3 @@ class EYBCommercialRentDataFilter(django_filters.rest_framework.FilterSet):
     class Meta:
         model = models.EYBCommercialPropertyRent
         fields = ['geo_description', 'vertical', 'sub_vertical']
-
-
-class SectorGVAValueBandFilter(django_filters.rest_framework.FilterSet):
-    full_sector_name = django_filters.CharFilter(field_name='full_sector_name', lookup_expr='iexact', required=True)
-
-    class Meta:
-        model = models.SectorGVAValueBand
-        fields = ['full_sector_name']

--- a/dataservices/management/commands/helpers.py
+++ b/dataservices/management/commands/helpers.py
@@ -106,7 +106,6 @@ class BaseDataWorkspaceIngestionCommand(BaseCommand):
 
 
 class MarketGuidesDataIngestionCommand(BaseDataWorkspaceIngestionCommand):
-
     def should_ingestion_run(self, view_name, table_name):
         dataflow_metadata = self.get_dataflow_metadata(table_name)
         swapped_date = dataflow_metadata.loc[:, 'dataflow_swapped_tables_utc'][0].to_pydatetime().date()

--- a/dataservices/management/commands/import_dbt_investment_opportunities.py
+++ b/dataservices/management/commands/import_dbt_investment_opportunities.py
@@ -32,7 +32,6 @@ class Command(BaseDataWorkspaceIngestionCommand):
         chunks = pd.read_sql(sa.text(self.sql), self.engine, chunksize=5000)
 
         for chunk in chunks:
-
             for _idx, row in chunk.iterrows():
                 data.append(
                     DBTInvestmentOpportunity(

--- a/dataservices/management/commands/import_dbt_sectors.py
+++ b/dataservices/management/commands/import_dbt_sectors.py
@@ -29,7 +29,6 @@ class Command(BaseDataWorkspaceIngestionCommand):
         chunks = pd.read_sql(sa.text(self.sql), self.engine, chunksize=5000)
 
         for chunk in chunks:
-
             for _idx, row in chunk.iterrows():
                 data.append(
                     DBTSector(

--- a/dataservices/management/commands/import_eyb_salary_data.py
+++ b/dataservices/management/commands/import_eyb_salary_data.py
@@ -26,7 +26,6 @@ class Command(BaseDataWorkspaceIngestionCommand):
         chunks = pd.read_sql(sa.text(self.sql), self.engine, chunksize=5000)
 
         for chunk in chunks:
-
             # in the source data some of the salary columns contain 'x', ':' and so on. Also represented as strings
             chunk = chunk.replace(
                 to_replace={'mean_salary': r'[^0-9.]', 'median_salary': r'[^0-9.]'}, value='0', regex=True

--- a/dataservices/management/commands/import_sectors_gva_value_bands.py
+++ b/dataservices/management/commands/import_sectors_gva_value_bands.py
@@ -33,7 +33,6 @@ class Command(BaseDataWorkspaceIngestionCommand):
         chunks = pd.read_sql(sa.text(self.sql), self.engine, chunksize=5000)
 
         for chunk in chunks:
-
             for _idx, row in chunk.iterrows():
                 data.append(
                     SectorGVAValueBand(

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -253,7 +253,6 @@ class UKFreeTradeAgreementSerializer(serializers.Serializer):
 
 
 class BusinessClusterInformationSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.EYBBusinessClusterInformation
         fields = '__all__'
@@ -279,35 +278,30 @@ class BusinessClusterInformationAggregatedDataSerializer(serializers.ModelSerial
 
 
 class EYBSalaryDataSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.EYBSalaryData
         fields = ['geo_description', 'vertical', 'professional_level', 'median_salary', 'dataset_year']
 
 
 class EYBCommercialRentDataSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.EYBCommercialPropertyRent
         fields = '__all__'
 
 
 class DBTSectorSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.DBTSector
         fields = '__all__'
 
 
 class SectorGVAValueBandSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.SectorGVAValueBand
         fields = '__all__'
 
 
 class DBTInvestmentOpportunitySerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.DBTInvestmentOpportunity
         fields = '__all__'

--- a/dataservices/tests/conftest.py
+++ b/dataservices/tests/conftest.py
@@ -616,3 +616,52 @@ def eyb_rent_data():
         models.EYBCommercialPropertyRent.objects.create(**record)
     yield
     models.EYBCommercialPropertyRent.objects.all().delete()
+
+@pytest.fixture
+def gva_bandings():
+    records=[
+        {
+            "id" : 1,
+            "full_sector_name" : "Aerospace",
+            "value_band_a_minimum" : 10000,
+            "value_band_b_minimum" : 1000,
+            "value_band_c_minimum" : 100,
+            "value_band_d_minimum" : 10,
+            "value_band_e_minimum" : 1,
+            "start_date" : "2020-04-01",
+            "end_date" : "2021-03-31",
+            "sector_classification_value_band" : "classification band",
+            "sector_classification_gva_multiplier" : "classification band"
+        },
+        {
+            "id" : 2,
+            "full_sector_name" : "Aerospace",
+            "value_band_a_minimum" : 20000,
+            "value_band_b_minimum" : 2000,
+            "value_band_c_minimum" : 200,
+            "value_band_d_minimum" : 20,
+            "value_band_e_minimum" : 2,
+            "start_date" : "2024-04-01",
+            "end_date" : "2025-03-31",
+            "sector_classification_value_band" : "classification band",
+            "sector_classification_gva_multiplier" : "classification band"
+        },
+        {
+            "id" : 3,
+            "full_sector_name" : "Aerospace",
+            "value_band_a_minimum" : 30000,
+            "value_band_b_minimum" : 3000,
+            "value_band_c_minimum" : 300,
+            "value_band_d_minimum" : 30,
+            "value_band_e_minimum" : 3,
+            "start_date" : "2022-04-01",
+            "end_date" : "2023-03-31",
+            "sector_classification_value_band" : "classification band",
+            "sector_classification_gva_multiplier" : "classification band"
+        }
+    ]
+
+    for record in records:
+        models.SectorGVAValueBand.objects.create(**record)
+    yield
+    models.EYBCommercialPropertyRent.objects.all().delete()

--- a/dataservices/tests/conftest.py
+++ b/dataservices/tests/conftest.py
@@ -617,48 +617,49 @@ def eyb_rent_data():
     yield
     models.EYBCommercialPropertyRent.objects.all().delete()
 
+
 @pytest.fixture
 def gva_bandings():
-    records=[
+    records = [
         {
-            "id" : 1,
-            "full_sector_name" : "Aerospace",
-            "value_band_a_minimum" : 10000,
-            "value_band_b_minimum" : 1000,
-            "value_band_c_minimum" : 100,
-            "value_band_d_minimum" : 10,
-            "value_band_e_minimum" : 1,
-            "start_date" : "2020-04-01",
-            "end_date" : "2021-03-31",
-            "sector_classification_value_band" : "classification band",
-            "sector_classification_gva_multiplier" : "classification band"
+            "id": 1,
+            "full_sector_name": "Aerospace",
+            "value_band_a_minimum": 10000,
+            "value_band_b_minimum": 1000,
+            "value_band_c_minimum": 100,
+            "value_band_d_minimum": 10,
+            "value_band_e_minimum": 1,
+            "start_date": "2020-04-01",
+            "end_date": "2021-03-31",
+            "sector_classification_value_band": "classification band",
+            "sector_classification_gva_multiplier": "classification band",
         },
         {
-            "id" : 2,
-            "full_sector_name" : "Aerospace",
-            "value_band_a_minimum" : 20000,
-            "value_band_b_minimum" : 2000,
-            "value_band_c_minimum" : 200,
-            "value_band_d_minimum" : 20,
-            "value_band_e_minimum" : 2,
-            "start_date" : "2024-04-01",
-            "end_date" : "2025-03-31",
-            "sector_classification_value_band" : "classification band",
-            "sector_classification_gva_multiplier" : "classification band"
+            "id": 2,
+            "full_sector_name": "Aerospace",
+            "value_band_a_minimum": 20000,
+            "value_band_b_minimum": 2000,
+            "value_band_c_minimum": 200,
+            "value_band_d_minimum": 20,
+            "value_band_e_minimum": 2,
+            "start_date": "2024-04-01",
+            "end_date": "2025-03-31",
+            "sector_classification_value_band": "classification band",
+            "sector_classification_gva_multiplier": "classification band",
         },
         {
-            "id" : 3,
-            "full_sector_name" : "Aerospace",
-            "value_band_a_minimum" : 30000,
-            "value_band_b_minimum" : 3000,
-            "value_band_c_minimum" : 300,
-            "value_band_d_minimum" : 30,
-            "value_band_e_minimum" : 3,
-            "start_date" : "2022-04-01",
-            "end_date" : "2023-03-31",
-            "sector_classification_value_band" : "classification band",
-            "sector_classification_gva_multiplier" : "classification band"
-        }
+            "id": 3,
+            "full_sector_name": "Aerospace",
+            "value_band_a_minimum": 30000,
+            "value_band_b_minimum": 3000,
+            "value_band_c_minimum": 300,
+            "value_band_d_minimum": 30,
+            "value_band_e_minimum": 3,
+            "start_date": "2022-04-01",
+            "end_date": "2023-03-31",
+            "sector_classification_value_band": "classification band",
+            "sector_classification_gva_multiplier": "classification band",
+        },
     ]
 
     for record in records:

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -795,6 +795,7 @@ def test_dataservices_eyb_commercial_rent_api_missing_query_param(client, url):
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+
 @pytest.mark.django_db
 def test_dataservices_sector_gva_bandings_view(gva_bandings, client):
     response = client.get(f"{reverse('dataservices-sector-gva-value-band')}?full_sector_name=aerospace")

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -794,3 +794,15 @@ def test_dataservices_eyb_commercial_rent_api_missing_query_param(client, url):
     response = client.get(url)
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+@pytest.mark.django_db
+def test_dataservices_sector_gva_bandings_view(gva_bandings, client):
+    response = client.get(f"{reverse('dataservices-sector-gva-value-band')}?full_sector_name=aerospace")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    api_data = json.loads(response.content)
+
+    assert len(api_data) == 1
+    # id:2 is the most recent record
+    assert api_data[0]['id'] == 2

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -1068,11 +1068,49 @@ class DBTSectorsView(generics.ListAPIView):
     queryset = models.DBTSector.objects.all()
 
 
+@extend_schema(
+    responses=OpenApiTypes.OBJECT,
+    examples=[
+        OpenApiExample(
+            'GET Request 200 Example',
+            value=[
+                    {
+                        "id" : 1,
+                        "full_sector_name" : "Aerospace",
+                        "value_band_a_minimum" : 10000,
+                        "value_band_b_minimum" : 1000,
+                        "value_band_c_minimum" : 100,
+                        "value_band_d_minimum" : 10,
+                        "value_band_e_minimum" : 1,
+                        "start_date" : "2024-04-01",
+                        "end_date" : "2026-03-31",
+                        "sector_classification_value_band" : "classification band",
+                        "sector_classification_gva_multiplier" : "classification band"
+                    }
+                ],
+            response_only=True,
+            status_codes=[200],
+        ),
+    ],
+    description='Gross Value Add classifications per sector',
+    parameters=[
+        OpenApiParameter(
+            name='full_sector_name',
+            description='Full sector name',
+            required=True,
+            type=str,
+            examples=[OpenApiExample('Aerospace', value='Aerospace')],
+        ),
+    ],
+)
 class SectorGVAValueBandView(generics.ListAPIView):
     permission_classes = []
     serializer_class = serializers.SectorGVAValueBandSerializer
-    filterset_class = filters.SectorGVAValueBandFilter
-    queryset = models.SectorGVAValueBand.objects.all()
+    
+    def get_queryset(self):
+        full_sector_name = self.request.query_params.get('full_sector_name', '')
+        # return the most recent GVA banding for the sector
+        return models.SectorGVAValueBand.objects.filter(full_sector_name__iexact=full_sector_name).order_by('-start_date')[:1]
 
 
 class DBTInvestmentOpportunityView(generics.ListAPIView):

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -1074,20 +1074,20 @@ class DBTSectorsView(generics.ListAPIView):
         OpenApiExample(
             'GET Request 200 Example',
             value=[
-                    {
-                        "id" : 1,
-                        "full_sector_name" : "Aerospace",
-                        "value_band_a_minimum" : 10000,
-                        "value_band_b_minimum" : 1000,
-                        "value_band_c_minimum" : 100,
-                        "value_band_d_minimum" : 10,
-                        "value_band_e_minimum" : 1,
-                        "start_date" : "2024-04-01",
-                        "end_date" : "2026-03-31",
-                        "sector_classification_value_band" : "classification band",
-                        "sector_classification_gva_multiplier" : "classification band"
-                    }
-                ],
+                {
+                    "id": 1,
+                    "full_sector_name": "Aerospace",
+                    "value_band_a_minimum": 10000,
+                    "value_band_b_minimum": 1000,
+                    "value_band_c_minimum": 100,
+                    "value_band_d_minimum": 10,
+                    "value_band_e_minimum": 1,
+                    "start_date": "2024-04-01",
+                    "end_date": "2026-03-31",
+                    "sector_classification_value_band": "classification band",
+                    "sector_classification_gva_multiplier": "classification band",
+                }
+            ],
             response_only=True,
             status_codes=[200],
         ),
@@ -1106,11 +1106,13 @@ class DBTSectorsView(generics.ListAPIView):
 class SectorGVAValueBandView(generics.ListAPIView):
     permission_classes = []
     serializer_class = serializers.SectorGVAValueBandSerializer
-    
+
     def get_queryset(self):
         full_sector_name = self.request.query_params.get('full_sector_name', '')
         # return the most recent GVA banding for the sector
-        return models.SectorGVAValueBand.objects.filter(full_sector_name__iexact=full_sector_name).order_by('-start_date')[:1]
+        return models.SectorGVAValueBand.objects.filter(full_sector_name__iexact=full_sector_name).order_by(
+            '-start_date'
+        )[:1]
 
 
 class DBTInvestmentOpportunityView(generics.ListAPIView):


### PR DESCRIPTION
This PR introduces a slight modification to the GET Gross Value Add (GVA) bandings endpoint (dataservices/sector-gva-value-band/) by ordering the queryset by start date and returning the first item. This is to ensure that only the latest GVA banding is returned. Additionally, OpenAPI documentation was added to the endpoint along with a unit test.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-179
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
1. Add data to the `dataservices_sectorgvavalueband` table
2. Call `curl -L 'http://api.trade.great:8000/dataservices/sector-gva-value-band?full_sector_name=aerospace'`

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
