### PR TITLE
downgrade waitress

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -52,7 +52,7 @@ sigauth==5.3.0
 sqlalchemy==1.4.36
 sqlparse==0.5.0
 urllib3==1.26.19
-waitress==3.0.1
+waitress==2.1.2
 whitenoise==6.4.0
 xhtml2pdf==0.2.11
 xmltodict==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -473,7 +473,7 @@ virtualenv==20.26.1
     # via pre-commit
 w3lib==1.22.0
     # via directory-client-core
-waitress==3.0.1
+waitress==2.1.2
     # via -r requirements.in
 wcwidth==0.2.13
     # via prompt-toolkit

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -563,7 +563,7 @@ virtualenv==20.26.1
     # via pre-commit
 w3lib==1.22.0
     # via directory-client-core
-waitress==3.0.1
+waitress==2.1.2
     # via -r requirements.in
 wcwidth==0.2.13
     # via prompt-toolkit


### PR DESCRIPTION
Recent waitress upgrade from 2.1.2 to 3.0.1 is causing authentication issues with activity stream endpoints. Downgrading to 2.1.2 until it can be properly investigated.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [x] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: sigauth, django-staff-sso-client, directory-validators, directory-constants, directory-sso-api-client, directory-healthcheck, directory-forms-api-client, directory-components

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
