### PR TITLE
BGST-169 add news content endpoint

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -553,6 +553,7 @@ SIGAUTH_URL_NAMES_WHITELIST = [
     'dataservices-dbt-investment-opportunity',
     'dataservices-countries-territories-regions',
     'dataservices-country-territory-region',
+    'dataservices-news-content',
     'enrolment-preverified',
     'enrolment-claim-preverified',
     'offices-by-postcode',

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -357,6 +357,9 @@ urlpatterns = [
         dataservices.views.CountryTerritoryRegionView.as_view(),
         name='dataservices-country-territory-region',
     ),
+    re_path(
+        r'^dataservices/news-content/$', dataservices.views.NewsContent.as_view(), name='dataservices-news-content'
+    ),
     re_path(r'^testapi/buyer/(?P<email>.*)/$', testapi.views.BuyerTestAPIView.as_view(), name='buyer_by_email'),
     re_path(r'^testapi/test-buyers/$', testapi.views.BuyerTestAPIView.as_view(), name='delete_test_buyers'),
     re_path(

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from conf import settings
+from core.tests.helpers import create_response
 from dataservices import models
 from dataservices.tests import factories
 
@@ -881,3 +882,46 @@ def test_dataservices_country_territory_region(iso2_code, expected_id, countries
     api_data = json.loads(response.content)
 
     assert api_data['id'] == expected_id
+
+
+@mock.patch(
+    'dataservices.views.requests.get',
+    return_value=create_response(
+        {
+            'details': {
+                'ordered_featured_documents': [
+                    {
+                        "document_type": "Press release",
+                        "href": "/government/news/employment-rights-bill-to-boost-productivity",
+                        "image": {
+                            "alt_text": "",
+                            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/67c7ab48866e12.png",
+                            "medium_resolution_url": "https://assets.publishing.service.gov.uk/media/67c71ee866.png",  # noqa: E501 # /PS-IGNORE
+                            "url": "https://assets.publishing.service.gov.uk/media/67c71a39a0f0c95a498d22.png",  # noqa: E501 # /PS-IGNORE
+                        },
+                        "public_updated_at": "2025-03-04T12:07:17.000+00:00",
+                        "summary": "The Government will today table amendments to the Employment Rights Bill.\n",
+                        "title": "Employment Rights Bill to boost productivity for British workers",
+                    },
+                    {
+                        "document_type": "Press release",
+                        "href": "/government/news/talks-relaunch-on-india-trade-deal-to-boost-uks-growth-agenda",
+                        "image": {
+                            "alt_text": "Jonathan Reynolds and Piyush Goyal in Delhi",
+                            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/67b63e782d.png",
+                            "medium_resolution_url": "https://assets.publishing.service.gov.uk/media/67b313f.png",
+                            "url": "https://assets.publishing.service.gov.uk/media/67bcb5a598ea2db44fadddd_.png",  # noqa: E501 # /PS-IGNORE
+                        },
+                        "public_updated_at": "2025-02-23T00:00:00.000+00:00",
+                        "summary": "UK-India free trade talks are being relaunched.\n",
+                        "title": "Talks relaunch on India trade deal to boost UK’s growth agenda",
+                    },
+                ]
+            }
+        },
+    ),
+)
+@pytest.mark.django_db
+def test_dataservices_news_content(mock_news, client):
+    response = client.get(reverse('dataservices-news-content'))
+    assert len(response.json()) == 2


### PR DESCRIPTION
## What
Adds an endpoint that surfaces DBT news items that appear on https://www.gov.uk/government/organisations/department-for-business-and-trade
The response of the GET method is cached for one hour as the news items change infrequently.

## Why
Part of the UI design for Business Growth Service.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/BGST-169
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
1. Pull this branch
2. Visit `http://api.trade.great:8000/dataservices/news-content` in browser
3. An array of news items should be displayed

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
