### PR TITLE
New doc string and order_by method in contrade helper

### DIFF
--- a/dataservices/helpers.py
+++ b/dataservices/helpers.py
@@ -28,9 +28,13 @@ class TTLCache:
 
 
 def get_comtrade_data_by_country(commodity_code, country_list):
+    '''
+    Comtrade data is ingested annually. The trade_value is cumulative so we
+    should always report the highest figure for the most recent year
+    '''
     data = {}
     qs = models.ComtradeReport.objects.filter(country__iso2__in=country_list, commodity_code=commodity_code).order_by(
-        '-year'
+        '-trade_value'
     )
     for record in qs:
         iso_code = record.country.iso2


### PR DESCRIPTION
## What
Comtrade data is cumulative and we should ALWAYS report the highest trade_value in our data tables
## Why
This change will guarantee that the highest value will be the first item found in the array.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1479
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
