### PR TITLE
Fixed redis_url issue DBT Platform

### DIFF
--- a/conf/env.py
+++ b/conf/env.py
@@ -253,7 +253,7 @@ class DBTPlatformEnvironment(BaseSettings):
     e.g. DBTPlatformEnvironment.app_environment loads and validates the APP_ENVIRONMENT environment variable.
     """
 
-    celery_broker_url: str = ''
+    redis_endpoint: str = ''
     opensearch_url: str
 
     @computed_field(return_type=list[str])
@@ -270,7 +270,7 @@ class DBTPlatformEnvironment(BaseSettings):
     @computed_field(return_type=str)
     @property
     def redis_url(self):
-        return self.celery_broker_url
+        return self.redis_endpoint
 
     @computed_field(return_type=dict)
     @property

--- a/conf/tests/test_env.py
+++ b/conf/tests/test_env.py
@@ -164,7 +164,7 @@ def test_dbt_platform_environment(database_credentials, environment):
     os.environ['APP_ENVIRONMENT'] = 'local'
     os.environ['COPILOT_ENVIRONMENT_NAME'] = 'test'
     os.environ['DATABASE_CREDENTIALS'] = database_credentials
-    os.environ['CELERY_BROKER_URL'] = 'rediss://examplepassword@example.com:6379'
+    os.environ['REDIS_ENDPOINT'] = 'rediss://examplepassword@example.com:6379'
     os.environ['OPENSEARCH_URL'] = 'https://exampleuser:examplepassword@example.com:19676'
 
     reload(environment_reader)


### PR DESCRIPTION
## What
Set redis_url correctly for DBT platform environment
## Why
redis_url should use REDIS_ENDPOINT

_Tick or delete as appropriate:_

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1488
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: sigauth, django-staff-sso-client, directory-validators, directory-constants, directory-sso-api-client, directory-healthcheck, directory-forms-api-client, directory-components

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
