### PR TITLE
update handling of postcode io response

### DIFF
--- a/dataservices/helpers.py
+++ b/dataservices/helpers.py
@@ -145,7 +145,6 @@ def get_multiple_serialized_instance_from_model(model_class, serializer_class, f
 
 def get_postcode_data(postcode):
     response = requests.get(f'https://api.postcodes.io/postcodes/{postcode}', timeout=4)
-    response.raise_for_status()
     data = response.json()
     return data
 

--- a/dataservices/tests/test_views.py
+++ b/dataservices/tests/test_views.py
@@ -941,3 +941,27 @@ def test_dataservices_country_territory_region(iso2_code, expected_id, countries
 def test_dataservices_news_content(mock_news, client):
     response = client.get(reverse('dataservices-news-content'))
     assert len(response.json()) == 2
+
+
+@pytest.mark.parametrize(
+    "post_code, expected_data",
+    [
+        (
+            'SW15EW',
+            {
+                "postcode_data": {"country": "England", "region": "London"},
+                "support_hubs": [],
+                "chambers_of_commerce": [],
+            },
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_local_support_by_postcode(post_code, expected_data, client):
+    response = client.get(f"{reverse('dataservices-growth-hubs-commerce-chambers')}?postcode={post_code}")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    api_data = json.loads(response.content)
+
+    assert api_data == expected_data

--- a/dataservices/views.py
+++ b/dataservices/views.py
@@ -1351,11 +1351,16 @@ class LocalSupportByPostcode(generics.GenericAPIView):
         response = {}
         postcode = self.request.GET.getlist('postcode', '')
         postcode_data = get_postcode_data(postcode[0])
+        response['postcode_data'] = {
+            "country": "England",
+            "region": "London",
+        }
+        response['support_hubs'] = []
+        response['chambers_of_commerce'] = []
 
-        response['postcode_data'] = postcode_data['result']
-
-        response['support_hubs'] = get_support_hub_by_postcode(postcode_data['result'])
-
-        response['chambers_of_commerce'] = get_chamber_by_postcode(postcode_data['result'])
+        if postcode_data['status'] == 200:
+            response['postcode_data'] = postcode_data['result']
+            response['support_hubs'] = get_support_hub_by_postcode(postcode_data['result'])
+            response['chambers_of_commerce'] = get_chamber_by_postcode(postcode_data['result'])
 
         return Response(response, status=status.HTTP_200_OK)


### PR DESCRIPTION
## What
This PR prevents 404's back from postcodes.io from being raised and inserts some basic dummy data in the response to prevent the front end from falling over
## Why
Temporary fix for edge case of invalid postcodes passing postcode validation, to prevent issues from occurring during the DAC audit

Reasoning behind the values in the dummy response:

- "country": "england" this value determines which default content is selected in the event that there are no support hubs (which will be the case here) currently this content is the not different for each country, but in the event that changes England is the chosen value simply because we assume that the largest proportion of our users are based in England.
- "region": "london" this value only effects the graphic that is shown on the growth hubs snippet. In this case the value london has been selected as this places the arrow in the middle of the country graphic.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/BGST-365
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: sigauth, django-staff-sso-client, directory-validators, directory-constants, directory-sso-api-client, directory-healthcheck, directory-forms-api-client, directory-components

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
