### PR TITLE
Feature greatuk 1731 add guard against obsfucate in prod

### DIFF
--- a/company/management/commands/obsfucate_personal_details.py
+++ b/company/management/commands/obsfucate_personal_details.py
@@ -1,5 +1,6 @@
 import argparse
 
+from django.conf import settings
 from django.core.management import BaseCommand
 
 from company.models import CompanyUser
@@ -54,6 +55,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):  # noqa: C901
+
+        if settings.APP_ENVIRONMENT.lower() == 'production':
+            self.stdout.write(self.style.WARNING('Running in Production environment is disabled - exiting'))
+            return
 
         # Obsfucate CompanyUser Data
         for companty_user in CompanyUser.objects.all():

--- a/company/tests/test_tasks.py
+++ b/company/tests/test_tasks.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from django.test import override_settings
 
 from company import tasks
 from company.tests.factories import CompanyUserFactory
@@ -20,9 +21,20 @@ def test_suppliers_csv_upload(mocked_call_command):
     mocked_call_command.assert_called_once_with('generate_company_users_csv_dump')
 
 
+@override_settings(APP_ENVIRONMENT='dev')
 @mock.patch('company.management.commands.obsfucate_personal_details.Command.mask_company_user')
 @pytest.mark.django_db
-def test_obsfucate_personal_details(mock_mask_company_user):
+def test_obsfucate_personal_details_lower_env(mock_mask_company_user):
     CompanyUserFactory()
     tasks.obsfucate_personal_details()
     assert mock_mask_company_user.call_count == 1
+
+
+@override_settings(APP_ENVIRONMENT='production')
+@mock.patch('company.management.commands.obsfucate_personal_details.Command.mask_company_user')
+@pytest.mark.django_db
+def test_obsfucate_personal_details_prod_env(mock_mask_company_user):
+    CompanyUserFactory()
+    tasks.obsfucate_personal_details()
+    assert mock_mask_company_user.call_count == 0
+

--- a/company/tests/test_tasks.py
+++ b/company/tests/test_tasks.py
@@ -37,4 +37,3 @@ def test_obsfucate_personal_details_prod_env(mock_mask_company_user):
     CompanyUserFactory()
     tasks.obsfucate_personal_details()
     assert mock_mask_company_user.call_count == 0
-


### PR DESCRIPTION
## What
Guard against running Obsfucate in Prod env
## Why
Would be disastrous

_Tick or delete as appropriate:_

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1731
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: sigauth, django-staff-sso-client, directory-validators, directory-constants, directory-sso-api-client, directory-healthcheck, directory-forms-api-client, directory-components

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
