### PR TITLE
IGUK-220 all sectors GVA endpoint

### DIFF
--- a/company/management/commands/elasticsearch_migrate.py
+++ b/company/management/commands/elasticsearch_migrate.py
@@ -2,8 +2,8 @@ from django.conf import settings
 from django.core import management
 from django.db.models import Q
 from django.utils.crypto import get_random_string
-from opensearchpy.helpers import bulk
 from opensearch_dsl.connections import connections
+from opensearchpy.helpers import bulk
 
 from company import documents, models
 

--- a/company/tests/test_views.py
+++ b/company/tests/test_views.py
@@ -11,9 +11,9 @@ from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 from django.urls import reverse
+from freezegun import freeze_time
 from opensearch_dsl import Index
 from opensearch_dsl.connections import connections
-from freezegun import freeze_time
 from PIL import Image
 from rest_framework import status
 from rest_framework.test import APIClient

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -548,6 +548,7 @@ SIGAUTH_URL_NAMES_WHITELIST = [
     'dataservices-eyb-commercial-rent-data',
     'dataservices-dbt-sector',
     'dataservices-sector-gva-value-band',
+    'dataservices-all-sectors-gva-value-bands',
     'dataservices-dbt-investment-opportunity',
     'enrolment-preverified',
     'enrolment-claim-preverified',

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -343,6 +343,11 @@ urlpatterns = [
         name='dataservices-sector-gva-value-band',
     ),
     re_path(
+        r'^dataservices/all-sectors-gva-value-bands/$',
+        dataservices.views.AllSectorsGVAValueBandsView.as_view(),
+        name='dataservices-all-sectors-gva-value-bands',
+    ),
+    re_path(
         r'^dataservices/dbt-investment-opportunity/$',
         dataservices.views.DBTInvestmentOpportunityView.as_view(),
         name='dataservices-dbt-investment-opportunity',

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -300,7 +300,6 @@ class SectorGVAValueBandSerializer(serializers.ModelSerializer):
         model = models.SectorGVAValueBand
         fields = '__all__'
 
-
 class DBTInvestmentOpportunitySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.DBTInvestmentOpportunity

--- a/dataservices/serializers.py
+++ b/dataservices/serializers.py
@@ -300,6 +300,7 @@ class SectorGVAValueBandSerializer(serializers.ModelSerializer):
         model = models.SectorGVAValueBand
         fields = '__all__'
 
+
 class DBTInvestmentOpportunitySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.DBTInvestmentOpportunity

--- a/dataservices/tests/conftest.py
+++ b/dataservices/tests/conftest.py
@@ -660,9 +660,48 @@ def gva_bandings():
             "sector_classification_value_band": "classification band",
             "sector_classification_gva_multiplier": "classification band",
         },
+        {
+            "id": 4,
+            "full_sector_name": "Technology and smart cities : Software : Blockchain",
+            "value_band_a_minimum": 40000,
+            "value_band_b_minimum": 4000,
+            "value_band_c_minimum": 400,
+            "value_band_d_minimum": 40,
+            "value_band_e_minimum": 4,
+            "start_date": "2020-04-01",
+            "end_date": "2021-03-31",
+            "sector_classification_value_band": "classification band",
+            "sector_classification_gva_multiplier": "classification band",
+        },
+        {
+            "id": 5,
+            "full_sector_name": "Technology and smart cities : Software : Blockchain",
+            "value_band_a_minimum": 50000,
+            "value_band_b_minimum": 5000,
+            "value_band_c_minimum": 500,
+            "value_band_d_minimum": 50,
+            "value_band_e_minimum": 5,
+            "start_date": "2021-04-01",
+            "end_date": "2022-03-31",
+            "sector_classification_value_band": "classification band",
+            "sector_classification_gva_multiplier": "classification band",
+        },
+        {
+            "id": 6,
+            "full_sector_name": "Technology and smart cities : Software : Blockchain",
+            "value_band_a_minimum": 60000,
+            "value_band_b_minimum": 6000,
+            "value_band_c_minimum": 600,
+            "value_band_d_minimum": 60,
+            "value_band_e_minimum": 6,
+            "start_date": "2023-04-01",
+            "end_date": "2025-03-31",
+            "sector_classification_value_band": "classification band",
+            "sector_classification_gva_multiplier": "classification band",
+        },
     ]
 
     for record in records:
         models.SectorGVAValueBand.objects.create(**record)
     yield
-    models.EYBCommercialPropertyRent.objects.all().delete()
+    models.SectorGVAValueBand.objects.all().delete()

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -807,3 +807,43 @@ def test_dataservices_sector_gva_bandings_view(gva_bandings, client):
     assert len(api_data) == 1
     # id:2 is the most recent record
     assert api_data[0]['id'] == 2
+
+
+@pytest.mark.django_db
+def test_dataservices_all_sectors_gva_bandings_view(gva_bandings, client):
+    response = client.get(f"{reverse('dataservices-all-sectors-gva-value-bands')}")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    api_data = json.loads(response.content)
+
+    assert list(api_data.keys()) == ['Aerospace', 'Technology and smart cities : Software : Blockchain']
+
+    # only the GVA with the most recent start date is returned for each sector
+    assert api_data['Aerospace'] == {
+        'id': 2,
+        'full_sector_name': 'Aerospace',
+        'value_band_a_minimum': 20000,
+        'value_band_b_minimum': 2000,
+        'value_band_c_minimum': 200,
+        'value_band_d_minimum': 20,
+        'value_band_e_minimum': 2,
+        'start_date': '2024-04-01',
+        'end_date': '2025-03-31',
+        'sector_classification_value_band': 'classification band',
+        'sector_classification_gva_multiplier': 'classification band',
+    }
+
+    assert api_data['Technology and smart cities : Software : Blockchain'] == {
+        'id': 6,
+        'full_sector_name': 'Technology and smart cities : Software : Blockchain',
+        'value_band_a_minimum': 60000,
+        'value_band_b_minimum': 6000,
+        'value_band_c_minimum': 600,
+        'value_band_d_minimum': 60,
+        'value_band_e_minimum': 6,
+        'start_date': '2023-04-01',
+        'end_date': '2025-03-31',
+        'sector_classification_value_band': 'classification band',
+        'sector_classification_gva_multiplier': 'classification band',
+    }

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -1114,15 +1114,16 @@ class SectorGVAValueBandView(generics.ListAPIView):
             '-start_date'
         )[:1]
 
+
 @extend_schema(
     responses=OpenApiTypes.OBJECT,
     examples=[
         OpenApiExample(
             'GET Request 200 Example',
-            value=[
-                {
+            value={
+                'Aerospace : Aircraft design': {
                     "id": 1,
-                    "full_sector_name": "Aerospace",
+                    "full_sector_name": "Aerospace : Aircraft design",
                     "value_band_a_minimum": 10000,
                     "value_band_b_minimum": 1000,
                     "value_band_c_minimum": 100,
@@ -1132,42 +1133,44 @@ class SectorGVAValueBandView(generics.ListAPIView):
                     "end_date": "2026-03-31",
                     "sector_classification_value_band": "classification band",
                     "sector_classification_gva_multiplier": "classification band",
-                }
-            ],
+                },
+                'Aerospace : Component manufacturing': {
+                    "id": 2,
+                    "full_sector_name": "Aerospace : Component manufacturing",
+                    "value_band_a_minimum": 20000,
+                    "value_band_b_minimum": 2000,
+                    "value_band_c_minimum": 200,
+                    "value_band_d_minimum": 20,
+                    "value_band_e_minimum": 2,
+                    "start_date": "2024-04-01",
+                    "end_date": "2026-03-31",
+                    "sector_classification_value_band": "classification band",
+                    "sector_classification_gva_multiplier": "classification band",
+                },
+            },
             response_only=True,
             status_codes=[200],
         ),
     ],
-    description='Gross Value Add classifications per sector',
-    parameters=[
-        OpenApiParameter(
-            name='full_sector_name',
-            description='Full sector name',
-            required=True,
-            type=str,
-            examples=[OpenApiExample('Aerospace', value='Aerospace')],
-        ),
-    ],
+    description='Gross Value Add classifications for all sectors',
 )
 class AllSectorsGVAValueBandsView(generics.ListAPIView):
     permission_classes = []
     serializer_class = serializers.SectorGVAValueBandSerializer
     # each full sector name may have multiple rows with different start dates, choose the latest
-    queryset = models.SectorGVAValueBand.objects.all().order_by('full_sector_name', '-start_date').distinct('full_sector_name')
+    queryset = (
+        models.SectorGVAValueBand.objects.all().order_by('full_sector_name', '-start_date').distinct('full_sector_name')
+    )
 
     def list(self, request, *args, **kwargs):
         response = super().list(request, *args, **kwargs)
-        # shape the result set so that front-end can access relevant GVA data by using user's sector as dictionary key
-        # as opposed to looping through an array to find GVA
-        response.data = {
-            row['full_sector_name']: {
-                **row
-            } for row in response.data
-        }
+        # shape the result set so that the consumer can access relevant GVA data by using user's sector as
+        # dictionary key as opposed to looping through an array to find GVA
+        response.data = {row['full_sector_name']: {**row} for row in response.data}
         return response
+
 
 class DBTInvestmentOpportunityView(generics.ListAPIView):
     permission_classes = []
     serializer_class = serializers.DBTInvestmentOpportunitySerializer
     queryset = models.SectorGVAValueBand.objects.all()
-

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -1114,8 +1114,60 @@ class SectorGVAValueBandView(generics.ListAPIView):
             '-start_date'
         )[:1]
 
+@extend_schema(
+    responses=OpenApiTypes.OBJECT,
+    examples=[
+        OpenApiExample(
+            'GET Request 200 Example',
+            value=[
+                {
+                    "id": 1,
+                    "full_sector_name": "Aerospace",
+                    "value_band_a_minimum": 10000,
+                    "value_band_b_minimum": 1000,
+                    "value_band_c_minimum": 100,
+                    "value_band_d_minimum": 10,
+                    "value_band_e_minimum": 1,
+                    "start_date": "2024-04-01",
+                    "end_date": "2026-03-31",
+                    "sector_classification_value_band": "classification band",
+                    "sector_classification_gva_multiplier": "classification band",
+                }
+            ],
+            response_only=True,
+            status_codes=[200],
+        ),
+    ],
+    description='Gross Value Add classifications per sector',
+    parameters=[
+        OpenApiParameter(
+            name='full_sector_name',
+            description='Full sector name',
+            required=True,
+            type=str,
+            examples=[OpenApiExample('Aerospace', value='Aerospace')],
+        ),
+    ],
+)
+class AllSectorsGVAValueBandsView(generics.ListAPIView):
+    permission_classes = []
+    serializer_class = serializers.SectorGVAValueBandSerializer
+    # each full sector name may have multiple rows with different start dates, choose the latest
+    queryset = models.SectorGVAValueBand.objects.all().order_by('full_sector_name', '-start_date').distinct('full_sector_name')
+
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+        # shape the result set so that front-end can access relevant GVA data by using user's sector as dictionary key
+        # as opposed to looping through an array to find GVA
+        response.data = {
+            row['full_sector_name']: {
+                **row
+            } for row in response.data
+        }
+        return response
 
 class DBTInvestmentOpportunityView(generics.ListAPIView):
     permission_classes = []
     serializer_class = serializers.DBTInvestmentOpportunitySerializer
     queryset = models.SectorGVAValueBand.objects.all()
+

--- a/healthcheck/backends.py
+++ b/healthcheck/backends.py
@@ -1,6 +1,6 @@
-from opensearch_dsl.connections import connections
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
+from opensearch_dsl.connections import connections
 
 
 class ElasticSearchCheckBackend(BaseHealthCheckBackend):


### PR DESCRIPTION
This PR adds an endpoint to retrieve the latest GVA bandings for all sectors. It is necessary as there is a requirement to perform bulk re-scoring periodically in great-cms. The addition of this endpoint ensures that the API does not need to be called in rapid succession for every sector.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-220
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
* Hydrate local copy of DB Table `dataservices_sectorgvavalueband` with data
* Start directory-api
* Make a `GET` request to `dataservices/all-sectors-gva-value-bands`

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
