### PR TITLE
chore: bump Django to 4.2.19

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 dbt-copilot-python==0.2.1
-django==4.2.17
+django==4.2.19
 django-celery-beat==2.5.0
 django-cleanup==8.1.0
 django-clearcache>=1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ distlib==0.3.8
     # via virtualenv
 dj-database-url==2.1.0
     # via -r requirements.in
-django==4.2.17
+django==4.2.19
     # via
     #   -r requirements.in
     #   directory-client-core

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -125,7 +125,7 @@ distlib==0.3.8
     # via virtualenv
 dj-database-url==2.1.0
     # via -r requirements.in
-django==4.2.17
+django==4.2.19
     # via
     #   -r requirements.in
     #   directory-client-core


### PR DESCRIPTION
This ticket upgrades Django to 4.2.9

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1637
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: sigauth, django-staff-sso-client, directory-validators, directory-constants, directory-sso-api-client, directory-healthcheck, directory-forms-api-client, directory-components

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
